### PR TITLE
Hotfix → Preview: neutral-host share links + create-time Manage-access panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drumee/ui-team",
   "description": "Drumee Web Os User Interface with collaborative features",
-  "version": "3.3.71",
+  "version": "3.3.72",
   "homepage": "https://drumee.com",
   "author": "Somanos Sar <somanos@drumee.com> (http://drumee.com)",
   "repository": {

--- a/patches/@drumee+ui-essentials+1.0.1.patch
+++ b/patches/@drumee+ui-essentials+1.0.1.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/@drumee/ui-essentials/socket/utils.js b/node_modules/@drumee/ui-essentials/socket/utils.js
+index d64d394..9769f5c 100644
+--- a/node_modules/@drumee/ui-essentials/socket/utils.js
++++ b/node_modules/@drumee/ui-essentials/socket/utils.js
+@@ -22,10 +22,20 @@ function defultHeaders() {
+  */
+ function defaultPayload() {
+   if (typeof (Visitor) == 'object') {
+-    return {
++    const payload = {
+       socket_id: Visitor.get(_a.socket_id),
+       device_id: Visitor.deviceId(),
+     };
++    // DMZ neutral-share host: a share opened on the neutral host (share.<domain>)
++    // bootstraps a different hub than the share's CONTENT hub, so requests must
++    // carry the content hub_id or the server resolves the wrong hub (403 on
++    // media.show_node_by etc.). `share_hub_id` is set ONLY while the DMZ sharebox
++    // is mounted and cleared on destroy, so this stays a no-op for desk /
++    // authenticated traffic. An explicit hub_id in call args still wins
++    // (preparePayload spreads the caller args after defaultPayload).
++    const shareHub = Visitor.get('share_hub_id');
++    if (shareHub) payload.hub_id = shareHub;
++    return payload;
+   }
+   return {}
+ }

--- a/src/drumee/builtins/media/form/index.js
+++ b/src/drumee/builtins/media/form/index.js
@@ -77,14 +77,53 @@ class __form_folder extends LetcBox {
         };
         if (!post || !hub) return closeForm();
 
-        const parent = this.parent;
-        if (!parent || !_.isFunction(parent.feed)) return closeForm();
-
         // permission_* dialogs call media.mget(...); wrap the plain
         // server response in a Backbone.View to satisfy that interface.
         const mediaShim = new Backbone.View({
           model: new Backbone.Model(hub),
         });
+
+        // Share workspace: open the SAME "Manage access" panel used INSIDE the
+        // workspace (window_secure_share, secure-share v2) instead of the legacy
+        // external-room panel (permission_shared) — the new panel gives editable
+        // per-link permissions + logged-in-recipient recognition, which the old
+        // one could not. Mirrors folder/index.js openManageAccess(): share the
+        // workspace ROOT node = actual_home_id (a hub's real node id; nid is the
+        // hub/0) with a "Manage access" title. There is no host workspace window
+        // here (the create form lives on the desk), so launch the standalone
+        // right-dock panel — it self-positions via _applyRightDock, matching the
+        // right-side dock the old panel showed. The team/private branch below is
+        // unchanged (permission_restricted is workspace-membership, not sharing).
+        if (post === "permission_shared") {
+          const shareNid = hub.actual_home_id || hub.home_id;
+          Wm.launch(
+            {
+              kind         : "window_secure_share",
+              wm_unique_id : `window_secure_share-${shareNid}`,
+              nid          : shareNid,
+              hub_id       : hub.hub_id || hub.id,
+              home_id      : hub.actual_home_id,
+              filetype     : _a.folder,
+              area         : hub.area || _a.share,
+              filename     : hub.filename,
+              name         : hub.filename,
+              privilege    : ~~hub.privilege,
+              manage_access: 1,
+              useKeyEvent  : 1,
+              radio        : _a.on,
+              state        : _a.on,
+              media        : mediaShim,
+              trigger      : mediaShim,
+              source       : this,
+              uiHandler    : [Wm],
+            },
+            { explicit: 1, singleton: 1 },
+          );
+          return closeForm();
+        }
+
+        const parent = this.parent;
+        if (!parent || !_.isFunction(parent.feed)) return closeForm();
 
         parent.feed({
           kind: post,

--- a/src/drumee/modules/dmz/sharebox/index.js
+++ b/src/drumee/modules/dmz/sharebox/index.js
@@ -48,6 +48,22 @@ class __dmz_sharebox extends LetcBox {
     this._requestEmailInput    = null;
     this._requestMessageInput  = null;
     this._requestSubmit        = null;
+    // Neutral share host: pin the share's CONTENT hub (the login response stores
+    // hub_id on the model) so every DMZ request targets it even when the page was
+    // opened on the neutral host (share.<domain>), whose bootstrap hub differs from
+    // the content hub. Fires on every login path (initial + gated unlock). Read by
+    // the request layer (@drumee/ui-essentials defaultPayload patch) and cleared in
+    // onBeforeDestroy, so desk / authenticated traffic is never affected.
+    this.listenTo(this.model, `change:${_a.hub_id}`, this._pinShareHub);
+  }
+
+  /**
+   * Pin the share's content hub onto Visitor for the request layer. Guarded on a
+   * real hub_id; a no-op otherwise.
+   */
+  _pinShareHub() {
+    const hubId = this.mget(_a.hub_id);
+    if (hubId) Visitor.set({ share_hub_id: hubId });
   }
 
   /**
@@ -56,6 +72,8 @@ class __dmz_sharebox extends LetcBox {
   onBeforeDestroy() {
     this.unbindEvent(_a.live);
     this._stopRevokePolling();
+    // Drop the neutral-host content-hub pin so it can never leak into desk traffic.
+    Visitor.set({ share_hub_id: null });
   }
 
   /**


### PR DESCRIPTION
## Secure-share follow-ups → preview (isolated hotfix)

Cherry-picked from `test` onto a `preview`-based branch so it carries **only** these fixes (no teammate work). Both verified on drumee.in.

### What's included (2 commits)
- **Neutral-host share links** (`a32e940f`) — recipient FE pins the content `hub_id` on DMZ requests + vendored `@drumee/ui-essentials` patch, so share links can be served on a neutral `share.<domain>` host. Verified on test + prod-readiness confirmed (wildcard routing/TLS/default-hub fallback already work on prod — no infra/DB action).
- **Create-time Manage-access panel → secure-share v2** (`04c97009`) — creating a SHARE workspace now auto-opens the secure-share v2 panel instead of the legacy external-room panel. Duy-verified.

### ⚠️ Notes
- **Merge together with server-team hotfix `hotfix/secure-share-neutral-createpanel-chat`** (neutral-host server side + chat-sender). Neutral-host needs both ui + server.
- **No schema change.** Preview merge = UAT; PROD = manual `target=PROD` dispatch.
