### PR TITLE
fix(gdrive): migrate hint says DOCX — Docs no longer exported as PDF

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -481,7 +481,7 @@
   "CALLING": "Call in progress",
   "MISSED_CALL": "Missed call",
   "MIGRATE_GDRIVE_TITLE": "Migrate from Google Drive",
-  "MIGRATE_GDRIVE_HINT": "Imports files and folders from your Google Drive into Drumee. Google Workspace files (Docs, Sheets, Slides) are exported as PDF/XLSX/PPTX.",
+  "MIGRATE_GDRIVE_HINT": "Imports files and folders from your Google Drive into Drumee. Google Workspace files (Docs, Sheets, Slides) are exported as DOCX/XLSX/PPTX.",
   "GDRIVE_PICKER_CHOOSE": "Choose from Google Drive",
   "GDRIVE_PICKER_HINT": "Open a folder and select the files inside — Drumee can only access the files you pick.",
   "GDRIVE_PICKER_UNAVAILABLE": "The Google Drive picker is not available right now. Please try again later.",


### PR DESCRIPTION
Companion to server-team drumee/server-team#88: the importer now exports Google Docs as editable **DOCX** instead of frozen PDF. Updates `MIGRATE_GDRIVE_HINT` copy accordingly (only en.json carries this key; other locales fall back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)