### PR TITLE
fix(folder): prevent permission dropdown overlap

### DIFF
--- a/src/drumee/builtins/window/folder/skeleton/settings-action-panel.js
+++ b/src/drumee/builtins/window/folder/skeleton/settings-action-panel.js
@@ -182,6 +182,7 @@ function memberRows(list, ui, pfx, isAdmin) {
     return Skeletons.Box.X({
       className: `${pfx}-member-row`,
       dataset: { index, member_id: member.id },
+      styleOpt: { zIndex: 1000 - index },
       kids: [
         Skeletons.Box.X({
           className: `${pfx}-member-info`,

--- a/src/drumee/builtins/window/folder/skin/index.scss
+++ b/src/drumee/builtins/window/folder/skin/index.scss
@@ -970,10 +970,13 @@
     align-items: center;
     justify-content: space-between;
     gap: 12px;
+    position: relative;
+    z-index: 1200;
     min-height: 46px;
     padding: 12px;
     border-radius: 4px;
     background: #ffffff;
+    overflow: visible;
   }
 
   &__settings-action-invite-entry {
@@ -1036,6 +1039,10 @@
   &__settings-action-member-actions,
   &__settings-action-members-section {
     overflow: visible;
+  }
+
+  &__settings-action-member-row {
+    position: relative;
   }
 
   &__settings-action-role-label {


### PR DESCRIPTION
## Summary
- keep folder permission member rows in a descending stacking order so opened role menus paint above following rows
- give the invite role row its own local layer so its dropdown can float above the send button

## Verification
- npm run dev compiled and synced to Aaron stage
- Aaron service restarted
- verified stage runtime hash: e2a6f5f58687a19fef0a
- verified manifest/HTML runtime: runtime-38aa56b2d66f7ad92bf6.js

Fixes #110