### PR TITLE
feat(folder): align success toasts to branded notice style

### DIFF
--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -2710,7 +2710,7 @@ class __window_folder extends mfsInteract {
           });
         }
       }
-      Wm.alert(LOCALE.ROLE_UPDATED_SUCCESSFULLY || "Role updated.");
+      this._showNoticeToast(LOCALE.ROLE_UPDATED_SUCCESSFULLY || "Role updated.");
     } catch (e) {
       Wm.alert(e?.reason || e?.error || LOCALE.TRY_AGAIN);
     } finally {
@@ -2754,15 +2754,15 @@ class __window_folder extends mfsInteract {
       });
   }
 
-  // Branded confirmation toast shown after an invitation is sent. It reuses the
-  // floating window_info component styled like window-confirm (the "notice"
-  // variant — drumee logo + a compact card) with a single Close button that
-  // dismisses the toast.
-  _showInviteSentToast() {
+  // Branded confirmation toast shown after a member-management action succeeds
+  // (invite sent, role updated, member removed, …). It reuses the floating
+  // window_info component styled like window-confirm (the "notice" variant —
+  // drumee logo + a compact card, see window-info skin [data-variant="notice"])
+  // with a single Close button that dismisses the toast. Every success
+  // confirmation goes through here so they share one consistent style.
+  _showNoticeToast(message) {
     Wm.info({
-      message: LOCALE.INVITATION_SENT_SUCCESSFULLY,
-      // Compact, window-confirm styled card (see window-info skin
-      // [data-variant="notice"]).
+      message,
       variant: "notice",
       actions: [
         {
@@ -2773,6 +2773,11 @@ class __window_folder extends mfsInteract {
         },
       ],
     });
+  }
+
+  // Confirmation toast shown after an invitation is sent.
+  _showInviteSentToast() {
+    this._showNoticeToast(LOCALE.INVITATION_SENT_SUCCESSFULLY);
   }
 
   // Open a destructive Wm.confirm popup; on confirm POST
@@ -2821,7 +2826,7 @@ class __window_folder extends mfsInteract {
         return;
       }
       await this._refreshFolderMembers();
-      Wm.alert(LOCALE.MEMBER_REMOVED_SUCCESSFULLY || "Member removed.");
+      this._showNoticeToast(LOCALE.MEMBER_REMOVED_SUCCESSFULLY || "Member removed.");
     } catch (e) {
       Wm.alert(e?.reason || e?.error || LOCALE.TRY_AGAIN);
     } finally {

--- a/src/drumee/builtins/window/info/skin/index.scss
+++ b/src/drumee/builtins/window/info/skin/index.scss
@@ -213,6 +213,7 @@
   transform: translate(-50%, -50%) !important;
   margin: 0 !important;
   z-index: 100000;
+  background-color: var(--normal-bg-90);
 
   min-width: 340px;
   min-height: 0 !important;


### PR DESCRIPTION
Route the "role updated" and "member removed" confirmations through a shared _showNoticeToast helper so they use the same compact, branded window-confirm styled card as the invite-sent toast instead of the default 600x300 info dialog. Also set the notice card background.