### PR TITLE
fix(tasks): make detail sidebar scroll independently

### DIFF
--- a/src/drumee/builtins/window/tasks/skin/index.scss
+++ b/src/drumee/builtins/window/tasks/skin/index.scss
@@ -1004,9 +1004,10 @@
   &__detail-panel &__modal-side {
     flex-basis: 380px;
     width: 380px;
-    padding-left: 24px;
+    padding: 0 24px;
     box-sizing: border-box;
     border-left: 3px solid var(--col-primary-40, #5950ff);
+    max-height: 100%;
     overflow-y: auto; // short windows: sidebar scrolls alone, Save stays reachable
   }
 


### PR DESCRIPTION
Give the detail-panel sidebar an explicit max-height: 100% so its overflow-y: auto has a constrained height to scroll against (align-self: flex-start alone sized it to content height, so it never scrolled and tall content was clipped by the body's overflow: hidden). Also switch padding-left to symmetric padding: 0 24px.