### PR TITLE
perf(upload): bounded-concurrency uploader (serial → pool of 4)

### DIFF
--- a/src/drumee/builtins/media/uploader/index.js
+++ b/src/drumee/builtins/media/uploader/index.js
@@ -34,6 +34,14 @@ class __media_uploader extends LetcBox {
     this._bytesPending = 0;
     this._filesSent = 0;
     this._pendingCount = 0;
+    /**
+     * Max concurrent uploads. Serial (1) meant 200 files ran one-at-a-time —
+     * each file's full network + server round-trip serialized into 20-30 min.
+     * A small pool overlaps that latency across files. Kept bounded because a
+     * flood of parallel XHRs previously 504'd the gateway; the server-side
+     * file move is now async (non-blocking), so 4 in flight is safe.
+     */
+    this._maxParallel = 4;
   }
 
   /**
@@ -398,14 +406,21 @@ class __media_uploader extends LetcBox {
       clearInterval(this.spoolTimer);
       return;
     }
-    // One in-flight upload per uploader — parallel XHRs were overwhelming
-    // the gateway (504) on multi-file batches.
-    if (this._pendingCount > 0) return;
-    const item = this._queue.shift();
-    if ((item == null)) {
-      return;
+    // Bounded concurrency: keep up to _maxParallel uploads in flight so the
+    // network + server round-trip of separate files overlap instead of
+    // serializing. add() seeds only _queue[0] and parks the rest in _buffer
+    // (spool drains it one-per-200ms), so top the queue up from _buffer here
+    // to keep the pool full between spool ticks.
+    while (this._pendingCount < this._maxParallel) {
+      if (this._queue.length === 0 && this._buffer.length) {
+        this._queue.push(this._buffer.shift());
+      }
+      const item = this._queue.shift();
+      if (item == null) {
+        return;
+      }
+      this._send(item);
     }
-    this._send(item);
   }
 
   /**


### PR DESCRIPTION
## Problem
Uploading ~200 files took **~20-30 minutes**.

## Root cause (confirmed)
The uploader ran **strictly serial** — one XHR in flight at a time. `_run()` bailed out while `_pendingCount > 0`:

```js
// One in-flight upload per uploader — parallel XHRs were overwhelming
// the gateway (504) on multi-file batches.
if (this._pendingCount > 0) return;
```

So each file's full network + server round-trip serialized: 200 × ~6-9s ≈ 20-30 min. The serial gate was a workaround for parallel XHRs 504-ing the gateway — which was really the **server blocking on a synchronous cross-device copy** (fixed in server-team #91).

## Fix
Replace the serial gate with a **bounded pool** (`_maxParallel = 4`): `_run()` keeps up to 4 uploads in flight and tops the queue up from `_buffer` between the 200 ms spool ticks (so the pool never starves — `add()` seeds only `_queue[0]` and parks the rest in `_buffer`). Network + server latency overlap across files.

## Verification
Standalone discrete-event **simulation** of the queue machinery (add → spool → _run → _send → onUploadEnd) across 8 scenarios (1/3/5/6/7/50/200 files, pools of 1/3/4):

```
PASS files=200 max=4  observedConcurrency=4  ticks=256   completed
PASS files=200 max=1  observedConcurrency=1  ticks=1002  completed   (old serial baseline)
PASS files=  6 max=4  observedConcurrency=4  ticks=12    completed
... all 8 PASS
```

- Never exceeds `_maxParallel` in flight.
- Every file sent **exactly once** (no double-send, none dropped).
- Every run completes.
- 200-file run: **256 ticks vs 1002 serial → ~3.9× faster** (≈ 20-30 min → ~5-8 min).

Live end-to-end verification on the vudangnt test endpoint pending (deploy step). Kept the pool conservative (4) because the server-side blocking copy — the original 504 cause — is fixed separately; bump if the gateway comfortably handles more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
