### PR TITLE
fix(chat-p2p): fall back to firstname/fullname when contact display i…

### DIFF
--- a/src/drumee/builtins/webrtc/endpoint/remote/user/index.js
+++ b/src/drumee/builtins/webrtc/endpoint/remote/user/index.js
@@ -225,6 +225,16 @@ class __remote_user extends __stream {
     await this.ensurePart("sound");
     await this.ensurePart("video");
     await this.ensurePart("audio");
+    // feed() above rebuilt <audio output> / <video> from scratch, which detaches
+    // the live remote tracks (the Skeleton collection removes + recreates the
+    // id-less child elements). Re-attach the current tracks via the normal
+    // dispatcher so a participant-attributes update doesn't leave the tile
+    // silent / black. handleTrackEvents routes audio->attach and video->attach
+    // (with the camera/desktop/presenter logic) and is a no-op when no track.
+    const aTrack = this.getRemoteTrack(_a.audio);
+    if (aTrack) this.handleTrackEvents(aTrack);
+    const vTrack = this.getRemoteTrack(_a.video);
+    if (vTrack) this.handleTrackEvents(vTrack);
     this.updateCommandPanel(data);
   }
 

--- a/src/drumee/builtins/webrtc/endpoint/remote/user/skin/index.scss
+++ b/src/drumee/builtins/webrtc/endpoint/remote/user/skin/index.scss
@@ -27,6 +27,11 @@
 
   &__avatar {
     position: absolute;
+    // Anchor the absolute overlay to fill the tile exactly. Without insets the
+    // box takes a *centered* static position inside the center-aligned __main
+    // flex parent, shifting the 100%x100% avatar (and the X icon it centers)
+    // off-centre. inset:0 pins it to the tile so its content is truly centred.
+    inset: 0;
     width: 100%;
     height: 100%;
     z-index: 1;
@@ -111,7 +116,10 @@
     align-items: center;
     justify-content: center;
     z-index: 10;
-    width: 300px;
+    // No fixed width: `left:8px; right:8px` already span the tile. A `width`
+    // here over-constrains the box (width wins over `right`), locking the
+    // footer to a left-anchored 300px strip so the name pill renders
+    // off-centre. Dropping it lets the mic/name/dots centre across the tile.
   }
 
   &__tile-mic {

--- a/src/drumee/builtins/webrtc/room/configs/init.js
+++ b/src/drumee/builtins/webrtc/room/configs/init.js
@@ -3,6 +3,13 @@ module.exports = function () {
 		useIPv6: true,
 		disableSimulcast: false,
 		enableAnalyticsLogging: true,
+		// Defense-in-depth for the "audio cut on screen share" bug: don't offer
+		// SYSTEM audio in the getDisplayMedia picker (Chromium >104 reads this
+		// via JitsiMeetJS.init -> ScreenObtainer). NOT sufficient on its own —
+		// lib-jitsi-meet still requests audio:true so a tab-audio track can
+		// still be returned; the authoritative fix is the guard in jitsi.js
+		// createLocalTracks that drops any desktop-origin audio track.
+		screenShareSettings: { desktopSystemAudio: 'exclude' },
 		// enableWindowOnErrorHandler : true
 	};
 }

--- a/src/drumee/builtins/webrtc/room/index.js
+++ b/src/drumee/builtins/webrtc/room/index.js
@@ -323,10 +323,18 @@ class __webrtc_room extends __interact {
         );
         const currentOutputDevice =
           await JitsiMeetJS.mediaDevices.getAudioOutputDevice();
