### PR TITLE
chore(settings): hide Billing & Subscription card on Settings page

### DIFF
--- a/src/drumee/builtins/widget/settings/main/skeleton/index.js
+++ b/src/drumee/builtins/widget/settings/main/skeleton/index.js
@@ -533,16 +533,22 @@ function billingCard(ui) {
 
 function settings_body(ui) {
   const pfx = ui.fig.family;
+  // TEMP: Billing & Subscription card hidden on the Settings page (also removes
+  // the "Manage Subscription" entry point into settings_billing). Flip
+  // SHOW_BILLING to true to restore.
+  const SHOW_BILLING = false;
   return [
     header(ui),
     Skeletons.Box.X({
       className: `${pfx}__row ${pfx}__row-1`,
       kids: [generalProfileCard(ui), preferencesCard(ui)],
     }),
-    Skeletons.Box.X({
-      className: `${pfx}__row ${pfx}__row-billing`,
-      kids: [billingCard(ui)],
-    }),
+    SHOW_BILLING
+      ? Skeletons.Box.X({
+          className: `${pfx}__row ${pfx}__row-billing`,
+          kids: [billingCard(ui)],
+        })
+      : null,
     Skeletons.Box.X({
       className: `${pfx}__row ${pfx}__row-2`,
       kids: [accountCredentialsCard(ui), dangerZoneCard(ui)],
@@ -561,7 +567,7 @@ function settings_body(ui) {
       className: `${pfx}__toast-slot`,
       sys_pn: "settings-toast",
     }),
-  ];
+  ].filter(Boolean);
 }
 
 export default settings_body;


### PR DESCRIPTION
## What
Hide the **Billing & Subscription** card on the main Settings page (`settings_main`).

## Why
Payment/billing UI is not ready to be exposed in production yet; hiding the card also removes the **Manage Subscription** button — the only entry point into the `settings_billing` popup — so the whole payment/billing surface is unreachable from Settings.

## How
`settings/main/skeleton/index.js` → `settings_body()`: the billing row is gated behind a `SHOW_BILLING` flag (default `false`) and the kids array is `.filter(Boolean)`-ed. The `billingCard()` function is kept for the restore path — flip `SHOW_BILLING = true` to bring it back. No other behavior changes.

## Test
- `node --check` passes.
- Settings page renders without the Billing & Subscription row; other cards (profile, preferences, credentials, danger zone, linked accounts) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)