### PR TITLE
fix: wire member search in apps admin console

### DIFF
--- a/src/drumee/builtins/widget/apps/main/index.js
+++ b/src/drumee/builtins/widget/apps/main/index.js
@@ -328,7 +328,7 @@ class apps_main extends LetcBox {
       const res = this._role === "admin"
         ? await this.postService(SERVICE.admin.hub_member_list, {
             hub_id: this._activeAdminHub,
-            role_id: roleId,
+            role_id: this._roleFilter || "all",
             key: this._memberQuery || "",
             page: this._page || 1,
           })
@@ -974,6 +974,12 @@ class apps_main extends LetcBox {
             ? args.value
             : cmd && cmd.mget && cmd.mget(_a.value)) || ""
         );
+
+      case "apps-search-submit":
+        return this.ensurePart("apps-search-input").then((p) => {
+          const value = p && p.getValue ? p.getValue() : "";
+          this._searchMembers(value);
+        });
 
       case "apps-toggle-member":
         return this.toggleMember(cmd.mget("member_id"));

--- a/src/drumee/builtins/widget/apps/main/skeleton/index.js
+++ b/src/drumee/builtins/widget/apps/main/skeleton/index.js
@@ -194,12 +194,15 @@ function pageHeader(ui) {
       Skeletons.Box.X({
         className: `${pfx}__search`,
         kids: [
-          Skeletons.Image.Svg({
+          Skeletons.Button.Svg({
             ico: "magnifying-glass",
             className: `${pfx}__search-ico`,
+            service: "apps-search-submit",
+            uiHandler: [ui],
           }),
           Skeletons.Entry({
             className: `${pfx}__search-input`,
+            sys_pn: "apps-search-input",
             placeholder: LOCALE.SEARCH || "Search...",
             name: "apps_search",
             value: ui._memberQuery || "",


### PR DESCRIPTION
Search icon was a non-interactive Image.Svg and the admin endpoint was receiving role_id as numeric 0 (a sentinel the new SP doesn't accept). Promote the icon to Button.Svg with apps-search-submit handler that reads the entry's value via ensurePart, and send role_id as a string ('all' or the selected role key) to admin.hub_member_list.