### PR TITLE
fix(meeting): scope joiner's meeting chat to the folder channel

### DIFF
--- a/src/drumee/builtins/window/folder/skeleton/meeting-panel.js
+++ b/src/drumee/builtins/window/folder/skeleton/meeting-panel.js
@@ -22,6 +22,20 @@ module.exports = function meetingPanel(ui) {
             hub_id: ui.mget(_a.hub_id),
             filename: ui.mget(_a.filename),
             nid: ui.mget(_a.actual_home_id) || ui.mget(_a.nid),
+            room_id: ui.mget(_a.actual_home_id) || ui.mget(_a.nid),
+            // Forward this folder's chat-channel identity so the joiner's meeting
+            // chat binds to the SAME folder-scoped conversation as the host (who
+            // launches via _launchMeetingStandalone). Without these the side panel
+            // mounts UNSCOPED (meetingSidePanel's isTeamChannel = false): the
+            // joiner's posts carry no _scope_nid, so the host's folder-scoped chat
+            // filters them out in realtime. chat_nid is the folder chat's scope
+            // nid (this window's own nid), not the workspace root.
+            actual_hub_id: ui.mget(_a.actual_hub_id),
+            actual_home_id: ui.mget(_a.actual_home_id),
+            chat_nid: ui.mget(_a.nid),
+            home_id: ui.mget(_a.home_id),
+            ownpath: ui.mget(_a.ownpath),
+            area: ui.mget(_a.area),
             trigger: ui.mget(_a.media) || ui,
             media: ui.mget(_a.media) || ui,
             service: "meeting",


### PR DESCRIPTION
The "Join the meeting" path renders the embedded meeting-panel, which launched window_meeting without the folder's chat-channel identity (chat_nid/actual_hub_id/actual_home_id). meetingSidePanel keys its folder-scoping on those fields, so the joiner's chat mounted UNSCOPED while the host (via _launchMeetingStandalone) mounted folder-scoped.

Effect: the joiner's posts carried no _scope_nid, so the host's folder-scoped widget filtered them out in realtime (host->joiner worked, joiner->host showed nothing). Forward the same channel identity the host launch passes so both bind to the same folder-scoped conversation.