### PR TITLE
fix(dmz): route subfolder markdown files through service API in DMZ context

### DIFF
--- a/src/drumee/builtins/editor/markdow/index.js
+++ b/src/drumee/builtins/editor/markdow/index.js
@@ -186,7 +186,16 @@ class __editor_markdown extends __player {
    */
   onDomRefresh() {
     if (this.media) {
-      let { url } = this.media.actualNode();
+      let { url, nid, hub_id, ownpath } = this.media.actualNode();
+      const isSubfolder = ownpath && ownpath.split('/').filter(Boolean).length > 1;
+      if (Visitor.inDmz && nid && isSubfolder) {
+        // The vhost endpoint does not serve subfolder paths (only root-level files
+        // work via the vhost).  Route through the same-origin service API using
+        // the file's nid directly — no path depth restriction applies there.
+        const env = bootstrap();
+        const ksel = env.keysel ? `&keysel=${env.keysel}` : '';
+        url = `${env.svc}media.orig?nid=${nid}&hub_id=${hub_id}${ksel}`;
+      }
       this.media.wait(0);
       this._loadContent(url)
       return


### PR DESCRIPTION
## Summary

- **Root cause**: When a DMZ share link points to a markdown file in a subfolder, `editor_markdown._loadContent` was calling `xhRequest` against the vhost URL (e.g. `/kkk/abc.md`). The vhost only serves root-level paths — subfolder paths fail with an internal error.
- **Fix**: In `onDomRefresh`, when `Visitor.inDmz` and the file's `ownpath` has depth > 1, bypass the vhost and build a direct `svc/media.orig?nid=…&hub_id=…` URL instead. Same `makeHeaders` auth (keysel header) — same dmz_guest session — no path depth restriction on the service API.
- Root-level files (`ownpath` depth = 1) are completely unchanged.

## Test plan

- [ ] Open a DMZ share link for a markdown file in a subfolder — file renders correctly, no internal error
- [ ] Open a DMZ share link for a markdown file at root level — unchanged, still works via vhost
- [ ] Open a DMZ share link for a non-markdown file — unaffected