### PR TITLE
feat(window-folder)

### DIFF
--- a/src/drumee/builtins/window/folder/skeleton/topbar.js
+++ b/src/drumee/builtins/window/folder/skeleton/topbar.js
@@ -9,7 +9,7 @@
  *   ↑ left cluster                                      ↑ right cluster (gap 13.14)
  * ==================================================================== */
 
-const { getAreaLabel, newFileMenu, zoomMenu } = require("../../skeleton/toolkit");
+const { getAreaLabel, newFileMenu, zoomMenu, topbarMoreMenu } = require("../../skeleton/toolkit");
 
 const __skl_folder_topbar = function (ui) {
   const cnFolder = `${ui.fig.family}-topbar`;
@@ -135,9 +135,14 @@ const __skl_folder_topbar = function (ui) {
 
   const zoomBtn = headless ? "" : zoomMenu(ui);
 
+  // Overflow menu for the narrow (≤700px container) layout. Holds the same
+  // actions as videoBtn / shareBtn / settingsBtn; CSS swaps it in for those
+  // inline buttons by window width. Always in the DOM (hidden on desktop).
+  const moreMenu = topbarMoreMenu(ui);
+
   const rightCluster = Skeletons.Box.X({
     className: `${cnFolder}__right`,
-    kids: [videoBtn, uploadBtn, addNew, shareBtn, settingsBtn, zoomBtn, minimizeBtn, controls],
+    kids: [videoBtn, uploadBtn, addNew, shareBtn, settingsBtn, moreMenu, zoomBtn, minimizeBtn, controls],
   });
 
   // ── Root row ─────────────────────────────────────────────────

--- a/src/drumee/builtins/window/folder/skin/index.scss
+++ b/src/drumee/builtins/window/folder/skin/index.scss
@@ -738,6 +738,145 @@
       flex: 1;
     }
 
+    // ── Overflow "More" menu ──────────────────────────────────────
+    // Mirrors the zoom menu's CSS-hover dropdown. Holds Meeting / Manage
+    // access / Settings — the controls that collapse out of the row on a
+    // narrow window. Hidden on the full-width desktop layout; the ≤700px
+    // container block shows it (as a 32×32 chip) and hides the inline
+    // video / manage-access / settings / zoom controls.
+    &__more-wrapper {
+      display: none;
+      position: relative;
+      overflow: visible;
+      flex-shrink: 0;
+      width: 20px;
+      height: 20px;
+      align-items: center;
+      justify-content: center;
+
+      &:hover .window-folder-topbar__more-menu,
+      .window-folder-topbar__more-menu:hover {
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(0);
+        pointer-events: auto;
+      }
+    }
+
+    &__more-trigger {
+      width: 20px;
+      height: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--normal-fg-20, var(--normal-fg-10));
+      cursor: pointer;
+      transition:
+        color 0.15s ease,
+        transform 0.15s ease;
+
+      svg {
+        width: 18px;
+        height: 18px;
+      }
+
+      &:hover {
+        color: var(--normal-fg-10);
+        transform: scale(1.06);
+      }
+    }
+
+    &__more-menu {
+      position: absolute;
+      top: calc(100% + 8px);
+      right: -4px;
+      z-index: 1000;
+      min-width: 200px;
+      padding: 6px;
+      background-color: var(--normal-bg-elevated, #fff);
+      border: 1px solid rgba(0, 0, 0, 0.06);
+      border-radius: 10px;
+      box-shadow:
+        0 4px 8px -2px rgba(0, 0, 0, 0.08),
+        0 12px 24px -4px rgba(0, 0, 0, 0.12);
+      // Box.Y already supplies `display: flex; flex-direction: column`.
+      gap: 2px;
+
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-4px);
+      // `visibility 0s linear 0.15s` delays the close so the cursor can
+      // cross the trigger→menu gap without the panel disappearing.
+      transition:
+        opacity 0.15s ease,
+        transform 0.15s ease,
+        visibility 0s linear 0.15s;
+      pointer-events: none;
+
+      // Invisible strip between trigger and panel — bridges the 8px gap
+      // so the cursor doesn't drop out of hover during transit.
+      &::before {
+        content: "";
+        position: absolute;
+        top: -10px;
+        left: 0;
+        right: 0;
+        height: 10px;
+      }
+    }
+
+    // Override the close-delay on `visibility` so opening is immediate.
+    &__more-wrapper:hover .window-folder-topbar__more-menu,
+    .window-folder-topbar__more-menu:hover {
+      transition:
+        opacity 0.15s ease,
+        transform 0.15s ease,
+        visibility 0s linear 0s;
+    }
+
+    &__more-item {
+      // Box.X already supplies `display: flex; flex-direction: row`.
+      align-items: center;
+      gap: 10px;
+      padding: 8px 10px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-family: "Geist", sans-serif;
+      font-size: 13px;
+      font-weight: 500;
+      line-height: 1.2;
+      color: var(--normal-fg-10);
+      white-space: nowrap;
+      transition: background-color 0.12s ease;
+
+      &:hover {
+        background-color: var(--normal-bg-90);
+      }
+    }
+
+    &__more-item-icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+      color: var(--normal-fg-20, var(--normal-fg-10));
+
+      svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    // Settings glyph is stroke-only (matches the inline control-icon).
+    &__more-item--settings .window-folder-topbar__more-item-icon svg,
+    &__more-item--settings .window-folder-topbar__more-item-icon use {
+      fill: none;
+      stroke: currentColor;
+    }
+
+    &__more-item-label {
+      flex: 1;
+    }
+
     // The window control (close ×) sits at the far right of the row.
     // Figma 272:49268 / layout_VZ2RLI: row, gap 12, height 20.
     .window-button__icon-button {
@@ -2778,7 +2917,8 @@
         height: auto;
         min-height: 52px;
         min-width: 0;
-        padding: 0 var(--spacer-3);
+        padding: 0 var(--spacer-6);
+        border-radius: 0;
       }
 
       &__left {
@@ -2795,7 +2935,7 @@
       // share the same background fill.
       &__right {
         flex: 0 1 auto;
-        gap: var(--spacer-2);
+        gap: var(--spacer-4);
         min-width: 0;
         overflow: visible;
       }
@@ -2855,10 +2995,12 @@
       // icons. Mobile unifies them: same square, same Grey/20 bg,
       // same 6px radius, flex-centered SVG. The Add-new trigger
       // keeps its purple via the .secondary override below.
-      &__video-btn,
+      // Video / manage-access / settings / zoom drop out of the row here
+      // and move into the overflow "More" menu (the only chip-styled
+      // control-icon kept is the More trigger).
       &__upload-btn,
       &__add-new-wrapper,
-      &__control-icon,
+      &__more-wrapper,
       .window-button__icon-button {
         flex: 0 0 auto;
         height: 32px;
@@ -2874,6 +3016,33 @@
         // Desktop close-button row used `gap: 12` for inline children;
         // a single-icon chip needs none.
         gap: 0;
+      }
+
+      // Collapse the standalone Meeting / Manage-access / Settings / zoom
+      // controls — they live in the overflow "More" menu at this width.
+      &__video-btn,
+      &__control-icon.share,
+      &__control-icon.settings,
+      &__zoom-wrapper {
+        display: none;
+      }
+
+      // The More trigger fills its 32×32 chip; the hover panel anchors to
+      // the chip and is width-capped to the window like the Add-new menu.
+      &__more-trigger {
+        width: 100%;
+        height: 100%;
+
+        svg {
+          width: 18px;
+          height: 18px;
+        }
+      }
+
+      &__more-menu {
+        max-width: calc(100cqw - 24px);
+        min-width: 200px;
+        right: 0;
       }
 
       // Hide the split/layout toggle on mobile — single-column layout
@@ -2951,7 +3120,8 @@
       flex-wrap: nowrap;
       gap: var(--spacer-5);
       overflow-x: auto;
-      padding: var(--spacer-2) var(--spacer-3);
+      padding: var(--spacer-4);
+      justify-content: center;
       scrollbar-width: none;
 
       &::-webkit-scrollbar {

--- a/src/drumee/builtins/window/skeleton/toolkit/index.js
+++ b/src/drumee/builtins/window/skeleton/toolkit/index.js
@@ -778,6 +778,93 @@ export function zoomMenu(ui) {
 }
 
 /**
+ * Overflow "More" menu — an icon trigger with a CSS-hover dropdown that
+ * holds the right-cluster actions which collapse out of the row on a
+ * narrow window (≤700px container width): Meeting, Manage access, Settings.
+ *
+ * Each item carries the SAME service as the standalone button it stands in
+ * for, and is gated by the SAME condition, so the menu is a faithful mirror
+ * of the inline controls. In a share-recipient context (a window carrying a
+ * pinned share token) none of these chrome actions apply, so the helper
+ * returns "" — no orphan trigger.
+ *
+ * Always rendered into the row; CSS toggles its visibility against the inline
+ * buttons by container width (see the ≤700px block in the folder skin).
+ *
+ * @param {*} ui
+ */
+export function topbarMoreMenu(ui) {
+  const cnRoot = `${ui.fig.family}-topbar__more`;
+  const inShare = !!ui.mget(_a.token);
+  const area = ui.mget(_a.area);
+
+  const items = [];
+  if (!inShare) {
+    items.push({
+      service: "tab-meeting",
+      ico: "video-camera-header",
+      content: LOCALE.MEETING,
+      modifier: "video",
+    });
+  }
+  // Manage Access mirrors the share control-icon: share areas only.
+  if (!inShare && area === _a.share) {
+    items.push({
+      service: "folder-manage-access",
+      ico: "app-share",
+      content: LOCALE.MANAGE_ACCESS,
+      modifier: "share",
+    });
+  }
+  if (!inShare) {
+    items.push({
+      service: _e.settings,
+      ico: "gear-header",
+      content: LOCALE.SETTINGS,
+      modifier: "settings",
+    });
+  }
+
+  if (!items.length) return "";
+
+  return Skeletons.Box.X({
+    className: `${cnRoot}-wrapper`,
+    kids: [
+      Skeletons.Button.Svg({
+        ico: "apps-dots-vertical",
+        className: `${cnRoot}-trigger`,
+        sys_pn: "topbar-more",
+        uiHandler: [ui],
+        partHandler: ui,
+      }),
+      Skeletons.Box.Y({
+        className: `${cnRoot}-menu`,
+        kids: items.map(({ service, ico, content, modifier }) =>
+          Skeletons.Box.X({
+            className: `${cnRoot}-item ${cnRoot}-item--${modifier}`,
+            uiHandler: [ui],
+            service,
+            kidsOpt: { active: 0 },
+            kids: [
+              Skeletons.Button.Svg({
+                ico,
+                active: 0,
+                className: `${cnRoot}-item-icon`,
+              }),
+              Skeletons.Note({
+                content,
+                active: 0,
+                className: `${cnRoot}-item-label`,
+              }),
+            ],
+          }),
+        ),
+      }),
+    ],
+  });
+}
+
+/**
  *
  * @param {*} ui
  * @returns

--- a/src/drumee/builtins/window/skin/window.scss
+++ b/src/drumee/builtins/window/skin/window.scss
@@ -220,7 +220,11 @@
       min-width: 0 !important;
       overflow: hidden;
       right: auto;
-      width: 100vw !important;
+      width: 90vw !important;
+    }
+
+    &-folder__main.drive-popup{
+      border-radius: 0 !important;
     }
 
     &__content-row {

--- a/src/drumee/modules/desk/breadcrumb/skin/index.scss
+++ b/src/drumee/modules/desk/breadcrumb/skin/index.scss
@@ -10,6 +10,7 @@
     display: flex;
     color: #65656c;
     min-width: 0;
+    min-width: 40px;  
   }
 
   &__main {

--- a/src/drumee/modules/desk/skin/topbar.scss
+++ b/src/drumee/modules/desk/skin/topbar.scss
@@ -61,7 +61,10 @@
     gap: 4px;
     flex: 0 1 auto;
     min-width: 0;
-    overflow: hidden;
+    overflow: auto;
+    &::-webkit-scrollbar { width: 4px; } ;
+    &::-webkit-scrollbar-track { background: rgba(0, 0, 0, 0.05); } ;
+    &::-webkit-scrollbar-thumb { background: var(--primary-40); border-radius: 4px; };
   }
 
   &__folder-tab {
@@ -291,6 +294,7 @@
   &__actions-cluster {
     align-items: center;
     gap: 12px;
+    padding-left: 12px;
   }
 
   // New workspace button
@@ -771,6 +775,14 @@
   @media (min-width: 1025px) {
     &__more-btn {
       display: none !important;
+    }
+  }
+
+  // Narrow viewports: cap the search bar so it doesn't crowd the rest of
+  // the topbar (the 192px default eats too much of a sub-650px row).
+  @media (max-width: 650px) {
+    &__search-bar {
+      max-width: 140px;
     }
   }
 


### PR DESCRIPTION
 collapse topbar controls into a "More" menu on narrow windows

Folder window topbar:
- Add topbarMoreMenu(ui) helper (CSS-hover dropdown, mirrors zoomMenu) holding Meeting / Manage access / Settings, gated by the same conditions as the inline buttons; returns "" in a share-recipient context.
- Render it into the right cluster; at <=700px (window-folder-w container query) hide video / manage-access / settings / zoom inline controls and show the More chip instead.

Desk topbar:
- Cap .desk-module-topbar__search-bar to max-width 140px under @media (max-width: 650px).

Also bundles in-progress tweaks: window.scss drive-popup width/border-radius and breadcrumb min-width.