### PR TITLE
fix(settings): resolve leftover merge conflict in settings body

### DIFF
--- a/src/drumee/builtins/widget/settings/main/skeleton/index.js
+++ b/src/drumee/builtins/widget/settings/main/skeleton/index.js
@@ -587,12 +587,6 @@ function settings_body(ui) {
       className: `${pfx}__row ${pfx}__row-1`,
       kids: [generalProfileCard(ui), preferencesCard(ui)],
     }),
-<<<<<<< HEAD
-    Skeletons.Box.X({
-      className: `${pfx}__row ${pfx}__row-billing`,
-      kids: [billingCard(ui), referralCard(ui)],
-    }),
-=======
     SHOW_BILLING
       ? Skeletons.Box.X({
           className: `${pfx}__row ${pfx}__row-billing`,
@@ -602,7 +596,6 @@ function settings_body(ui) {
           className: `${pfx}__row ${pfx}__row-referral`,
           kids: [referralCard(ui)],
         }),
->>>>>>> feat/upload-popup-auto-minimize
     Skeletons.Box.X({
       className: `${pfx}__row ${pfx}__row-2`,
       kids: [accountCredentialsCard(ui), dangerZoneCard(ui)],


### PR DESCRIPTION
Remove stray conflict markers in settings_body and keep the SHOW_BILLING-gated billing/referral rows from
feat/upload-popup-auto-minimize (billing shown only when enabled, otherwise referral spans its own row).