### PR TITLE
feat(folder): validate invite email and show error inline

### DIFF
--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -2833,10 +2833,41 @@ class __window_folder extends mfsInteract {
     this.$el.find(".window__chat-panel").attr("data-chat_gated", gated);
   }
 
+  // Show / clear the inline validation message in the invite-error slot below
+  // the email input. Mirrors b2b-signup's showErrorMessage: toggle the
+  // wrapper's data-state and set the Note content.
+  _setInviteError(reason) {
+    const wrapper = this.getPart && this.getPart("invite-error");
+    const note = this.getPart && this.getPart("invite-error-message");
+    const entry = this.getPart && this.getPart("invite-email");
+    if (wrapper?.el) wrapper.el.dataset.state = reason ? _a.open : _a.closed;
+    if (note?.set) note.set({ content: reason || "" });
+    if (reason) {
+      if (entry?.showError) entry.showError();
+    } else if (entry?.hideError) {
+      entry.hideError();
+    }
+  }
+
   sendFolderInvitation(cmd) {
     const email = this.getInviteEmail(cmd);
     if (!email)
-      return Wm.alert(LOCALE.EMAIL_REQUIRED || LOCALE.ENTER_VALID_EMAIL);
+      return this._setInviteError(
+        LOCALE.EMAIL_REQUIRED || LOCALE.ENTER_VALID_EMAIL,
+      );
+
+    // Reject malformed addresses before hitting the server. Send is a separate
+    // Note button that reads the entry value directly, so the invite Entry
+    // never runs its own checkSanity — validate here. String.prototype.isEmail
+    // (ui-core addons/string.js) is the shared validator used across the app,
+    // same as the signup form gate.
+    if (!email.isEmail())
+      return this._setInviteError(
+        LOCALE.ENTER_VALID_EMAIL || LOCALE.INVALID_EMAIL,
+      );
+
+    // Valid address — drop any stale inline error before sending.
+    this._setInviteError();
 
     const { hub_id } = this.actualNode();
     const privilege = this._folderInviteRole?.privilege || _K.privilege.admin;

--- a/src/drumee/builtins/window/folder/skeleton/settings-action-panel.js
+++ b/src/drumee/builtins/window/folder/skeleton/settings-action-panel.js
@@ -243,6 +243,21 @@ module.exports = function settingsActionPanel(ui) {
               }),
             ],
           }),
+          // Inline validation message rendered directly under the email input.
+          // Hidden (data-state=closed) until sendFolderInvitation opens it with
+          // a reason and clears it on a valid address — see _setInviteError.
+          Skeletons.Box.Y({
+            className: `${pfx}-invite-error`,
+            sys_pn: "invite-error",
+            dataset: { state: _a.closed },
+            kids: [
+              Skeletons.Note({
+                className: `${pfx}-invite-error-message`,
+                sys_pn: "invite-error-message",
+                content: "",
+              }),
+            ],
+          }),
           Skeletons.Note({
             className: `${pfx}-send-button`,
             sys_pn: "invite-send",

--- a/src/drumee/builtins/window/folder/skin/index.scss
+++ b/src/drumee/builtins/window/folder/skin/index.scss
@@ -1479,6 +1479,29 @@
     }
   }
 
+  // Inline email-validation message, directly under the invite input row.
+  // Toggled via data-state (see _setInviteError) so it takes no vertical space
+  // — and adds no section gap — while there is no error to show.
+  &__settings-action-invite-error {
+    &[data-state="closed"] {
+      display: none;
+    }
+
+    &[data-state="open"] {
+      display: flex;
+    }
+  }
+
+  &__settings-action-invite-error-message {
+    @include drumee.typo(
+      $size: 12px,
+      $line: 16px,
+      $weight: 500,
+      $color: var(--red-500)
+    );
+    padding: 0 4px;
+  }
+
   // Wrapper around the KIND.menu.topic root — must be position:relative so
   // the menu items wrapper anchors to the trigger, overflow:visible so the
   // popover can extend outside its row, and z-index high so it stacks above


### PR DESCRIPTION
Gate the folder-settings invite Send action on String.prototype.isEmail (ui-core addons/string.js, the app-wide validator) before hitting the server — the invite Entry never runs its own checkSanity because Send is a separate Note button that reads the value directly.

Surface both the required and invalid-format messages inline below the email input instead of a Wm.alert popup, using the b2b-signup data-state toggle pattern (_setInviteError).