### PR TITLE
fix(chat-p2p): show live online status in header and contact list

### DIFF
--- a/src/drumee/builtins/widget/chat-p2p/index.js
+++ b/src/drumee/builtins/widget/chat-p2p/index.js
@@ -17,7 +17,8 @@ class __chat_p2p extends LetcBox {
     this._filter = _a.contact;
     this.bindEvent(_a.live);
     this._onOutsideClick = this._onOutsideClick.bind(this);
-
+    this._onPeerData = this._onPeerData.bind(this);
+    RADIO_BROADCAST.on(_e.peerData, this._onPeerData);
   }
 
   /**
@@ -34,7 +35,34 @@ class __chat_p2p extends LetcBox {
     this.unbindEvent(_a.live);
     document.removeEventListener("mousedown", this._onDocClick);
     RADIO_CLICK.off(_e.click, this._onOutsideClick);
+    RADIO_BROADCAST.off(_e.peerData, this._onPeerData);
+  }
 
+  _onPeerData(data) {
+    if (!data || data.id == null) return;
+    const peerId = String(data.id);
+    const status = data.status;
+
+    if (this.activePeer && String(this.activePeer.entity_id) === peerId) {
+      this.activePeer.online = status;
+      const statusEl = this.el && this.el.querySelector(`.${this.fig.family}__header-status`);
+      if (statusEl) {
+        const s = ~~status;
+        const label = s === 1 ? LOCALE.ACTIVE_NOW : s === 2 ? LOCALE.AWAY : LOCALE.OFFLINE;
+        statusEl.textContent = label;
+        statusEl.dataset.online = status == null ? '' : status;
+      }
+    }
+
+    const list = this._contactList;
+    if (list && list.getItemsByAttr) {
+      const items = list.getItemsByAttr(_a.entity_id, data.id) || [];
+      items.forEach(item => {
+        if (!item) return;
+        item.mset && item.mset(_a.online, status);
+        if (item.el) item.el.dataset.online = status == null ? '' : status;
+      });
+    }
   }
 
   /**

--- a/src/drumee/builtins/widget/chat-p2p/index.js
+++ b/src/drumee/builtins/widget/chat-p2p/index.js
@@ -56,7 +56,7 @@ class __chat_p2p extends LetcBox {
 
     const list = this._contactList;
     if (list && list.getItemsByAttr) {
-      const items = list.getItemsByAttr(_a.entity_id, data.id) || [];
+      const items = list.getItemsByAttr(_a.entity_id, peerId) || [];
       items.forEach(item => {
         if (!item) return;
         item.mset && item.mset(_a.online, status);

--- a/src/drumee/builtins/widget/chat-p2p/skeleton/chat-header.js
+++ b/src/drumee/builtins/widget/chat-p2p/skeleton/chat-header.js
@@ -33,6 +33,16 @@ module.exports = function (ui, contact) {
   const entityId = contact.mget('entity_id');
   const isContact = contact.mget('flag') === _a.contact;
 
+  const cached = (window.Wm && Wm.getContactStatus && Wm.getContactStatus(entityId)) || null;
+  const onlineState = (cached && cached.status != null) ? cached.status : contact.mget(_a.online);
+
+  const statusLabel = (state) => {
+    const s = ~~state;
+    if (s === 1) return LOCALE.ACTIVE_NOW;
+    if (s === 2) return LOCALE.AWAY;
+    return LOCALE.OFFLINE;
+  };
+
   const profileIcon = isContact
     ? Skeletons.UserProfile({
         className: `${fig}__header-profile`,
@@ -40,7 +50,7 @@ module.exports = function (ui, contact) {
         firstname: fname,
         lastname: lname,
         fullname,
-        online: contact.mget(_a.online),
+        online: onlineState,
         live_status: 1,
         sys_pn: 'header-profile'
       })
@@ -60,11 +70,12 @@ module.exports = function (ui, contact) {
             className: `${fig}__header-name`,
             content: displayName
           }),
-          Skeletons.Note({
+          isContact ? Skeletons.Note({
             className: `${fig}__header-status`,
             sys_pn: 'header-status',
-            content: LOCALE.ACTIVE_NOW
-          })
+            dataset: { online: onlineState == null ? '' : onlineState },
+            content: statusLabel(onlineState)
+          }) : null
         ]
       })
     ]

--- a/src/drumee/modules/desk/wm/push.js
+++ b/src/drumee/modules/desk/wm/push.js
@@ -146,9 +146,10 @@ class __push_manager extends winman {
 
       case SERVICE.contact.connection_status:
       case "user.connection_status":
-        this.myContactsStatus.set(data.user_id, data);
+        // UserProfile.updateStatus guards on data.id; server push uses user_id.
+        this.myContactsStatus.set(data.user_id, { status: data.status });
         this.trigger(options.service, data);
-        RADIO_BROADCAST.trigger(_e.peerData, data);
+        RADIO_BROADCAST.trigger(_e.peerData, { id: data.user_id, status: data.status });
         break;
 
       case "subscription.paid":


### PR DESCRIPTION
Normalise the user.connection_status WS payload to { id, status } so UserProfile.updateStatus (which guards on data.id) actually fires on real-time presence events. Drive the chat-p2p header status text from the peer's online state, seed it from Wm.getContactStatus, and refresh both the header and contact-item data-online on subsequent peerData events.