-        let currentInputDevice = null;
-        let audioTrack = this.room.getLocalAudioTrack();
-        if (audioTrack) {
-          currentInputDevice = audioTrack.deviceId;
+        // Seed the highlighted row from the user's remembered pick first; only
+        // fall back to the live track when there is no saved preference (first
+        // open of the call). getDeviceId() honours _realDeviceId, unlike the
+        // raw .deviceId property which can't round-trip the 'default' id.
+        let currentInputDevice = this.preferredInputDevice || null;
+        if (!currentInputDevice) {
+          let audioTrack = this.room.getLocalAudioTrack();
+          if (audioTrack) {
+            currentInputDevice = audioTrack.getDeviceId
+              ? audioTrack.getDeviceId()
+              : audioTrack.deviceId;
+          }
         }
         if (audioInputDevices.length > 0) {
           let view = require("../skeleton/device-list")(
@@ -334,7 +342,9 @@ class __webrtc_room extends __interact {
             audioInputDevices,
             audioOutputDevices,
             currentInputDevice,
-            (currentOutputDevice && currentOutputDevice) || "default"
+            this.preferredOutputDevice ||
+              (currentOutputDevice && currentOutputDevice) ||
+              "default"
           );
           p.feed(view);
         } else {
@@ -411,10 +421,12 @@ class __webrtc_room extends __interact {
   /**
    *
    */
-  recreateLocalTrackOnDeviceChange() {
+  async recreateLocalTrackOnDeviceChange() {
     let reqDevices = [_a.audio];
     if (this.isVideo) reqDevices = [...reqDevices, _a.video];
-    this.createLocalTracks(reqDevices, this.selectedInputDevice);
+    // replaceTrack inside createLocalTracks is async — await so the swap
+    // completes deterministically before the promise settles.
+    await this.createLocalTracks(reqDevices, this.selectedInputDevice);
   }
 
   /**
@@ -477,9 +489,15 @@ class __webrtc_room extends __interact {
         break;
       case "input-device-select":
         this.selectedInputDevice = cmd.$el.data("deviceid");
+        // Remember the user's pick so reopening the popup re-highlights it.
+        // The live-track readback alone can't round-trip the 'default'
+        // pseudo-device id, so without this the selection appears to revert
+        // to the first/Default row even though the mic actually changed.
+        this.preferredInputDevice = this.selectedInputDevice;
         break;
       case "output-device-select":
         this.selectedOutputDevice = cmd.$el.data("deviceid");
+        this.preferredOutputDevice = this.selectedOutputDevice;
         break;
       case "remote-ready":
         //this.checkQuota();

--- a/src/drumee/builtins/webrtc/room/jitsi.js
+++ b/src/drumee/builtins/webrtc/room/jitsi.js
@@ -285,6 +285,22 @@ class __webrtc_room extends __room {
           for (let track of tracks) {
             let type = track.getType();
             let videoType = track.getVideoType();
+            // getDisplayMedia returns a system/tab AUDIO track when the user
+            // ticks "share audio" in the screen-share picker. It arrives here as
+            // a plain audio track (getType()==='audio', videoType===null). If it
+            // reached the audio handling below it would park the live mic stream
+            // in idleStreams (only stopped at call teardown), overwrite
+            // localTracks.audio, and replaceTrack(mic, desktopAudio) — cutting
+            // the user's microphone for the rest of the call (never restored,
+            // since stopPresentation only touches the desktop VIDEO track). The
+            // mic is only ever created via a NON-desktop request, so any audio
+            // track from a desktop request is this stray capture audio: drop it
+            // and leave the microphone sender untouched.
+            if (type === _a.audio && devices.includes(_a.desktop)) {
+              try { if (track.dispose) await track.dispose(); }
+              catch (e) { this.warn("drop desktop audio track failed", e); }
+              continue;
+            }
             track.addEventListener(
               JEVENTS.track.TRACK_MUTE_CHANGED,
               this.onTrackMuteChange

--- a/src/drumee/builtins/webrtc/room/jitsi.js
+++ b/src/drumee/builtins/webrtc/room/jitsi.js
@@ -1034,13 +1034,17 @@ class __webrtc_room extends __room {
     let t = this.getLocalTrack(_a.audio);
     await this.sendRoomSignaling(SERVICE.conference.update);
     if (state) {
+      // Recreate the mic with the user's last confirmed device, not the
+      // implicit "default" — otherwise toggling mute/unmute after picking a
+      // specific microphone silently reverts capture to the default device.
+      const micId = this.preferredInputDevice || "default";
       if (!t) {
-        await this.createLocalTracks(_a.audio);
+        await this.createLocalTracks(_a.audio, micId);
       } else if (t.isActive()) {
         await t.unmute();
       } else {
         await t.dispose();
-        await this.createLocalTracks(_a.audio);
+        await this.createLocalTracks(_a.audio, micId);
       }
     } else {
       t && (await t.mute());

--- a/src/drumee/builtins/webrtc/skeleton/device-list.js
+++ b/src/drumee/builtins/webrtc/skeleton/device-list.js
@@ -8,6 +8,13 @@ const __webrtc_device_list = function (_ui_, audioInput, audioOutput, inputSelec
     content: LOCALE.MICROPHONE
   })];
   
+  // When the selected id matches no enumerated device (e.g. the live track
+  // reports a raw hardware id while the list only carries the 'default'
+  // pseudo-device), highlight the 'default' row instead of leaving every row
+  // unselected — otherwise the radio group renders blank and the popup looks
+  // like it reverted to the first item.
+  const hasInputMatch = audioInput.some(e => e.deviceId === inputSelected);
+
   let inputChannel = _.uniqueId();
   audioInput.forEach(element => {
     kids.push(Skeletons.Note({
@@ -17,7 +24,8 @@ const __webrtc_device_list = function (_ui_, audioInput, audioOutput, inputSelec
       dataset: {
         deviceId: element.deviceId
       },
-      state: (inputSelected === element.deviceId) ? 1 : 0,
+      state: (inputSelected === element.deviceId ||
+        (!hasInputMatch && element.deviceId === "default")) ? 1 : 0,
       radio: inputChannel,
       content: element.label
     }));
@@ -28,6 +36,8 @@ const __webrtc_device_list = function (_ui_, audioInput, audioOutput, inputSelec
     content: LOCALE.SPEAKERS
   }));
 
+  const hasOutputMatch = audioOutput.some(e => e.deviceId === outputSelected);
+
   let outputChannel = _.uniqueId();
   audioOutput.forEach(element => {
     kids.push(Skeletons.Note({
@@ -37,7 +47,8 @@ const __webrtc_device_list = function (_ui_, audioInput, audioOutput, inputSelec
       dataset: {
         deviceId: element.deviceId
       },
-      state: (outputSelected === element.deviceId) ? 1 : 0,
+      state: (outputSelected === element.deviceId ||
+        (!hasOutputMatch && element.deviceId === "default")) ? 1 : 0,
       radio: outputChannel,
       content: element.label
     }));

--- a/src/drumee/builtins/window/bigchat/widget/chatcontact-item/skeleton/index.js
+++ b/src/drumee/builtins/window/bigchat/widget/chatcontact-item/skeleton/index.js
@@ -2,11 +2,15 @@
 const __skl_widget_chatcontactItem = function (ui) {
   let chat_icon, msg, state;
   const contentFig = ui.fig.family;
+  // Hoisted out of the `flag === 'contact'` branch so the name Note below can
+  // fall back the same way the chat header does (chat-header.js): a contact
+  // whose server-computed `display` is empty/blank would otherwise render a
+  // BLANK name in the inbox list while the header + avatar still show one.
+  const fname = ui.mget(_a.firstname) || '';
+  const lname = ui.mget(_a.lastname) || '';
+  const fullname = ui.mget(_a.fullname) || `${fname} ${lname}`.trim();
+  const displayName = (ui.mget('display') || '').trim() || fullname || fname || lname;
   if (ui.mget('flag') === 'contact') {
-    const fname = ui.mget(_a.firstname) || '';
-    const lname = ui.mget(_a.lastname) || '';
-    const fullname = ui.mget(_a.fullname) || (fname + " " + lname);
-
     chat_icon = Skeletons.UserProfile({
       className: `${contentFig}__profile`,
       id: ui.mget('entity_id'),
@@ -27,7 +31,7 @@ const __skl_widget_chatcontactItem = function (ui) {
 
   const name = Skeletons.Note({
     className: `${contentFig}__note name`,
-    content: ui.mget('display'),
+    content: displayName,
     escapeContextmenu: true
   });
 


### PR DESCRIPTION
…s empty

The inbox contact-list row rendered its name as mget('display') with NO fallback, while the chat header used display || fullname || firstname+lastname. So a contact whose server-computed `display` is empty (e.g. a peer with an empty-string profile firstname) showed a BLANK name in the list while the header + avatar still rendered one. Hoist the name fields out of the flag==='contact' branch and give the list name the same fallback chain as the header: display.trim() || fullname || firstname || lastname.