### PR TITLE
fix(trash): overlay-safe realtime reload + Q_RESTORE_TO_HOME locale (follow-up to #284)

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -237,6 +237,7 @@
   "Q_DELETE_ACCOUNT": "Delete account and all data?",
   "Q_DELETE_ALL_FILES": "<p>Do you want to delete </p><p>all files in the trash? </p>",
   "Q_FORGOT_PASSWORD": "Forgot password?",
+  "Q_RESTORE_TO_HOME": "Original folder no longer exists. Restore to home folder instead?",
   "REMOVE": "Remove",
   "RENAME": "Rename",
   "REPLACE": "Replace",

--- a/locale/es.json
+++ b/locale/es.json
@@ -146,6 +146,7 @@
   "PASSWORD_AT_LEAST": "La contraseña debe tener al menos {0} caracteres.",
   "WE_HAVE_SENT_CODE": "Nos enviaremos un código a su dirección {0} para que pueda definir una nueva contraseña.",
   "Q_FORGOT_PASSWORD": "¿Has olvidado tu contraseña?",
+  "Q_RESTORE_TO_HOME": "La carpeta original ya no existe. ¿Restaurar en la carpeta principal?",
   "NEW_PASSWORD": "Nueva contraseña",
   "RESET_PASSWORD": "Restablecer contraseña",
   "UNKNOWN_ERROR": "Error desconocido",

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -253,6 +253,7 @@
   "EXPORT_BACKUP_PREPARING": "Your backup is being prepared. This may take a long time. You will receive an email with a download link when it is ready.",
   "Q_DELETE_ALL_FILES": "<p>Voulez-vous supprimer</p><p> tous les fichiers de la poubelle ?</p>",
   "Q_FORGOT_PASSWORD": "Mot de passe oublié?",
+  "Q_RESTORE_TO_HOME": "Le dossier d'origine n'existe plus. Restaurer dans le dossier personnel ?",
   "REMOVE": "Supprimer",
   "RENAME": "Renommer",
   "REPLACE": "Remplacer",

--- a/locale/km.json
+++ b/locale/km.json
@@ -251,6 +251,7 @@
   "EXPORT_BACKUP_PREPARING": "Your backup is being prepared. This may take a long time. You will receive an email with a download link when it is ready.",
   "Q_DELETE_ALL_FILES": "<p>តើ​អ្នក​ចង់​លុប </p><p>ឯកសារ​ទាំងអស់​ក្នុង​ធុង​សំរាម​ដែរ​ឬ​ទេ? </p>",
   "Q_FORGOT_PASSWORD": "ភ្លេច​លេខសំងាត់​?",
+  "Q_RESTORE_TO_HOME": "ថតដើមលែងមានទៀតហើយ។ ស្ដារទៅថតផ្ទះវិញឬ?",
   "REMOVE": "ដកចេញ",
   "RENAME": "ប្តូរឈ្មោះ",
   "REPLACE": "ជំនួស",

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -253,6 +253,7 @@
   "EXPORT_BACKUP_PREPARING": "Your backup is being prepared. This may take a long time. You will receive an email with a download link when it is ready.",
   "Q_DELETE_ALL_FILES": "<p>Хотите удалить</p><p>все файлы в корзине? </p>",
   "Q_FORGOT_PASSWORD": "Забыли пароль?",
+  "Q_RESTORE_TO_HOME": "Исходная папка больше не существует. Восстановить в домашнюю папку?",
   "REMOVE": "Удалить",
   "RENAME": "Переименовать",
   "REPLACE": "Переместить",

--- a/locale/zh.json
+++ b/locale/zh.json
@@ -253,6 +253,7 @@
   "EXPORT_BACKUP_PREPARING": "Your backup is being prepared. This may take a long time. You will receive an email with a download link when it is ready.",
   "Q_DELETE_ALL_FILES": "<p>是否要删除</p><p>回收站中的所有文件？</p>",
   "Q_FORGOT_PASSWORD": "丢失了密码?",
+  "Q_RESTORE_TO_HOME": "原文件夹已不存在。要恢复到主文件夹吗？",
   "REMOVE": "删除",
   "RENAME": "重命名",
   "REPLACE": "更换",

--- a/src/drumee/builtins/panel/trash/index.js
+++ b/src/drumee/builtins/panel/trash/index.js
@@ -76,6 +76,15 @@ class __panel_trash extends mfsInteract {
 
   _wsRefresh() {
     if (!this.el || this.isDestroyed()) return;
+    // Don't clobber the empty-bin confirm overlay mid-decision — feed()
+    // replaces the whole subtree, overlay included. Flag it and replay once
+    // the overlay closes (cancel handler; confirm re-feeds anyway).
+    const overlay = this.getPart && this.getPart('overlay');
+    if (overlay && overlay.children && overlay.children.length) {
+      this._pendingWsRefresh = true;
+      return;
+    }
+    this._pendingWsRefresh = false;
     this.feed(require('./skeleton')(this));
   }
 
@@ -130,9 +139,10 @@ class __panel_trash extends mfsInteract {
     requestAnimationFrame(() => {
       if (this.el) this.el.dataset.anim = "in";
     });
+    // off() first so a re-render never stacks duplicate subscriptions.
+    RADIO_CLICK.off(_e.click, this._onOutsideClick);
     RADIO_CLICK.on(_e.click, this._onOutsideClick);
-    // Listen to the Wm websocket relay (see handleWsEvent). off() first so a
-    // re-render never stacks a duplicate subscription.
+    // Listen to the Wm websocket relay (see handleWsEvent).
     Wm.off(WS_EVENT, this.handleWsEvent);
     Wm.on(WS_EVENT, this.handleWsEvent);
 
@@ -233,6 +243,9 @@ class __panel_trash extends mfsInteract {
     const overlay = await this.ensurePart('overlay');
     overlay.clear();
     if (data) RADIO_MEDIA.trigger(_a.free, data);
+    // Full re-feed below IS the freshest state — drop any reload held back
+    // while the confirm overlay was open.
+    this._pendingWsRefresh = false;
     this.feed(require('./skeleton')(this));
   }
 
@@ -245,7 +258,12 @@ class __panel_trash extends mfsInteract {
       case 'confirm-empty-bin':
         return this._confirmEmptyBin();
       case 'cancel-empty-bin':
-        this.ensurePart('overlay').then(p => p.clear());
+        this.ensurePart('overlay').then(p => {
+          p.clear();
+          // Replay a websocket reload that was held back while the confirm
+          // overlay was open (see _wsRefresh).
+          if (this._pendingWsRefresh) this._wsRefresh();
+        });
         return;
       case 'delete-permanently':
         return this.deleteFilePermanently(args.media || cmd);

--- a/src/drumee/builtins/panel/trash/index.js
+++ b/src/drumee/builtins/panel/trash/index.js
@@ -187,12 +187,16 @@ class __panel_trash extends mfsInteract {
 
     if (data.parent_missing) {
       // Original parent folder is gone — ask user before falling back to home
+      // No || fallbacks: LOCALE is a createSafeObject — a missing key comes
+      // back as the truthy key STRING, so the fallback branch can never run
+      // (the dialog used to literally display "Q_RESTORE_TO_HOME" because the
+      // key was absent from every locale file).
       const confirmed = await Wm.confirm({
         title: LOCALE.RESTORE,
-        message: LOCALE.Q_RESTORE_TO_HOME || 'Original folder no longer exists. Restore to home folder instead?',
-        confirm: LOCALE.RESTORE || 'Restore',
+        message: LOCALE.Q_RESTORE_TO_HOME,
+        confirm: LOCALE.RESTORE,
         confirm_type: 'primary',
-        cancel: LOCALE.CANCEL || 'Cancel',
+        cancel: LOCALE.CANCEL,
         cancel_type: 'secondary',
         mode: 'hbf',
       }).then(() => true).catch(() => false);
@@ -244,7 +248,10 @@ class __panel_trash extends mfsInteract {
     overlay.clear();
     if (data) RADIO_MEDIA.trigger(_a.free, data);
     // Full re-feed below IS the freshest state — drop any reload held back
-    // while the confirm overlay was open.
+    // while the confirm overlay was open, including a debounce timer still
+    // queued (a WS echo landing <400ms ago would otherwise re-feed AGAIN
+    // right after this one: duplicate show_bin + visible flicker).
+    if (this._wsRefresh.cancel) this._wsRefresh.cancel();
     this._pendingWsRefresh = false;
     this.feed(require('./skeleton')(this));
   }


### PR DESCRIPTION
Follow-up to #284 (merged squash before these landed). Branch rebased onto preview — the previously-shown conflict came from the squash-merge leaving the original commits unmatched; diff is now just the follow-up work.

## 1. Overlay-safe websocket reload (refine)
- `_wsRefresh` no longer clobbers the empty-bin confirm overlay mid-decision — it flags the reload and the cancel handler replays it; confirm re-feeds anyway.
- `_confirmEmptyBin` also **cancels a still-queued debounce timer**: a WS bin echo landing <400ms before the confirm (e.g. another session purging) used to re-feed the panel AGAIN right after the confirm's own re-feed — duplicate `show_bin` request + visible flicker. (Adversarially verified in review.)
- `RADIO_CLICK` subscription is off-first like the Wm relay — re-renders can't stack duplicate outside-click handlers.

## 2. Q_RESTORE_TO_HOME was a raw key on screen (pre-existing, found in review)
`LOCALE.Q_RESTORE_TO_HOME` existed in **no** locale file, and LOCALE is a createSafeObject — a missing key returns the truthy key STRING, so the `|| 'fallback'` was dead code and the restore-confirm dialog literally displayed **"Q_RESTORE_TO_HOME"** in every language. Key added to all six locales (en/fr/es/ru/zh/km); unreachable fallbacks dropped.

Review method: 3-lens adversarial review (lifecycle/leak, race/async, framework invariants) with independent verification; the two findings above were the only confirmed ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)