### PR TITLE
fix(desk): make server onboarded flag authoritative for onboarding gate

### DIFF
--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -661,11 +661,18 @@ class desk_module extends LetcBox {
       return window.Wm.route();
     }
     this._pending = { available: false };
+    // The server-side profile.onboarded flag is authoritative: a user who has
+    // completed onboarding (persisted via onboarding.update_profile -> onboarded=1)
+    // must never be pushed back into the wizard on a later login. Check it FIRST,
+    // and also drop any stale "force-onboarding" marker so it can't re-trigger the
+    // wizard after completion. Onboarding loads purely from this flag — new
+    // accounts are created with onboarded=0 and the plugin is installed.
+    if (Visitor.profile().onboarded) {
+      try { localStorage.removeItem("force-onboarding"); } catch (e) {}
+      return this.loadDefault();
+    }
     if (localStorage.getItem("force-onboarding")) {
       return this._loadOnboarding();
-    }
-    if (Visitor.profile().onboarded) {
-      return this.loadDefault();
     }
     this._loadOnboarding();
   }


### PR DESCRIPTION
The desk route() checked the localStorage "force-onboarding" marker before profile.onboarded, and that marker was never cleared on completion (the onboarding plugin finishes via softDestroy, which never bubbles the "onboarding-completed" service that clears it). Result: once set, the wizard re-displayed on every login even though onboarding.update_profile had already persisted onboarded=1 server-side.

Check Visitor.profile().onboarded FIRST and drop any stale force-onboarding marker there, so a completed user is never pushed back into the wizard and a stuck flag self-heals. Onboarding now loads purely from the server flag (new accounts are created with onboarded=0 and the plugin is installed).