### PR TITLE
feat(settings): toast the 2FA enable/disable outcome

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1189,6 +1189,8 @@
   "MEMBERS_SUBTITLE": "Manage organization access and define custom roles.",
   "SECURITY_GOVERNANCE": "Security Governance",
   "TWO_FACTOR_AUTH": "Two-Factor Authentication",
+  "TWO_FACTOR_ENABLED": "Two-factor authentication enabled",
+  "TWO_FACTOR_DISABLED": "Two-factor authentication disabled",
   "RECOMMENDED": "RECOMMENDED",
   "AUTHENTICATOR_APP": "Authenticator App",
   "AUTHENTICATOR_APP_DESC": "Use Google Authenticator or Authy",

--- a/locale/es.json
+++ b/locale/es.json
@@ -222,6 +222,8 @@
   "MEMBERS_SUBTITLE": "Gestione el acceso a la organización y defina roles personalizados.",
   "SECURITY_GOVERNANCE": "Gobernanza de seguridad",
   "TWO_FACTOR_AUTH": "Autenticación de dos factores",
+  "TWO_FACTOR_ENABLED": "Autenticación de dos factores activada",
+  "TWO_FACTOR_DISABLED": "Autenticación de dos factores desactivada",
   "RECOMMENDED": "RECOMENDADO",
   "AUTHENTICATOR_APP": "Aplicación de autenticación",
   "AUTHENTICATOR_APP_DESC": "Use Google Authenticator o Authy",

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -1108,6 +1108,8 @@
   "MEMBERS_SUBTITLE": "Gérez l'accès à l'organisation et définissez des rôles personnalisés.",
   "SECURITY_GOVERNANCE": "Gouvernance de la sécurité",
   "TWO_FACTOR_AUTH": "Authentification à deux facteurs",
+  "TWO_FACTOR_ENABLED": "Authentification à deux facteurs activée",
+  "TWO_FACTOR_DISABLED": "Authentification à deux facteurs désactivée",
   "RECOMMENDED": "RECOMMANDÉ",
   "AUTHENTICATOR_APP": "Application d'authentification",
   "AUTHENTICATOR_APP_DESC": "Utilisez Google Authenticator ou Authy",

--- a/locale/km.json
+++ b/locale/km.json
@@ -1108,6 +1108,8 @@
   "MEMBERS_SUBTITLE": "គ្រប់គ្រងការចូលប្រើប្រាស់អង្គភាព និងកំណត់តួនាទីផ្ទាល់ខ្លួន។",
   "SECURITY_GOVERNANCE": "ការគ្រប់គ្រងសន្តិសុខ",
   "TWO_FACTOR_AUTH": "ការផ្ទៀងផ្ទាត់ពីរកត្តា",
+  "TWO_FACTOR_ENABLED": "បានបើកការផ្ទៀងផ្ទាត់ពីរកត្តា",
+  "TWO_FACTOR_DISABLED": "បានបិទការផ្ទៀងផ្ទាត់ពីរកត្តា",
   "RECOMMENDED": "ត្រូវបានណែនាំ",
   "AUTHENTICATOR_APP": "កម្មវិធីផ្ទៀងផ្ទាត់",
   "AUTHENTICATOR_APP_DESC": "ប្រើ Google Authenticator ឬ Authy",

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -1108,6 +1108,8 @@
   "MEMBERS_SUBTITLE": "Управляйте доступом к организации и определяйте пользовательские роли.",
   "SECURITY_GOVERNANCE": "Управление безопасностью",
   "TWO_FACTOR_AUTH": "Двухфакторная аутентификация",
+  "TWO_FACTOR_ENABLED": "Двухфакторная аутентификация включена",
+  "TWO_FACTOR_DISABLED": "Двухфакторная аутентификация отключена",
   "RECOMMENDED": "РЕКОМЕНДУЕТСЯ",
   "AUTHENTICATOR_APP": "Приложение-аутентификатор",
   "AUTHENTICATOR_APP_DESC": "Используйте Google Authenticator или Authy",

--- a/locale/zh.json
+++ b/locale/zh.json
@@ -1108,6 +1108,8 @@
   "MEMBERS_SUBTITLE": "管理组织访问权限并定义自定义角色。",
   "SECURITY_GOVERNANCE": "安全治理",
   "TWO_FACTOR_AUTH": "双因素认证",
+  "TWO_FACTOR_ENABLED": "已启用双因素认证",
+  "TWO_FACTOR_DISABLED": "已禁用双因素认证",
   "RECOMMENDED": "推荐",
   "AUTHENTICATOR_APP": "身份验证器应用",
   "AUTHENTICATOR_APP_DESC": "使用 Google Authenticator 或 Authy",

