### PR TITLE
feat(otp): modernize dtk_otp widget and use it in reconnect flow

### DIFF
--- a/docs/superpowers/specs/2026-06-11-dtk-otp-modern-input-design.md
+++ b/docs/superpowers/specs/2026-06-11-dtk-otp-modern-input-design.md
@@ -1,0 +1,156 @@
+# dtk_otp — Modern OTP Input Behavior
+
+**Date:** 2026-06-11
+**Component:** `@drumee/ui-toolkit/widgets/otp` (`dtk_otp`)
+**Delivery:** Patched in `ui-team` via `patch-package` (package is published, v0.0.20; no local source checkout).
+
+## Goal
+
+Bring the `dtk_otp` widget up to modern authentication-flow UX: one char per box,
+auto-advance, full keyboard navigation, robust paste, and overwrite-on-type.
+
+## Constraints
+
+- Changes stay **inside the `dtk_otp` widget**. The shared core `Entry`
+  (`@drumee/ui-core/letc/widgets/entry/input`) is used by every input in the app
+  and must not be modified.
+- OTP-specific key handling is bound directly to each box's DOM `<input>`, the same
+  pattern the widget already uses for paste (`bindPasteEvent`).
+- Existing integration is preserved: `api`/`successService` verify wiring,
+  `resend-code`, `displayMessage` (3s transient), model `flow`, CSS classes, markup.
+
+## Configuration (read in `initialize`)
+
+| Option    | Default     | Meaning |
+|-----------|-------------|---------|
+| `length`  | `6`         | Number of boxes; drives skeleton loop, paste, and auto-submit. |
+| `charset` | `'numeric'` | `'numeric'` → `/^[0-9]$/`; `'alphanumeric'` → `/^[0-9a-zA-Z]$/`. |
+
+Case is **preserved as typed** (no upper/lower normalization).
+A single `_validChar(ch)` helper is the one source of truth, reused by keydown and paste.
+
+## Skeleton changes
+
+- Loop `length` times instead of literal `6`.
+- `maxlength: 1` per box (fixes the current `maxlength: 6` bug allowing multiple chars).
+- Drop `min/max` from box `kidsOpt` (range only matters for numeric pacing; validation
+  is now handled by `_validChar`).
+
+## Keydown behavior (`bindKeyEvents`, bound per `_input`)
+
+- **Printable key:** if `_validChar` → set this box to the char, advance focus to next
+  box, `preventDefault` (no native insert → no double-entry). Overwrites any existing
+  value. Invalid char → `preventDefault`, ignored.
+- **Backspace:** box has value → clear it (stay). Box empty → move to previous box and
+  clear it.
+- **Delete:** clear current box.
+- **ArrowLeft / ArrowRight:** move focus between boxes, `preventDefault`.
+- **Tab / Shift+Tab:** no `preventDefault` — normal browser navigation.
+- **Ctrl/Meta/Alt + key:** ignored (lets copy/paste/select-all shortcuts through).
+- After a box is filled, run `checkForm` (existing auto-submit on full code).
+
+Overwrite-on-type and select-then-type both fall out of "always `setValue` the current
+box + `preventDefault`". Focus moves also `select()` the target box so the digit is
+highlighted for easy overwrite.
+
+## Paste behavior (rewrite `bindPasteEvent`)
+
+- `preventDefault`; read text from `clipboardData` directly (drop the fixed 300ms timeout).
+- Filter to `_validChar` only (fixes the current unanchored `[0-9]{1,6}` regex that let
+  stray non-digits through), distribute starting at the **focused box's index**.
+- Stop when boxes run out (ignore overflow beyond `length`).
+- Focus the **last populated** box, then `checkForm`.
+
+## checkForm (generalized)
+
+Collect each box's value; require all `length` boxes filled with valid chars before
+POSTing `{ ...payload, code }` to `api`. (Previously hardcoded `>= 6` and filtered with
+`/[0-9]/`, which would drop letters in alphanumeric mode.)
+
+## onUiEvent (simplified)
+
+`_a.input` case now just calls `checkForm` (navigation is owned by the keydown handler).
+`resend-code` and `default` unchanged.
+
+## Bugfix: click anywhere auto-submits
+
+The framework binds `el.onclick = __handleClick` on the widget root
+(`letc.js`), and `__handleClick` calls `triggerHandlers(MouseEvent)`, which
+dispatches the widget's `service` (the host's `successService`) on **any**
+click in the card's empty space — prematurely submitting/closing the modal.
+The old mitigation was a fragile per-consumer guard ("require `args.data`").
+
+There are two click paths, and both are closed:
+
+1. **Click on the widget root element.** `onlyKeyboard: 1` on the `dtk_otp` model
+   in `initialize` — the framework's own flag (`letc.js`) that skips binding the
+   root's mouse handlers.
+
+2. **Click on a descendant (the real bug: `dtk-otp__main`, header, message,
+   gaps between digits).** `getHandlers` walks *up* the parent chain, so a click
+   on any serviceless descendant is routed to `dtk_otp.onUiEvent` with
+   `service === undefined`, landing in the `default` branch. Re-dispatching that
+   event made the host read `dtk_otp`'s own `service` — i.e. `successService` —
+   and submit. Fix: the `default` branch now forwards **only** when `service` is
+   truthy; serviceless stray clicks are swallowed.
+
+Keyboard handling, child views (digits/resend/close), and the programmatic
+`checkForm()` → `triggerHandlers({ data, service })` success dispatch are all
+unaffected. Submission happens **only** when every box is filled (`checkForm`).
+
+## Invalid-code handling (no page refresh, error shown in place)
+
+Server action endpoints report a bad code *inside* `data` in varying shapes:
+`set_mfa` → `{ error: "INVALID_CODE" }`; `otp.verify` → `{ error: 1, status:
+"wrong-code" }`. The old `checkForm` checked only `data.error`; a `status`-only
+or differently-shaped error could slip through, be treated as success, and fire
+the host's success service → navigation ("page refresh").
+
+Fix in `checkForm`:
+- `_isErrorResponse(data)` catches every failure shape: truthy `error`, a known
+  error `status` (`wrong-code`/`no-user`/`no-socket`/`expired`/`invalid`/
+  `INVALID_CODE`), a non-200 throw, or a null/empty body.
+- On failure → `_onInvalidCode`: show the message in the `tips` row **below**
+  the inputs (red, `data-error="1"`, persistent), clear the boxes, focus the
+  first. It does **not** trigger the success service and does **not** rethrow,
+  so the host never navigates and nothing bubbles to a global reload.
+- `displayMessage(msg, error, persist)` gained a `persist` flag (errors stay
+  until retry); `clearMessage()` wipes it when the user types again
+  (`_onDigitKeydown`).
+- Success path unchanged: a non-error response still triggers the host service.
+
+## Reconnect popup uses dtk_otp (reconnect only)
+
+The `router-butler__reconnect` popup embeds `welcome_signin`, whose OTP step
+(`prompt_otp`) rendered a single-input screen (`skeleton/otp.js`). For reconnect
+**only**, it now uses the dtk_otp 6-box widget so it matches `dtk-otp__main`.
+
+- `prompt_otp(data)` branches on `this.mget('reconnect')` → `_promptOtpReconnect`,
+  which self-registers `dtk_otp` (Kind.waitFor) and feeds a new
+  `skeleton/otp-reconnect.js`. Normal sign-in keeps `skeleton/otp.js` unchanged.
+- Widget config: `api: SERVICE.yp.authenticate`, `payload: { secret }`,
+  `length: 6`, `charset: 'numeric'`, `service: 'reconnect-otp-verified'`,
+  `resendService: 'resend-otp'`, `uiHandler: [module]`.
+- Auto-submit POSTs `yp.authenticate { secret, code }`. A clean response fires
+  `reconnect-otp-verified` → `checkLoginStatus(args.data)` (reuses all existing
+  ok/cross-signin/etc. logic). A bad code (`INVALID_CODE`/`INVALID_SECRET`) is
+  caught inline by the widget and shown below the boxes — no navigation.
+- Resend: dtk_otp's built-in resend link delegates to the host's existing
+  `resend-otp` (re-runs `yp.login`) via the new `resendService` option.
+
+Two generic, backward-compatible widget additions support this (patched in all
+three projects): `_isErrorResponse` now also treats `INVALID_SECRET` as a bad
+code; the `resend-code` handler delegates to `resendService` when set instead of
+POSTing `otp.send`.
+
+### Behavior note
+dtk_otp posts `yp.authenticate` directly (mirroring `authenticateUser()`),
+which skips the `yp.hello` cross-session pre-check the manual "Go" button ran.
+In practice reconnect takes the `authenticateUser()` branch anyway; flag if the
+cross-session prompt is required in the reconnect popup.
+
+## Out of scope
+
+- Single-hidden-input architectures; we keep N `Entry` widgets.
+- Theming/visual changes.
+- RTL-specific arrow remapping.

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "deploy": "drumee-ui-deploy",
     "add-widget": "drumee-make-widget",
     "md:style": "cd src/drumee && sass -I ./skin --no-source-map --update builtins/editor/markdow/skin/viewer.scss builtins/editor/markdow/template/style.css.txt",
