### PR TITLE
fix(meeting): align local tile avatar and name with remote

### DIFF
--- a/src/drumee/builtins/webrtc/endpoint/local/user/skeleton/index.js
+++ b/src/drumee/builtins/webrtc/endpoint/local/user/skeleton/index.js
@@ -7,14 +7,34 @@ const __skl_stream_local = function (_ui_) {
     uiHandler: [_ui_]
   };
 
-  const uname = _ui_.mget('username') || _ui_.mget('uname') || LOCALE.ME;
+  // Source name fields exactly like broadcastJoining does (`mget || Visitor.*`)
+  // so the local tile derives its initials, color, and footer name from the
+  // SAME values the remote tiles receive. The local endpoint model is seeded
+  // only from Visitor.profile() (participants/index.js), whose lastname can be
+  // empty while Visitor.lastname() falls back to a secondary field — without
+  // the fallback the owner read "T"/"Test" here vs "TO"/"Test Owner1" remotely.
+  const firstname = _ui_.mget(_a.firstname) || Visitor.firstname() || "";
+  const lastname = _ui_.mget(_a.lastname) || Visitor.lastname() || "";
+  // Footer badge: match the remote footer, which shows the broadcast display
+  // name (Visitor.fullname() for a member). Fall back to the split name, then
+  // the old username chain, then LOCALE.ME for a nameless guest.
+  const uname =
+    Visitor.fullname() ||
+    `${firstname} ${lastname}`.trim() ||
+    _ui_.mget("username") ||
+    _ui_.mget("uname") ||
+    LOCALE.ME;
 
+  // Feed the profile widget the SAME split firstname/lastname the remote tile
+  // uses (endpoint/remote/user/skeleton) so initiales() and colorFromName()
+  // produce identical initials + color for the same person on every client.
   const avatar = {
     kind: KIND.profile,
     id: _ui_.mget('avatar_id') || Visitor.profile().id,
     type: 'thumb',
     active: 0,
-    firstname: uname
+    firstname,
+    lastname
   };
 
   const topActions = Skeletons.Box.X({


### PR DESCRIPTION
The local participant tile rendered a different avatar and footer name than the same person's remote tile: initials "T" (green) vs "TO" (teal) and footer "Test" vs "Test Owner1".

Root cause: the local skeleton crammed the whole display string into the profile widget's `firstname` (no `lastname`), so initiales() produced one letter and colorFromName() hashed a different color than the remote's two-letter initials. The footer likewise used username||uname||ME instead of the full name. Sourcing firstname/lastname only from the local endpoint model was also insufficient — that model is seeded from Visitor.profile(), whose lastname can be empty, while the data broadcast to remotes uses the Visitor.lastname() fallback.

Fix: source firstname/lastname as `mget || Visitor.*` (mirroring broadcastJoining) and set the footer name to Visitor.fullname(), so the local tile derives its initials, color, and name from the exact values the remote tiles receive.