### PR TITLE
fix(otp-gate): attach submit spinner on part.ready, not ensurePart

### DIFF
--- a/src/drumee/builtins/widget/otp-gate/index.js
+++ b/src/drumee/builtins/widget/otp-gate/index.js
@@ -151,49 +151,62 @@ async function openOtpModal(widget, opts) {
   // duration of the verify round-trip (see the `[data-submitting]` rule in
   // the otp-gate skin). Only the submit `api` is gated — resend already has
   // its own [data-resending] state and is delegated to the host anyway.
-  attachSubmitSpinner(card, api, widget);
+  attachSubmitSpinner(card, api);
 }
 
 /**
  * Wrap the dtk_otp instance's postService so the verify round-trip shows a
- * spinner and locks input. Idempotent and best-effort: any failure to resolve
- * the instance just leaves the modal without a submit spinner.
+ * spinner and locks input. Idempotent and best-effort: if the widget never
+ * mounts the modal simply runs without a submit spinner.
+ *
+ * dtk_otp's kind is pulled in via a dynamic import, so it mounts (and
+ * registers its part) AFTER feed() returns — we can't `ensurePart` it
+ * synchronously (its parent has no `_branches` yet). Instead we listen for the
+ * part.ready event and wrap the instance the moment it registers.
  *
  * @param {Backbone.View} card  the Box.Y returned by overlay.feed()
  * @param {string}        api   the submit SERVICE (resend POSTs elsewhere)
- * @param {Backbone.View} host  host widget, for warn()
  */
-async function attachSubmitSpinner(card, api, host) {
-  if (!card || typeof card.ensurePart !== "function") return;
-  let otp;
-  try {
-    otp = await card.ensurePart("otp-widget");
-  } catch (e) {
-    host && host.warn && host.warn("[otp-gate] no otp-widget to gate submit", e);
-    return;
-  }
-  if (!otp || otp._otpGateSubmitWrapped || typeof otp.postService !== "function") {
-    return;
-  }
-  otp._otpGateSubmitWrapped = true;
-  const post = otp.postService.bind(otp);
-  otp.postService = function (service, ...rest) {
-    // Resend (and any non-verify POST) keeps the stock behaviour.
-    if (service !== api) return post(service, ...rest);
-    if (this.el) this.el.dataset.submitting = "1";
-    let p;
-    try {
-      p = post(service, ...rest);
-    } catch (e) {
-      if (this.el) this.el.dataset.submitting = "0";
-      throw e;
+function attachSubmitSpinner(card, api) {
+  if (!card || typeof card.on !== "function") return;
+
+  const wrap = (otp) => {
+    if (!otp || otp._otpGateSubmitWrapped || typeof otp.postService !== "function") {
+      return;
     }
-    return Promise.resolve(p).finally(() => {
-      // On success the modal is torn down; on a rejected code dtk_otp clears
-      // the boxes for re-entry — either way the inputs unlock here.
-      if (this.el) this.el.dataset.submitting = "0";
-    });
+    otp._otpGateSubmitWrapped = true;
+    const post = otp.postService.bind(otp);
+    otp.postService = function (service, ...rest) {
+      // Resend (and any non-verify POST) keeps the stock behaviour.
+      if (service !== api) return post(service, ...rest);
+      if (this.el) this.el.dataset.submitting = "1";
+      let p;
+      try {
+        p = post(service, ...rest);
+      } catch (e) {
+        if (this.el) this.el.dataset.submitting = "0";
+        throw e;
+      }
+      return Promise.resolve(p).finally(() => {
+        // On success the modal is torn down; on a rejected code dtk_otp clears
+        // the boxes for re-entry — either way the inputs unlock here.
+        if (this.el) this.el.dataset.submitting = "0";
+      });
+    };
   };
+
+  // Fast path: already mounted (guard `_branches`, which is created lazily on
+  // the first registerPart and is undefined until then).
+  const existing = card._branches && card._branches["otp-widget"];
+  if (existing && (!existing.isDestroyed || !existing.isDestroyed())) {
+    return wrap(existing);
+  }
+  // Otherwise wrap as soon as dtk_otp registers itself as the "otp-widget" part.
+  card.on(_e.part.ready, (child) => {
+    if (child && child.mget && child.mget(_a.sys_pn) === "otp-widget") {
+      wrap(child);
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
dtk_otp's class loads via dynamic import, so it mounts and registers its part AFTER overlay.feed() returns. attachSubmitSpinner awaited card.ensurePart("otp-widget") immediately, but the freshly-fed card has no _branches yet — the framework's ensurePart reads this._branches[name] unguarded and throws "Cannot read properties of undefined (reading 'otp-widget')". It was caught best-effort, so the spinner silently never attached.

Make attachSubmitSpinner synchronous: wrap immediately if the widget is already mounted, otherwise listen for _e.part.ready and wrap the instance the moment dtk_otp registers as the "otp-widget" part. Uses the same globals (_e.part.ready / _a.sys_pn) the framework's own registerPart/ensurePart use. No throw, no console error, spinner works.