### PR TITLE
fix(folder): render real user avatars in folder permission matrix

### DIFF
--- a/src/drumee/builtins/window/folder/skeleton/settings-action-panel.js
+++ b/src/drumee/builtins/window/folder/skeleton/settings-action-panel.js
@@ -43,18 +43,16 @@ function mapFolderMember(row) {
     row.email,
   );
   const isSelf = row.id === Visitor.id || row.entity_id === Visitor.id;
-  const parts = name.split(/\s+/).filter(Boolean);
-  const initials =
-    parts.length >= 2
-      ? (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
-      : (name.slice(0, 2) || "?").toUpperCase();
   return {
     id: row.entity_id || row.drumate_id || row.id,
     name: isSelf ? `${name} (${LOCALE.YOU || "You"})` : name,
     rawName: name,
-    initials,
+    // Carried through to UserProfile so it can load the real avatar and derive
+    // initials/auto-color the same way every other member list in the app does.
+    firstname: (row.firstname || "").trim(),
+    lastname: (row.lastname || "").trim(),
+    fullname: (row.fullname || "").trim() || name,
     role: roleFromPrivilege(row.privilege),
-    color: isSelf ? "user" : "primary",
     isSelf,
   };
 }
@@ -120,18 +118,19 @@ function roleDropdown(pfx, role, service, extra = {}) {
   };
 }
 
+// Render every member's real avatar via UserProfile — it loads the user's
+// photo by id and falls back to initials when none exists. Self and other
+// members share one path so the list stays visually consistent. auto_color
+// is off so the fallback keeps the fixed grey/dark styling from the skin
+// instead of a per-name generated background.
 function memberAvatar(pfx, member) {
-  if (member.color === "user") {
-    return Skeletons.UserProfile({
-      className: `${pfx}-avatar user`,
-      id: Visitor.id,
-      firstname: Visitor.get(_a.firstname),
-      lastname: Visitor.get(_a.lastname),
-    });
-  }
-  return Skeletons.Note({
-    className: `${pfx}-avatar ${member.color}`,
-    content: member.initials,
+  return Skeletons.UserProfile({
+    className: `${pfx}-avatar`,
+    auto_color: 0,
+    id: member.id,
+    firstname: member.firstname,
+    lastname: member.lastname,
+    fullname: member.fullname,
   });
 }
 

--- a/src/drumee/builtins/window/folder/skin/index.scss
+++ b/src/drumee/builtins/window/folder/skin/index.scss
@@ -1382,24 +1382,14 @@
     flex: 0 0 32px;
     width: 32px;
     height: 32px;
-    border-radius: 12px;
+    border-radius: 50%;
     overflow: hidden;
-    @include drumee.typo(
-      $size: 10px,
-      $line: 15px,
-      $weight: 600,
-      $color: #e4e3ff
-    );
+    background: #e8e8ed;
 
-    &.primary {
-      background: #5950ff;
-    }
-    &.secondary {
-      background: #38a2ce;
-      color: #d8f9fd;
-    }
-    &.dark {
-      background: #3c3989;
+    // Fallback initials when UserProfile has no photo: near-black text on the
+    // light-grey disc. Depth beats ui-core's .user-profile__initiales rule.
+    .user-profile__initiales .note-content {
+      color: #0b0a21;
     }
   }
 


### PR DESCRIPTION
## Vấn đề
QC báo avatar trong list user của **Permissions Matrix** (Folder Setting) không đồng nhất với các chỗ khác trong app: chỉ user hiện tại có avatar thật, member khác chỉ hiện chữ cái trên nền màu.

## Thay đổi
- `memberAvatar()`: mọi member render qua `UserProfile` → load avatar thật theo user id (giống mọi member list khác trong app). `auto_color: 0` để giữ style cố định từ skin.
- `mapFolderMember()`: giữ thêm `firstname/lastname/fullname` truyền vào UserProfile; bỏ field `color` đã thành dead.
- SCSS: avatar **bo tròn 50%**, **nền xám nhẹ** (`#e8e8ed`); fallback không có ảnh → **chữ gần-đen** (`#0b0a21`) trên nền xám (override rule trắng của ui-core).

## Kết quả
Có ảnh → hiện ảnh thật cắt tròn. Không có ảnh → chữ cái đen trên đĩa xám. Self và member khác đồng nhất.