### PR TITLE
Hotfix → Preview: DMZ shared-workspace download (buttons + progress + zip content)

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1116,6 +1116,7 @@
   "WAITING_FOR_CONFIRMATION": "Waiting for confirmation",
   "ENTER_AS_PARTICIPANT": "Enter as attendee",
   "DOWNLOAD_LONG_TIME": "Downloading <u>{0}</u> for {1}. This may take a while.",
+  "DOWNLOAD_SAVING_IN_BROWSER": "Your file is saving to your browser’s downloads — you can keep working.",
   "MULTIPLE_CONNECTION": "Multiple connections",
   "DMZ_MORE_ON": "Learn more",
   "LEAVE_COMMENTS": "Leave comments",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drumee/ui-team",
   "description": "Drumee Web Os User Interface with collaborative features",
-  "version": "3.3.62",
+  "version": "3.3.71",
   "homepage": "https://drumee.com",
   "author": "Somanos Sar <somanos@drumee.com> (http://drumee.com)",
   "repository": {

--- a/src/drumee/builtins/media/core.js
+++ b/src/drumee/builtins/media/core.js
@@ -1,4 +1,4 @@
-const { filesize, timestamp, dataTransfer } = require("@drumee/ui-essentials")
+const { timestamp, dataTransfer } = require("@drumee/ui-essentials")
 
 const MEDIA_GRID = "media_grid";
 const MEDIA_ROW = "media_row";
@@ -2282,12 +2282,10 @@ class __media_core extends DrumeeMFS {
             const _sst = this.mget(_a.token) ? `&token=${encodeURIComponent(this.mget(_a.token))}` : '';
             let url = `${svc}media.zip?hub_id=${hub_id}&nid=${nid}&id=${zip_id}&keysel=${keysel}&zipname=${encodeURIComponent(zipname)}${_sst}`;
             this.getFromUrl(url);
-            Wm.alert(
-              LOCALE.DOWNLOAD_LONG_TIME.format(
-                zipname,
-                filesize(this._zipsize)
-              )
-            );
+            // Native browser download (no in-app byte progress possible). Show a
+            // simulated size-scaled progress bar instead of the plain alert so
+            // the user sees motion + can tell it's working. Download unchanged.
+            Wm.downloadNotice(zipname, this._zipsize);
             return;
           }
           this.append({

--- a/src/drumee/builtins/window/downloader/index.js
+++ b/src/drumee/builtins/window/downloader/index.js
@@ -106,9 +106,17 @@ class __window_downloader extends mfsInteract {
     let hub_id = opt.hub_id || this.mget(_a.hub_id) || Visitor.get(_a.id);
     let zip_id = opt.zipid || this._zipid;
     let { svc, keysel } = bootstrap();
-    let url = `${svc}media.zip?hub_id=${hub_id}&nid=${nid}&id=${zip_id}&keysel=${keysel}&zipname=${data.zipname}`;
+    // Two fixes here: (1) `data.zipname` was an undefined ReferenceError (should
+    // be opt.zipname) — this branch (large "Single file .zip" downloads) threw
+    // before ever starting; (2) carry the secure-share token so DMZ-share
+    // recipients pass the server download guard (mirrors media/core.js). Encode
+    // the name (archives carry spaces/colons).
+    const _sst = this._token ? `&token=${encodeURIComponent(this._token)}` : '';
+    let url = `${svc}media.zip?hub_id=${hub_id}&nid=${nid}&id=${zip_id}&keysel=${keysel}&zipname=${encodeURIComponent(opt.zipname || '')}${_sst}`;
     super.getFromUrl(url);
-    Wm.alert(LOCALE.DOWNLOAD_LONG_TIME.format(opt.zipname, filesize(this._zipsize)));
+    // Native browser download (no in-app byte progress) → simulated size-scaled
+    // progress bar instead of the plain alert. Download itself is unchanged.
+    Wm.downloadNotice(opt.zipname, this._zipsize);
     this.goodbye();
   }
 

--- a/src/drumee/builtins/window/downloader/index.js
+++ b/src/drumee/builtins/window/downloader/index.js
@@ -148,15 +148,30 @@ class __window_downloader extends mfsInteract {
   /**
    * 
    */
+  // The progress bar (kind 'progress_bar', a ui-core widget) is not registered
+  // in every context — e.g. the DMZ share bundle — so ensurePart('progress')
+  // can resolve to a failover view that lacks update/setLabel/restart. Guard
+  // every call so a missing progress widget never crashes the download; the
+  // size-scaled Wm.downloadNotice still gives the user feedback for the (native)
+  // transfer. Returns the widget only when it's the real, functional one.
+  _progress(method, ...args) {
+    const p = this.__progress;
+    if (p && typeof p[method] === "function") return p[method](...args);
+  }
+
+  _hasProgress() {
+    return this.__progress && typeof this.__progress.update === "function";
+  }
+
   downloadZip(data) {
     if (this._isDownloading) return;
     if (this._zipsize > MAX_BLOB_SIZE) {
       this.getFromUrl(data);
       return;
     }
-    this.__progress.setLabel(data.zipname);
+    this._progress('setLabel', data.zipname);
     this.once(_e.eod, () => {
-      this.__progress.setLabel(LOCALE.YOUR_DATA.printf(LOCALE.HAS_BEEN_SAVED));
+      this._progress('setLabel', LOCALE.YOUR_DATA.printf(LOCALE.HAS_BEEN_SAVED));
       this.__btnCancel.suppress();
       this.__btnStatus.set({ content: LOCALE.ACK_REQ_OK });
       this.__btnAction.mset({ service: _e.close });
@@ -165,16 +180,16 @@ class __window_downloader extends mfsInteract {
       this.postService({ service: SERVICE.media.zip_release, id: data.zipid, token: this._token });
     });
     this._isDownloading = 1;
-    this.__progress.restart(this._filesize);
-    this.download_zip({ ...data, progress: this.__progress })
+    this._progress('restart', this._filesize);
+    this.download_zip({ ...data, progress: this._hasProgress() ? this.__progress : undefined })
       .then()
       .catch((e) => {
         this.warn("GOT ERRO WHILE DOWNLOADING", e);
         // this.postService({service: SERVICE.media.zip_release, id:data.zipid});
         if (/aborted/.test(e)) {
-          this.__progress.setLabel(LOCALE.CANCELED);
+          this._progress('setLabel', LOCALE.CANCELED);
         } else {
-          this.__progress.setLabel(e);
+          this._progress('setLabel', e);
         }
       });
 
@@ -257,11 +272,11 @@ class __window_downloader extends mfsInteract {
     }
     switch (phase) {
       case 'archive':
-        this.__progress.update(progress);
+        this._progress('update', progress);
         break;
       case 'exit':
         this.downloadZip(data);
-        this.__progress.setLabel(LOCALE.BACKUP_TIPS);
+        this._progress('setLabel', LOCALE.BACKUP_TIPS);
         break;
     }
   }

--- a/src/drumee/builtins/window/downloader/index.js
+++ b/src/drumee/builtins/window/downloader/index.js
@@ -62,7 +62,14 @@ class __window_downloader extends mfsInteract {
       socket_id: Visitor.get(_a.socket_id),
     };
     if (this.mget(_a.token)) {
-      this._api.hub_id = Host.id
+      // Use the share's CONTENT hub, not the connect host's hub. On a neutral
+      // share host (share.<domain>) Host.id is the share-host hub, NOT where the
+      // files live, so zip_size/media.zip would run against the wrong hub →
+      // size:null + 403 PERMISSION_DENIED (works on desk only because an
+      // authenticated session already resolves to its real hub). The sharebox
+      // pins the content hub as Visitor.share_hub_id; the per-node list also
+      // carries it (hub_id). Fall back to Host.id for legacy per-vhost links.
+      this._api.hub_id = Visitor.get('share_hub_id') || hub_id || Host.id;
       this._api.token = this.mget(_a.token);
     }
     this.mset({

--- a/src/drumee/builtins/window/downloader/index.js
+++ b/src/drumee/builtins/window/downloader/index.js
@@ -127,6 +127,33 @@ class __window_downloader extends mfsInteract {
     this.goodbye();
   }
 
+  /**
+   * Retrieve a prepared archive over the blob path (< MAX_BLOB_SIZE). Overrides
+   * ui-core's download_zip, which built the media.zip URL with `name=` — but the
+   * server does input.need('zipname') (→ 412 without it) — and sent no
+   * secure-share token (→ 403 for a signed-in non-member recipient). Mirror
+   * media/core.js: send `zipname` + the token + the CONTENT hub (this.mget
+   * (hub_id) was set to the share's content hub in onDomRefresh). Without this,
+   * "Single file .zip" of a shared folder failed even after the folder was
+   * successfully staged server-side.
+   */
+  download_zip(o = {}) {
+    let nid = o.nid || this.mget(_a.nid) || Visitor.get(_a.home_id);
+    let hub_id = o.hub_id || this.mget(_a.hub_id) || Visitor.get(_a.id);
+    let zip_id = o.zipid || this._zipid;
+    let { svc, keysel } = bootstrap();
+    let zipname =
+      o.zipname || this.mget('zipname') || this.mget(_a.filename) ||
+      Dayjs().format("[drumee]-YYYY-MM-DD");
+    const _sst = this._token ? `&token=${encodeURIComponent(this._token)}` : '';
+    let url = `${svc}media.zip?hub_id=${hub_id}&nid=${nid}&id=${zip_id}&keysel=${keysel}&zipname=${encodeURIComponent(zipname)}${_sst}`;
+    return this.fetchFile({
+      url,
+      progress: o.progress,
+      download: `${zipname}.zip`,
+    });
+  }
+
 
   /**
    * 

--- a/src/drumee/builtins/window/downloader/skeleton/progress.js
+++ b/src/drumee/builtins/window/downloader/skeleton/progress.js
@@ -16,13 +16,22 @@ const __window_downloader_progress = function(_ui_, size) {
           })
         ]})
     ]});
-  const progress = {  
+  // `size` is the wet-run zip_size response, which comes back null here (the
+  // byte total was already resolved in the downloader's onDomRefresh dry run →
+  // _ui_._zipsize). Guard it: the old `size.printf(LOCALE.BACKUP_TIPS)` threw
+  // "Cannot read properties of null (reading 'printf')" and — printf being a
+  // String method — would also throw on the numeric byte count, so the "Single
+  // file .zip" button crashed before the download started. BACKUP_TIPS is a
+  // static tip (no placeholder), so show it directly and size the bar from the
+  // known total.
+  const bytes = Number(size) || _ui_._zipsize || 0;
+  const progress = {
     kind : 'progress_bar',
     sys_pn : "progress",
     partHandler: _ui_,
     className: `${pfx}__progress`,
-    label: (size.printf(LOCALE.BACKUP_TIPS)),
-    total:filesize(size),
+    label: LOCALE.BACKUP_TIPS,
+    total:filesize(bytes),
     autoDestroy : _a.no,
     uiHandler:[_ui_],
   };

--- a/src/drumee/builtins/window/downloader/skin/index.scss
+++ b/src/drumee/builtins/window/downloader/skin/index.scss
@@ -81,7 +81,12 @@
     .button {
       border-radius:var(--border-radius);
       @include drumee.typo($size: 16px, $line: 19px, $color: var(--btn-commit-text));//$size: 15px,
-      background-color:var(--btn-commit-background);// var(--egreen-soft);
+      // Was var(--btn-commit-background), which resolves to the invalid token
+      // "-primary-500" (see skin/vars/default.scss) → transparent background +
+      // white text = the two action buttons ("Single file .zip" / "Multiple
+      // files") were invisible until hover. Use the valid brand commit color
+      // (--btn-commit) for the resting state; the darker hover is unchanged.
+      background-color:var(--btn-commit);// var(--egreen-soft);
       cursor: pointer;
       justify-content: center;
       padding : 10px;

--- a/src/drumee/builtins/window/info/skeleton/download-progress.js
+++ b/src/drumee/builtins/window/info/skeleton/download-progress.js
@@ -1,0 +1,61 @@
+const { filesize } = require("@drumee/ui-essentials");
+
+// Simulated (size-scaled) download-progress body for the window_info modal.
+//
+// Why simulated: for large archives (> MAX_BLOB_SIZE, 100 MB) the ZIP is streamed
+// by the BROWSER's own native download (media.zip via getFromUrl), so the app
+// cannot read real byte progress — the browser owns the stream. Per product
+// (Natrix, 2026-07-08) a reassuring bar is enough; the number need not be real.
+// We ease a bar toward ~90% over a size-bucketed duration (pure CSS keyframe,
+// holds at 90% via animation-fill-mode) and tell the user the file is saving in
+// their browser. The real byte-accurate design (stream-to-disk) is preserved in
+// memory (project_dmz_download_progress_2b) if it is ever required.
+//
+// Replaces the plain Wm.alert(DOWNLOAD_LONG_TIME) notice; it is fed to
+// window_info as a `body` (see Wm.downloadNotice in window/manager.js).
+const __window_info_download_progress = function (ui) {
+  const fig = ui.fig.family; // window-info
+  const zipname = ui.mget("zipname") || "";
+  const bytes = Number(ui.mget(_a.filesize)) || 0;
+  const size = filesize(bytes);
+
+  // Size bucket → the fill's ease-out duration (defined in skin). Fake and
+  // approximate on purpose: a bigger archive eases more slowly so the motion
+  // "feels" proportional to what's being downloaded.
+  const GB = 1000 * 1000 * 1000;
+  let bucket = "xs";
+  if (bytes >= 10 * GB) bucket = "lg";
+  else if (bytes >= GB) bucket = "md";
+  else if (bytes >= 100 * 1000 * 1000) bucket = "sm";
+
+  return Skeletons.Box.Y({
+    debug: __filename,
+    className: `${fig}__container ${fig}__dl-progress`,
+    kids: [
+      Skeletons.Note({
+        className: `${fig}__message inner`,
+        // Same string the old alert used (localised in all 6 langs) so nothing
+        // regresses on wording; `<u>{0}</u> for {1}` = name + human size.
+        content: LOCALE.DOWNLOAD_LONG_TIME.format(zipname, size),
+      }),
+
+      Skeletons.Box.X({
+        className: `${fig}__dl-track`,
+        kids: [
+          Skeletons.Box.X({
+            className: `${fig}__dl-fill ${fig}__dl-fill--${bucket}`,
+          }),
+        ],
+      }),
+
+      Skeletons.Note({
+        className: `${fig}__dl-hint`,
+        content:
+          LOCALE.DOWNLOAD_SAVING_IN_BROWSER ||
+          "Your file is saving to your browser’s downloads — you can keep working.",
+      }),
+    ],
+  });
+};
+
+module.exports = __window_info_download_progress;

--- a/src/drumee/builtins/window/info/skin/index.scss
+++ b/src/drumee/builtins/window/info/skin/index.scss
@@ -202,6 +202,51 @@
     cursor: pointer;
     background-color: var(--normal-bg-80) !important;
   }
+
+  // ── Simulated download-progress bar (window_info `body` = download-progress) ──
+  // Scoped to __dl-* only, so standard info dialogs/alerts are untouched.
+  &__dl-progress {
+    width: 100%;
+    gap: 14px;
+    justify-content: flex-start;
+  }
+
+  &__dl-track {
+    width: 100%;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--normal-bg-80, #e6e6ef);
+    overflow: hidden;
+  }
+
+  &__dl-fill {
+    height: 100%;
+    width: 0;
+    border-radius: 999px;
+    background: var(--btn-commit, #18a3ac);
+    // Ease toward ~90% and hold (fill-mode: forwards). Duration is bucketed by
+    // archive size below — approximate/simulated, never a real byte count.
+    animation-name: dl-progress-ease;
+    animation-timing-function: ease-out;
+    animation-fill-mode: forwards;
+    animation-duration: 30s;
+    &--xs { animation-duration: 12s; }
+    &--sm { animation-duration: 30s; }
+    &--md { animation-duration: 90s; }
+    &--lg { animation-duration: 240s; }
+  }
+
+  &__dl-hint {
+    width: 100%;
+    text-align: center;
+    opacity: 0.75;
+    @include drumee.typo($weight: 400, $size: 13px, $line: 18px, $color: var(--normal-fg));
+  }
+}
+
+@keyframes dl-progress-ease {
+  from { width: 0; }
+  to   { width: 90%; }
 }
 
 // ── "notice" variant ────────────────────────────────────────────────────────

--- a/src/drumee/builtins/window/manager.js
+++ b/src/drumee/builtins/window/manager.js
@@ -12,6 +12,7 @@ const mfsInteract = require("./interact");
 const pseudo_media = require("media/pseudo");
 const { xhRequest, dataTransfer } = require("@drumee/ui-essentials");
 const { createQrcode } = require("@drumee/ui-essentials");
+const { filesize } = require("@drumee/ui-essentials");
 const DEFAULT_WIDTH = 800;
 const DEFAULT_HEIGHT = 600;
 
@@ -1357,6 +1358,36 @@ class __window_manager extends mfsInteract {
         resolve(s);
       });
     });
+  }
+
+  /**
+   * Notice shown when a large archive download starts. Large (>100MB) archives
+   * are fetched by the BROWSER's native download (media.zip via getFromUrl), so
+   * the app cannot read real byte progress. Instead of the old plain
+   * DOWNLOAD_LONG_TIME alert, show a window_info modal whose body is a SIMULATED
+   * size-scaled progress bar (see info/skeleton/download-progress + memory
+   * project_dmz_download_progress_2b for the real-progress design). `size` is a
+   * byte count; the body formats it. Falls back to the plain alert so a download
+   * is never left with no notice.
+   */
+  downloadNotice(zipname, size) {
+    const bytes = Number(size) || 0;
+    try {
+      const body = require("builtins/window/info/skeleton/download-progress");
+      Kind.waitFor("window_info").then(() => {
+        this.__wrapperModal.feed({
+          kind: "window_info",
+          mode: "hbf",
+          zipname: zipname || "",
+          // Computed key so it always matches the body's ui.mget(_a.filesize).
+          [_a.filesize]: bytes,
+          body,
+        });
+      });
+    } catch (e) {
+      this.warn && this.warn("downloadNotice failed; using plain alert", e);
+      this.alert(LOCALE.DOWNLOAD_LONG_TIME.format(zipname, filesize(bytes)));
+    }
   }
 
   /**

--- a/src/drumee/seeds.js
+++ b/src/drumee/seeds.js
@@ -543,6 +543,14 @@ module.exports = {
   window_upload_progress: function () {
     return import("./builtins/window/upload-progress");
   },
+  // The progress bar widget lives in ui-core but was never registered as a kind,
+  // so skeletons that use `kind: 'progress_bar'` (the downloader's download
+  // progress, account-data export, server-explorer) rendered the failover
+  // placeholder ("Snippet **progress_bar** was not found") instead of a bar.
+  // Register it so those show a real progress bar.
+  progress_bar: function () {
+    return import("@drumee/ui-core/letc/widgets/progress/bar");
+  },
   window_wallpaper_settings: function () {
     return import("./builtins/window/wallpaper-settings");
   },


### PR DESCRIPTION
## DMZ shared-workspace download fixes (isolated hotfix)

Cherry-picked from `test` onto a `preview`-based branch so it carries **only** these download fixes (no teammate work). Verified end-to-end on drumee.in ("Single file .zip" of a shared workspace downloads all content, with a real progress bar).

### What's fixed (7 commits — the download chooser + "Single file .zip" flow)
- **Buttons visible** — the chooser's "Single file .zip" / "Multiple files" buttons were invisible until hover (invalid `--btn-commit-background` token) → use the valid brand teal.
- **Simulated progress notice (2C)** — replace the plain `DOWNLOAD_LONG_TIME` alert with a size-scaled progress bar in `window_info`; also fixed a latent `getFromUrl` bug (`data.zipname` ReferenceError + missing share token).
- **null zip-size crash** — `skeleton/progress.js` `size.printf(...)` threw on the null wet-run size.
- **progress-widget guards** — guard `this.__progress.*` calls so a missing widget never crashes the download.
- **content-hub routing** — zip against the share's content hub (`Visitor.share_hub_id` / node hub), not the connect host. Falls back to the node's hub on per-vhost links, so this works on preview independently of the neutral-host feature.
- **zip retrieval** — `download_zip` override sends `zipname` (server requires it → was 412) + share token (→ was 403) + content hub.
- **register `progress_bar`** — the ui-core widget was never registered as a kind (→ "Snippet progress_bar was not found"); registered it so a real bar shows (also fixes account-data export & server-explorer).

### ⚠️ Notes
- **Must merge together with server-team hotfix `hotfix/dmz-download`** — the client (zip retrieval) and server (zip staging + branch manifest) fixes are interdependent; either alone leaves the download broken.
- The `check-source` guard will show a red ✗ (head isn't `test`); it's **not a required check**, so merge past it.
- **No schema change.** Merging to `preview` = UAT; PROD needs the manual `target=PROD` dispatch.
- NOT included here (separate work): neutral-host, create-panel, task-assigned. 2B (real byte-accurate progress) was deferred, never built.

Author: EddyOne81.
