### PR TITLE
fix(tasks): keep viewbar-right cluster right-aligned when it wraps

### DIFF
--- a/src/drumee/builtins/window/tasks/skin/index.scss
+++ b/src/drumee/builtins/window/tasks/skin/index.scss
@@ -2530,7 +2530,14 @@
 
   // Right cluster: view-specific controls + New task / New board / Filter.
   &__viewbar-right {
+    // Always hug the right edge. The parent viewbar wraps (flex-wrap:wrap) and
+    // uses justify-content:space-between, so once this cluster drops onto its
+    // own line it would otherwise align LEFT (space-between on a lone item =
+    // start). margin-left:auto pins it right on whichever row it lands, and
+    // flex-end keeps its own buttons right-aligned when the cluster itself wraps.
+    margin-left: auto;
     align-items: center;
+    justify-content: flex-end;
     flex-wrap: wrap;
     gap: 8px;
   }


### PR DESCRIPTION
The viewbar wraps (flex-wrap:wrap) with justify-content:space-between, so when the right cluster (New task / New board / Filter) dropped to a second line it aligned left. Pin it right with margin-left:auto (holds on any row) and justify-content:flex-end so its own buttons stay right-aligned when the cluster wraps internally.