--- a/src/drumee/builtins/widget/settings/main/index.js
+++ b/src/drumee/builtins/widget/settings/main/index.js
@@ -202,6 +202,7 @@ class settings_main extends LetcBox {
 
   onBeforeDestroy() {
     clearTimeout(this._saveStatusTimer);
+    clearTimeout(this._toastTimer);
     if (super.onBeforeDestroy) super.onBeforeDestroy();
   }
 
@@ -279,7 +280,11 @@ class settings_main extends LetcBox {
   _cancelMfa(errorMessage) {
     if (this._mfaCmd) this._mfaCmd.setState(this._mfaPrev);
     this._resetMfaState();
-    if (errorMessage) this.alert(errorMessage);
+    // errorMessage is only set on a genuine failure (e.g. otp.send died);
+    // a plain user cancel passes nothing and shows no toast.
+    if (errorMessage) {
+      return this.closeOverlay().then(() => this._showToast(errorMessage, "error"));
+    }
     return this.closeOverlay();
   }
 
@@ -290,7 +295,52 @@ class settings_main extends LetcBox {
       profile: { ...current, mfa: next, otp: next ? "email" : 0 },
     });
     this._resetMfaState();
-    return this.closeOverlay();
+    // Confirm the outcome on the settings page once the OTP modal is gone.
+    return this.closeOverlay().then(() =>
+      this._showToast(
+        next
+          ? (LOCALE.TWO_FACTOR_ENABLED || "Two-factor authentication enabled")
+          : (LOCALE.TWO_FACTOR_DISABLED || "Two-factor authentication disabled"),
+        "success"
+      )
+    );
+  }
+
+  /**
+   * Show a transient toast at the top-right of the settings page.
+   * `kind` drives both the colour and the glyph: "success" → app-check,
+   * "error" → apps-warning (see the `__toast` rules in the skin).
+   */
+  _showToast(message, kind = "success") {
+    this._toast = { message, kind };
+    if (this._toastTimer) clearTimeout(this._toastTimer);
+    this._toastTimer = setTimeout(() => {
+      this._toast = null;
+      this._renderToast();
+    }, 3500);
+    return this._renderToast();
+  }
+
+  _renderToast() {
+    return this.ensurePart("settings-toast").then((part) => {
+      if (!part) return;
+      if (!this._toast) return part.feed([]);
+      const pfx = this.fig.family;
+      const { message, kind } = this._toast;
+      const ico = kind === "error" ? "apps-warning" : "app-check";
+      part.feed(
+        Skeletons.Box.X({
+          className: `${pfx}__toast ${pfx}__toast--${kind}`,
+          kids: [
+            Skeletons.Image.Svg({ ico, className: `${pfx}__toast-ico` }),
+            Skeletons.Note({
+              className: `${pfx}__toast-text`,
+              content: message,
+            }),
+          ],
+        })
+      );
+    });
   }
 
   _resetMfaState() {

--- a/src/drumee/builtins/widget/settings/main/skeleton/index.js
+++ b/src/drumee/builtins/widget/settings/main/skeleton/index.js
@@ -519,6 +519,12 @@ function settings_body(ui) {
       className: `${pfx}__overlay`,
       sys_pn: "overlay",
     }),
+    // Transient top-right toast slot (empty until _showToast feeds it). Used
+    // to confirm the 2FA enable/disable outcome once the OTP modal closes.
+    Skeletons.Box.Y({
+      className: `${pfx}__toast-slot`,
+      sys_pn: "settings-toast",
+    }),
   ];
 }
 

--- a/src/drumee/builtins/widget/settings/main/skin/index.scss
+++ b/src/drumee/builtins/widget/settings/main/skin/index.scss
@@ -786,6 +786,72 @@
     }
   }
 
+  // ── Toast (top-right) ─────────────────────────────────────
+  // Transient confirmation, fed by _showToast/_renderToast. Sits above the
+  // overlay so it remains visible even if a modal is mid-teardown. The slot
+  // collapses when empty so it never intercepts clicks.
+  &__toast-slot {
+    position: fixed;
+    top: 24px;
+    right: 24px;
+    z-index: 30000;
+    pointer-events: none;
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  &__toast {
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
+    max-width: 360px;
+    padding: 12px 16px;
+    border-radius: 10px;
+    background: $row-bg;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+    pointer-events: auto;
+    animation: settings-toast-in 160ms ease-out;
+
+    &-ico {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+
+      svg {
+        width: 20px;
+        height: 20px;
+      }
+    }
+
+    &-text {
+      font-size: 13px;
+      font-weight: 600;
+      line-height: 18px;
+      color: $ink-900;
+    }
+
+    &--success &-ico svg {
+      fill: $success-fg;
+
+      .icon-fill-blue,
+      .icon-fill-grey {
+        fill: $success-fg;
+      }
+    }
+
+    &--error &-ico svg {
+      fill: $danger-fg;
+
+      .icon-fill-blue,
+      .icon-fill-grey {
+        fill: $danger-fg;
+      }
+    }
+  }
+
   // ── Responsive: tablet ────────────────────────────────────
   // Two-column layout (~698 + 450 / ~375 + 773) doesn't fit at tablet
   // widths (≤ 1024). Stack rows; keep header on one line and avatar/
@@ -959,6 +1025,14 @@ html[data-theme="dark"] {
       background: var(--overlay-bg-05);
     }
 
+    &__toast {
+      background: var(--normal-bg-elevated);
+
+      &-text {
+        color: var(--normal-fg-10);
+      }
+    }
+
     &__inner {
       background: var(--normal-bg-elevated);
     }
@@ -1000,4 +1074,15 @@ html[data-theme="dark"] {
 
 @keyframes settings-main-spinner {
   to { transform: rotate(360deg); }
+}
+
+@keyframes settings-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }


### PR DESCRIPTION
After the OTP modal closes, confirm the result with a transient top-right toast: success uses the app-check glyph, failure (e.g. otp.send died) uses apps-warning. _finalizeMfa shows the success toast; _cancelMfa shows the error toast only on a genuine failure (plain cancel stays silent).

Adds a settings-toast slot to the skeleton, _showToast/_renderToast helpers (auto-dismiss + timer cleanup on destroy), and top-right toast styling with a dark-theme variant. New locale keys TWO_FACTOR_ENABLED / TWO_FACTOR_DISABLED across all six languages.