-    "setup": "node node_modules/@drumee/ui-dev-tools/env/write-env.js --type=app --output devel --base-dir=$(pwd)"
+    "setup": "node node_modules/@drumee/ui-dev-tools/env/write-env.js --type=app --output devel --base-dir=$(pwd)",
+    "postinstall": "patch-package"
   }
 }

--- a/patches/@drumee+ui-toolkit+0.0.20.patch
+++ b/patches/@drumee+ui-toolkit+0.0.20.patch
@@ -1,0 +1,396 @@
+diff --git a/node_modules/@drumee/ui-toolkit/widgets/otp/index.js b/node_modules/@drumee/ui-toolkit/widgets/otp/index.js
+index 3d66b94..480f856 100644
+--- a/node_modules/@drumee/ui-toolkit/widgets/otp/index.js
++++ b/node_modules/@drumee/ui-toolkit/widgets/otp/index.js
+@@ -8,81 +8,249 @@ export default class dtk_otp extends dtk_common {
+   */
+   initialize(opt = {}) {
+     super.initialize(opt);
++    this._len = this.mget('length') || 6;
++    this._charset = this.mget('charset') || 'numeric';
++    this._charRe = this._charset === 'alphanumeric' ? /^[0-9a-zA-Z]$/ : /^[0-9]$/;
+     this.declareHandlers();
+-    this.mset({ flow: _a.y })
++    // onlyKeyboard:1 stops the framework from binding the widget root's
++    // onclick (see letc.js __handleClick), which would otherwise dispatch
++    // this widget's `service` (the host's successService) on ANY click in
++    // the card's empty space — prematurely "submitting". Submission must
++    // happen only via checkForm() once every box is filled. Child views
++    // (digits, resend link, close button) keep their own click handlers.
++    this.mset({ flow: _a.y, onlyKeyboard: 1 })
+   }
+ 
+   /**
+-   * 
++   * Single source of truth for which characters a box accepts.
++   * @param {string} ch
++   * @returns {boolean}
++   */
++  _validChar(ch) {
++    return _.isString(ch) && this._charRe.test(ch);
++  }
++
++  /**
++   * Resolve the raw DOM <input> for an Entry box, tolerating either a
++   * jQuery-wrapped (`_input[0]`) or a raw-DOM (`_input`) representation.
++   * @param {object} c entry box widget
++   * @returns {HTMLInputElement|undefined}
++   */
++  _inputEl(c) {
++    return (c && c._input && c._input[0]) || (c && c._input);
++  }
++
++  /**
++   * Focus (and select) the box at `idx` if it exists.
++   * @param {Array} boxes
++   * @param {number} idx
++   */
++  _focusBox(boxes, idx) {
++    const box = boxes[idx];
++    if (!box) return;
++    box.focus();
++    if (_.isFunction(box.select)) box.select();
++  }
++
++  /**
++   * Bind OTP-specific keydown handling directly on each box's DOM input.
++   * Navigation and single-char entry are owned here (not the shared core Entry).
++   */
++  bindKeyEvents() {
++    this.ensurePart("digits").then(async (p) => {
++      await Kind.waitFor('entry');
++      const boxes = p.children.toArray();
++      for (let c of boxes) {
++        c.once("input:ready", () => {
++          const el = this._inputEl(c);
++          if (!el) return;
++          el.addEventListener('keydown', (e) => this._onDigitKeydown(e, c, p));
++        })
++      }
++    })
++  }
++
++  /**
++   * @param {KeyboardEvent} e
++   * @param {object} c the box that received the event
++   * @param {object} p the digits container part
++   */
++  _onDigitKeydown(e, c, p) {
++    const key = e.key;
++    const boxes = p.children.toArray();
++    const i = c.getIndex();
++
++    // Let the browser handle normal tab order.
++    if (key === 'Tab') return;
++
++    if (key === 'ArrowLeft') {
++      e.preventDefault();
++      return this._focusBox(boxes, i - 1);
++    }
++    if (key === 'ArrowRight') {
++      e.preventDefault();
++      return this._focusBox(boxes, i + 1);
++    }
++
++    if (key === 'Backspace') {
++      e.preventDefault();
++      if (c.getValue()) {
++        c.setValue('');
++      } else {
++        const prev = boxes[i - 1];
++        if (prev) { prev.setValue(''); prev.focus(); }
++      }
++      return;
++    }
++
++    if (key === 'Delete') {
++      e.preventDefault();
++      c.setValue('');
++      return;
++    }
++
++    // Non-printable keys (Shift, Arrow*, Home, ...) report key.length > 1: ignore.
++    if (key == null || key.length !== 1) return;
++
++    // Let shortcut combos through (copy/paste/select-all).
++    if (e.ctrlKey || e.metaKey || e.altKey) return;
++
++    // Printable character: we own insertion to enforce exactly one char per box.
++    e.preventDefault();
++    if (!this._validChar(key)) return;
++    // Retyping after a rejected code clears the stale error message.
++    this.clearMessage();
++    c.setValue(key);
++    const next = boxes[i + 1];
++    if (next) { next.focus(); if (_.isFunction(next.select)) next.select(); }
++    this.checkForm();
++  }
++
++  /**
++   * Bind paste on each box: distribute valid chars from the focused index,
++   * drop invalid chars, ignore overflow, focus the last populated box.
+    */
+   bindPasteEvent() {
+     this.ensurePart("digits").then(async (p) => {
+       await Kind.waitFor('entry');
+-      for (let c of p.children.toArray()) {
++      const boxes = p.children.toArray();
++      for (let c of boxes) {
+         c.once("input:ready", () => {
+-          c._input[0].onpaste = (e) => {
+-            setTimeout(() => {
+-              let value = c.getValue() || '';
+-              if (!/[0-9]{1,6}/.test(value)) {
+-                c.setValue("")
+-                return
+-              }
+-              let digits = value.split('');
+-              let i = c.getIndex();
+-              for (let d of digits) {
+-                if (!p.children._views[i]) continue;
+-                p.children._views[i].setValue(d);
+-                i++;
+-              }
+-              this.checkForm()
+-            }, 300)
+-          }
++          const el = this._inputEl(c);
++          if (!el) return;
++          el.addEventListener('paste', (e) => {
++            e.preventDefault();
++            const cb = e.clipboardData || window.clipboardData;
++            const text = (cb && cb.getData ? cb.getData('text') : '') || '';
++            const chars = text.split('').filter((ch) => this._validChar(ch));
++            if (!chars.length) return;
++            const start = c.getIndex();
++            let last = start;
++            for (let k = 0; k < chars.length; k++) {
++              const box = boxes[start + k];
++              if (!box) break;
++              box.setValue(chars[k]);
++              last = start + k;
++            }
++            this._focusBox(boxes, last);
++            this.checkForm();
++          })
+         })
+       }
+     })
+   }
+ 
+   /**
+-   * 
+-   * @param {*} msg 
++   * Show a transient note below the inputs (in the `tips` row). Non-error
++   * notes auto-clear after 3s; pass persist=1 to keep an error visible until
++   * the user retries (see clearMessage in _onDigitKeydown).
++   * @param {string} msg
++   * @param {number} error  1 = error styling
++   * @param {number} persist 1 = do not auto-clear
+    */
+-  displayMessage(msg, error = 0) {
++  displayMessage(msg, error = 0, persist = 0) {
++    if (!this.__tipsText) return;
++    if (this._msgTimer) { clearTimeout(this._msgTimer); this._msgTimer = null; }
+     this.__tipsText.set({ content: msg });
+     this.__tipsText.el.dataset.error = error;
+-    setTimeout(() => {
++    if (persist) return;
++    this._msgTimer = setTimeout(() => {
++      if (!this.__tipsText) return;
+       this.__tipsText.set({ content: '' });
+-      this.__tipsText.el.dataset.error = error;
++      this.__tipsText.el.dataset.error = 0;
+     }, 3000)
+   }
+ 
+   /**
+-   * 
++   * Clear any message currently shown below the inputs.
++   */
++  clearMessage() {
++    if (this._msgTimer) { clearTimeout(this._msgTimer); this._msgTimer = null; }
++    if (!this.__tipsText) return;
++    this.__tipsText.set({ content: '' });
++    this.__tipsText.el.dataset.error = 0;
++  }
++
++  /**
++   * True when the verify response indicates a bad/expired code. Tolerates the
++   * different shapes the server uses: `{error:1}`, `{error:"INVALID_CODE"}`,
++   * `{status:"wrong-code"}`, a non-200 throw, or a null/empty body.
++   * @param {*} data
++   * @returns {boolean}
++   */
++  _isErrorResponse(data) {
++    if (!data) return true;
++    if (data.error) return true;
++    const errStatus = ['wrong-code', 'no-user', 'no-socket', 'expired', 'invalid', 'INVALID_CODE', 'INVALID_SECRET'];
++    if (data.status && errStatus.includes(data.status)) return true;
++    return false;
++  }
++
++  /**
++   * Handle a rejected code: show the error BELOW the inputs, clear the boxes
++   * for re-entry, and focus the first one. Crucially we do NOT trigger the
++   * host success service (which would navigate) and do NOT rethrow (which
++   * could bubble to a global handler and reload the page).
++   * @param {Array} boxes
++   * @param {*} data
++   */
++  _onInvalidCode(boxes, data) {
++    let msg = LOCALE.INVALID_CODE;
++    const err = data && data.error;
++    if (_.isString(err) && LOCALE[err]) msg = LOCALE[err];
++    this.displayMessage(msg, 1, 1);
++    for (let c of boxes) c.setValue('');
++    this._focusBox(boxes, 0);
++  }
++
++  /**
++   * Auto-submit once every box holds a valid character. On an invalid code
++   * the error is shown in place and the page is never navigated/reloaded.
+    */
+   checkForm() {
+     this.ensurePart("digits").then((p) => {
++      const boxes = p.children.toArray();
+       let res = [];
+-      for (let c of p.children.toArray()) {
++      for (let c of boxes) {
+         let v = c.getValue()
+-        if (/[0-9]/.test(v)) {
++        if (this._validChar(v)) {
+           res.push(v)
+         }
+       }
+-      let api = this.mget(_a.api)
+-      let payload = this.mget('payload')
+-      if (res.length >= 6) {
+-        if (api) {
+-          return this.postService(api, { ...payload, code: res.join('') }, { async: 1 }).then((data) => {
+-            if (data.error) {
+-              return this.displayMessage(LOCALE.INVALID_CODE, 1)
+-            }
+-            let service = this.mget(_a.service) || 'otp-verified';
+-            this.triggerHandlers({ data, service })
+-          }).catch((e) => {
+-            this.warn("[checkForm] OTP verify error", e)
+-            this.displayMessage(LOCALE.INVALID_CODE, 1)
+-          })
++      if (res.length < this._len) return;
++      const api = this.mget(_a.api)
++      if (!api) return;
++      const payload = this.mget('payload')
++      return this.postService(api, { ...payload, code: res.join('') }, { async: 1 }).then((data) => {
++        if (this._isErrorResponse(data)) {
++          return this._onInvalidCode(boxes, data);
+         }
+-      }
++        let service = this.mget(_a.service) || 'otp-verified';
++        this.triggerHandlers({ data, service })
++      }).catch((e) => {
++        this.warn("[checkForm] OTP verify error", e)
++        this._onInvalidCode(boxes, e)
++      })
+     })
+   }
+ 
+@@ -91,6 +259,7 @@ export default class dtk_otp extends dtk_common {
+   */
+   onDomRefresh() {
+     this.feed(require("./skeleton").default(this));
++    this.bindKeyEvents();
+     this.bindPasteEvent();
+   }
+ 
+@@ -101,36 +270,20 @@ export default class dtk_otp extends dtk_common {
+   */
+   onUiEvent(cmd, args = {}) {
+     const service = args.service || cmd.get(_a.service);
+-    let status = cmd.status;
+     let { email, method } = this.mget('payload') || {}
+     switch (service) {
+       case _a.input:
+-        cmd.focus();
+-        if (status == _e.click) {
+-          cmd.setValue('');
+-          return;
+-        }
+-        let res = [];
+-        this.ensurePart("digits").then((p) => {
+-          let i = cmd.getIndex() + 1;
+-          let value = cmd.getValue();
+-          for (let c of p.children.toArray()) {
+-            if (c.getIndex() < i) {
+-              continue;
+-            } else {
+-              if (/[0-9]/.test(value) && /[0-9]/.test(status)) {
+-                c.focus();
+-                c.setValue('')
+-              } else {
+-                cmd.setValue('');
+-              }
+-              break;
+-            }
+-          }
+-          this.checkForm()
+-        })
++        // Navigation/entry is handled in _onDigitKeydown; just re-check completion.
++        this.checkForm();
+         break;
+       case "resend-code":
++        // Host-driven resend: when `resendService` is configured the widget
++        // delegates resending to the host (e.g. the reconnect flow re-runs
++        // yp.login) instead of POSTing otp.send itself.
++        const resendService = this.mget('resendService');
++        if (resendService) {
++          return this.triggerHandlers({ service: resendService });
++        }
+         let api = this.mget('resendApi') ||  SERVICE.otp.send
+         this.postService(api, { email, method }).then((data) => {
+           this.mset({ payload: data })
+@@ -142,7 +295,18 @@ export default class dtk_otp extends dtk_common {
+         })
+         break;
+       default:
+-        this.triggerHandlers({ ...args, service })
++        // Swallow stray clicks. A click on the card's empty space
++        // (dtk-otp__main, header, message, gaps between digits) has no
++        // `service`, but the framework still routes it here because this
++        // widget is registered as an ancestor ui-handler. Re-dispatching a
++        // serviceless event makes the host read THIS widget's own `service`
++        // (the host's successService) and submit prematurely. Only forward
++        // genuinely-named services; success is dispatched solely by
++        // checkForm() once every box is filled.
++        if (service) {
++          this.triggerHandlers({ ...args, service })
++        }
++        break;
+     }
+   }
+ 
+diff --git a/node_modules/@drumee/ui-toolkit/widgets/otp/skeleton/index.js b/node_modules/@drumee/ui-toolkit/widgets/otp/skeleton/index.js
+index a858a42..9645673 100644
+--- a/node_modules/@drumee/ui-toolkit/widgets/otp/skeleton/index.js
++++ b/node_modules/@drumee/ui-toolkit/widgets/otp/skeleton/index.js
+@@ -4,7 +4,8 @@ function __skl_welcome_signup(ui) {
+   const fig = ui.fig.family
+   let digits = []
+   let { title, message } = ui.model.toJSON()
+-  for (let i = 0; i < 6; i++) {
++  const len = ui.model.get('length') || 6
++  for (let i = 0; i < len; i++) {
+     digits.push(
+       Skeletons.Entry({
+         name: `digit-${i}`,
+@@ -16,9 +17,7 @@ function __skl_welcome_signup(ui) {
+     kidsOpt: {
+       className: `${fig}__digit`,
+       placeholder: "",
+-      min: 0,
+-      max: 9,
+-      maxlength: 6,
++      maxlength: 1,
+       interactive: 1
+     },
+     className: `${fig}__digits`,

--- a/src/drumee/modules/welcome/signin/index.js
+++ b/src/drumee/modules/welcome/signin/index.js
@@ -164,6 +164,12 @@ class __welcome_signin extends __welcome_interact {
         this._otpResent++;
         return this.loginUser(this._vars);
 
+      case "reconnect-otp-verified":
+        // dtk_otp (reconnect popup) auto-submitted yp.authenticate and got a
+        // clean response; hand it to the shared login-status handler. Bad
+        // codes are caught inline by the widget and never reach here.
+        return this.checkLoginStatus(args.data);
+
       case "authenticate":
         return this.postService(SERVICE.yp.hello).then((user) => {
           if (user.signed_in) {
@@ -324,6 +330,11 @@ class __welcome_signin extends __welcome_interact {
    */
   prompt_otp(data) {
     this.data = data;
+    // Reconnect popup uses the dtk_otp 6-box widget (matches dtk-otp__main);
+    // normal sign-in keeps the single-input ./otp.js screen.
+    if (this.mget(RECONNECT)) {
+      return this._promptOtpReconnect(data);
+    }
     // Upopn reload while prompting otp
     if (!this.__content) {
       let opt = {
@@ -341,6 +352,25 @@ class __welcome_signin extends __welcome_interact {
       this.__noCodeOptions.el.dataset.mode = _a.open;
     };
     return _.delay(f, Visitor.timeout(5000));
+  }
+
+  /**
+   * Reconnect-only OTP entry using the dtk_otp 6-box widget. Self-registers
+   * dtk_otp on demand (its loadSeeds() isn't run by this bundle), then feeds
+   * the dtk_otp skeleton. The widget auto-submits to yp.authenticate; its
+   * success is routed through `reconnect-otp-verified` -> checkLoginStatus.
+   * @param {Object} data
+   */
+  async _promptOtpReconnect(data) {
+    if (!Kind.get("dtk_otp")) {
+      Kind.registerAddons({ dtk_otp: import("@drumee/ui-toolkit/widgets/otp") });
+    }
+    await Kind.waitFor("dtk_otp");
+    const skel = require("./skeleton/otp-reconnect")(this);
+    if (!this.__content) {
+      return this.feed(this._skeleton(this, { content: skel }));
+    }
+    this.__content.feed(skel);
   }
 
   /**

--- a/src/drumee/modules/welcome/signin/skeleton/otp-reconnect.js
+++ b/src/drumee/modules/welcome/signin/skeleton/otp-reconnect.js
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2024 Thidima SA. All Rights Reserved.
+ * Licensed under the GNU AFFERO GENERAL PUBLIC LICENSE, Version 3 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+/**
+ * Reconnect OTP screen using the shared dtk_otp 6-box widget (matches
+ * dtk-otp__main). Used only in the reconnect popup; normal sign-in keeps
+ * ./otp.js. The widget auto-submits the 6 digits to yp.authenticate and
+ * routes the response to the host via `reconnect-otp-verified`; a rejected
+ * code is shown inline below the boxes (no navigation). The built-in resend
+ * link delegates to the host's existing `resend-otp` (re-runs yp.login) via
+ * `resendService`. Caller must ensure `dtk_otp` is registered (Kind.waitFor).
+ */
+function __skl_welcome_signin_otp_reconnect(ui) {
+  const otpFig = ui.fig.family;
+  const secret = (ui.data && ui.data.secret) || Visitor.get("otp_key");
+
+  return Skeletons.Box.Y({
+    debug: __filename,
+    className: `${otpFig}__items otp reconnect`,
+    kids: [
+      {
+        kind: "dtk_otp",
+        sys_pn: "reconnect-otp",
+        api: SERVICE.yp.authenticate,
+        payload: { secret },
+        length: 6,
+        charset: "numeric",
+        // dtk_otp's resend link triggers the host's existing resend-otp
+        // (yp.login) instead of POSTing otp.send.
+        resendService: "resend-otp",
+        title: LOCALE.MULTI_FACTOR_AUTH,
+        message: LOCALE.ENTER_CODE,
+        service: "reconnect-otp-verified",
+        uiHandler: [ui],
+        dataset: { fit: "parent" },
+      },
+    ],
+  });
+}
+module.exports = __skl_welcome_signin_otp_reconnect;

--- a/src/drumee/modules/welcome/signin/skin/index.scss
+++ b/src/drumee/modules/welcome/signin/skin/index.scss
@@ -42,6 +42,24 @@ $drumee-link-purple: #b1adff;
     height: 100%;
   }
 
+  // Reconnect OTP embeds the dtk_otp widget (data-fit="parent"). The widget's
+  // shared skin gives __main a 180px top offset meant for the standalone
+  // full-page OTP; inside the popup that reads as a large empty margin on top.
+  // Drop the offset and center the widget within the popup.
+  &__items.reconnect {
+    .dtk-otp__ui {
+      height: 100%;
+      padding: 0;
+      justify-content: center;
+      align-items: center;
+      align-content: center;
+    }
+
+    .dtk-otp__main {
+      top: 0;
+    }
+  }
+
   &__container {
     background-color: $drumee-bg;
     padding: 48px;
@@ -49,8 +67,8 @@ $drumee-link-purple: #b1adff;
     border-radius: 12px;
 
     &[data-mode="reconnect"] {
-      padding: 48px;
-      max-width: 520px;
+      padding: 32px;
+      max-width: 600px;
       margin: 0 auto;
     }
   }
@@ -88,7 +106,7 @@ $drumee-link-purple: #b1adff;
   &__items {
     align-items: stretch;
     margin: 0 auto;
-    max-width: 440px;
+    max-width: 500px;
     width: 100%;
     gap: 24px;
 

--- a/src/drumee/router/butler/skin/index.scss
+++ b/src/drumee/router/butler/skin/index.scss
@@ -163,7 +163,7 @@
     &.main {
       position: relative;
       width: 100%;
-      max-width: 520px;
+      max-width: 800px;
       min-width: 320px;
       background-color: #f2f2f7;
       border-radius: 12px;


### PR DESCRIPTION
Patch @drumee/ui-toolkit dtk_otp (via patch-package) into a standard OTP input and wire it into the reconnect popup.

Widget (patches/@drumee+ui-toolkit+0.0.20.patch):
- one char per box; configurable length (default 6) and charset (numeric default / alphanumeric); fix maxlength 6 -> 1 per box
- keyboard nav: auto-advance, overwrite-on-type, Backspace/Delete, Arrow Left/Right, native Tab; paste distributes from focused box, filters invalid chars, ignores overflow, focuses last filled
- stop click-anywhere auto-submit (onlyKeyboard + swallow serviceless events in onUiEvent); submit only when all boxes filled via checkForm
- invalid code: robust error detection (error/status/non-200/empty), inline error below boxes, no page navigation, no success trigger
- add host-driven resendService option

Reconnect popup (reconnect only):
- prompt_otp branches to dtk_otp 6-box widget; new skeleton/otp-reconnect.js
- onUiEvent 'reconnect-otp-verified' -> checkLoginStatus; resend reuses resend-otp; verify via yp.authenticate
- center the embedded widget (drop the shared top:180px offset)

Add patch-package postinstall hook and design spec.