### PR TITLE
fix(window): allow vertical drag for tall editors

### DIFF
--- a/src/drumee/builtins/window/utils.js
+++ b/src/drumee/builtins/window/utils.js
@@ -1076,20 +1076,23 @@ class __window_mfs extends DrumeeMFS {
   setContainment() {
     const w = this.$el.outerWidth();
     const h = this.$el.outerHeight();
-    // Clamp to the workspace rect (.window-manager__ui) in page coords so
-    // the dragged window can never leave the desk body on any side.
-    // jQuery UI's array containment constrains the element's TOP-LEFT
-    // corner, so subtract the window's own size from the bottom/right
-    // bounds to keep its bottom-right corner inside the workspace.
+    // Keep the draggable handle visible inside the workspace. Requiring the
+    // full window to stay inside leaves tall editors with almost no Y range.
     const $wm = Wm.$el;
     const offset = $wm.offset();
     const wmW = $wm.outerWidth();
     const wmH = $wm.outerHeight();
+    const minVisibleWidth = Math.min(w, Math.max(150, this.topbarHeight));
+    const minVisibleHeight = Math.min(h, this.topbarHeight);
+    const left = offset.left;
+    const top = offset.top;
+    const right = offset.left + wmW - minVisibleWidth;
+    const bottom = offset.top + wmH - minVisibleHeight;
     const containment = [
-      offset.left,
-      offset.top,
-      offset.left + wmW - w,
-      offset.top + wmH - h,
+      Math.min(left, right),
+      Math.min(top, bottom),
+      Math.max(left, right),
+      Math.max(top, bottom),
     ];
     this.$el.draggable("option", { containment });
   }


### PR DESCRIPTION
## Summary
- update window drag containment so tall editor windows can move vertically
- keep the draggable header visible inside the workspace instead of requiring the full window to fit inside the workspace
- preserve normalized containment bounds for small workspaces

Fixes #111

## Verification
- node --check src/drumee/builtins/window/utils.js
- git diff --check
- npm run dev (compiled and synced Aaron stage; existing webpack duplicate warning only)
- verified Aaron stage bundle hash f90d431a1a7fb4f435ad / runtime-8b2caac5b95ecd814ac2.js