### PR TITLE
fix(dmz): pass file_nid to dmz.login so sharebox navigates to the shared file

### DIFF
--- a/src/drumee/modules/dmz/sharebox/index.js
+++ b/src/drumee/modules/dmz/sharebox/index.js
@@ -141,9 +141,12 @@ class __dmz_sharebox extends LetcBox {
     // If the URL contains /<file_nid>/<method>, pass file_nid so the server
     // can navigate to the file's parent folder (same as _loginSecureShare).
     // args: ['dmz','share',token, file_nid, method]
+    // Guard with NID regex so hash query params (e.g. ?browser=1 → args[3]='browser=1')
+    // are never forwarded as file_nid.
+    const NID_RE = /^[0-9a-f]{16}$/;
     const urlFileNid = Visitor.parseModule()[3];
     const loginOpt = { token, hub_id };
-    if (urlFileNid) loginOpt.file_nid = urlFileNid;
+    if (NID_RE.test(urlFileNid)) loginOpt.file_nid = urlFileNid;
 
     let data = await this.postService(SERVICE.dmz.login, loginOpt);
 

--- a/src/drumee/modules/dmz/sharebox/index.js
+++ b/src/drumee/modules/dmz/sharebox/index.js
@@ -138,9 +138,14 @@ class __dmz_sharebox extends LetcBox {
     let token = this.mget(_a.token);
     let hub_id = Visitor.parseLocation().keysel || ""
 
-    let data = await this.postService(SERVICE.dmz.login,
-      { token, hub_id }
-    );
+    // If the URL contains /<file_nid>/<method>, pass file_nid so the server
+    // can navigate to the file's parent folder (same as _loginSecureShare).
+    // args: ['dmz','share',token, file_nid, method]
+    const urlFileNid = Visitor.parseModule()[3];
+    const loginOpt = { token, hub_id };
+    if (urlFileNid) loginOpt.file_nid = urlFileNid;
+
+    let data = await this.postService(SERVICE.dmz.login, loginOpt);
 
     this.mset(data);
     if (data.guest_name) {


### PR DESCRIPTION
## Summary

- In `dmz_sharebox.onDomRefresh`, extract `file_nid` from URL position [3] (the `/<file_nid>/play` segment generated by the Share button) and forward it to `dmz.login`
- When `file_nid` is absent (workspace-level share link), `loginOpt` is identical to before — no behaviour change
- Server-side companion PR: drumee/server-team#41

## Root cause

The Share button copies a URL of the form `.../#/dmz/share/<token>/<file_nid>/play`. The sharebox was sending only `{ token, hub_id }` to `dmz.login`, so the server always returned the workspace root nid. The file list showed root items only, and `checkAutoRun()` could not find files in subfolders (or sometimes at the root).

## What changed

| Line | Change | Purpose |
|---|---|---|
| `const urlFileNid = Visitor.parseModule()[3]` | Read args[3] from hash | Extracts file nid from share URL |
| `const loginOpt = { token, hub_id }` | Build options object | Same params as before |
| `if (urlFileNid) loginOpt.file_nid = urlFileNid` | Conditionally add file_nid | Only sent when URL has file nid; workspace-level links unchanged |
| `this.postService(SERVICE.dmz.login, loginOpt)` | Call with new options | Replaces inline object |

## No regressions

- Workspace-level share links: `urlFileNid` = undefined → `loginOpt` = `{ token, hub_id }` (identical to before)
- `verifyEmail`, `verifyPassword`, meeting DMZ: never call `onDomRefresh` this way, unaffected
- Server validates input as `/^[0-9a-f]{16}$/` before any DB use

## Test plan

- [ ] Share button on root-level file → link opens sharebox → file shown → auto-opens
- [ ] Share button on subfolder file → link opens sharebox → file shown → auto-opens
- [ ] Workspace-level share link → sharebox opens normally, all files shown, unchanged
- [ ] Hard-refresh browser after deploy (bundle hash changes)