### PR TITLE
fix(player): smooth edge-handle resize over editor iframe + doc toolbar styling

### DIFF
--- a/src/drumee/builtins/player/document/skeleton/menu.js
+++ b/src/drumee/builtins/player/document/skeleton/menu.js
@@ -9,6 +9,10 @@ function tooltip(ui, content) {
   };
 }
 
+// Download / save-as-PDF / preview / print get the filled (primary) look; every
+// other action is a plain icon button.
+const PRIMARY_SERVICES = [_a.download, "download-pdf", "preview", "print", _a.edit];
+
 function action(ui, { service, ico, tip, state, icons, sys_pn }) {
   const a = {
     ico,
@@ -16,6 +20,14 @@ function action(ui, { service, ico, tip, state, icons, sys_pn }) {
     service,
     uiHandler: ui,
     tooltips: tooltip(ui, tip),
+    style: PRIMARY_SERVICES.includes(service)
+      ? {
+          "background-color": "var(--normal-bg-90)",
+          color: "var(--normal-fg-10)",
+          padding: "4px 8px",
+          "border-radius": "6px",
+        }
+      : { color: "var(--normal-fg-20)" },
   };
   if (state != null) a.state = state;
   if (icons) a.icons = icons;
@@ -57,7 +69,7 @@ module.exports = function (ui) {
       actions.push(
         action(ui, {
           service: "preview",
-          ico: "desktop_preview",
+          ico: "eye",
           tip: LOCALE.PREVIEW,
         }),
       );

--- a/src/drumee/builtins/player/interact.js
+++ b/src/drumee/builtins/player/interact.js
@@ -256,6 +256,9 @@ class __window_interact_player extends __utils {
         scroll: false,
         handle: `.${this.fig.group}__header`,
         cancel: ".slidebar",
+        // Shield child iframes (e.g. OnlyOffice editor) so a fast drag over the
+        // iframe doesn't lose mouse events and stall the drag.
+        iframeFix: true,
       });
       this.setContainment();
       if (this.mget(_a.resizable) != _a.disable) {
@@ -381,14 +384,52 @@ class __window_interact_player extends __utils {
   }
 
   /**
-   * 
-   * @param {*} e 
-   * @param {*} ui 
+   * Never leave the resize shield behind if the player is torn down mid-drag —
+   * a stray full-viewport overlay would swallow every click.
+   */
+  onBeforeDestroy() {
+    this._removeResizeShield();
+    if (super.onBeforeDestroy) super.onBeforeDestroy();
+  }
+
+  /**
+   *
+   * @param {*} e
+   * @param {*} ui
    */
   _resizeStart(e, ui) {
     this.selector(0);
     this._sizeCtrl && this._sizeCtrl.changeState(0);
+    this._addResizeShield();
     super._resizeStart(e, ui);
+  }
+
+  /**
+   * jQuery UI tracks the resize via mousemove on the parent document. When the
+   * cursor passes over a child iframe (e.g. the OnlyOffice editor) the iframe
+   * captures the mouse events and the parent stops receiving them, so an edge
+   * resize stutters/freezes on fast moves while corner handles (which drag
+   * outward, away from the iframe) stay smooth. Lay a transparent full-viewport
+   * shield over everything for the duration of the drag so every mousemove/up
+   * lands on the parent document. (resizable has no `iframeFix` option — only
+   * draggable does — so this has to be manual.)
+   */
+  _addResizeShield() {
+    if (this._resizeShield) return;
+    const d = document.createElement("div");
+    d.style.cssText =
+      "position:fixed;top:0;left:0;width:100%;height:100%;z-index:2147483646;background:transparent;cursor:inherit;";
+    document.body.appendChild(d);
+    this._resizeShield = d;
+  }
+
+  /**
+   * Remove the resize shield added in _resizeStart.
+   */
+  _removeResizeShield() {
+    if (!this._resizeShield) return;
+    this._resizeShield.remove();
+    this._resizeShield = null;
   }
 
   /**
@@ -397,6 +438,7 @@ class __window_interact_player extends __utils {
    * @param {*} ui 
    */
   _resizeStop(e, ui) {
+    this._removeResizeShield();
     this.selector(1);
     this._image = null;
     this._video = null;


### PR DESCRIPTION


The OnlyOffice editor is an iframe. jQuery UI tracks resize via mousemove on the parent document, so when the cursor crosses the iframe the events are swallowed and an edge-handle (n/e/s/w) resize stalls on fast moves — corner handles stay smooth only because their CSS pulls them outside the window and elevates them above the iframe.

- Lay a transparent full-viewport shield over everything during a pointer resize (resizable has no iframeFix option, only draggable does) so every mousemove/up lands on the parent document; remove it on stop and on destroy so a stray max-z-index overlay can never swallow clicks.
- iframeFix: true on the draggable so dragging the title bar over the editor is solid too.
- Style the document toolbar buttons: download/save-as-PDF/preview/print/edit get the filled primary look (padding + radius); the rest get fg-20.