### PR TITLE
fix(webrtc): team-call voice — device change silent-fail (mic permission) + Confirm-button invisible

### DIFF
--- a/src/drumee/builtins/webrtc/room/index.js
+++ b/src/drumee/builtins/webrtc/room/index.js
@@ -325,6 +325,24 @@ class __webrtc_room extends __interact {
       }),
     ];
 
+    // Enumerate only AFTER permission is granted — otherwise the list rows carry
+    // empty deviceIds and every pick silently fails on Save (see
+    // ensureMediaPermission). Surface a clear note when it's denied.
+    if (!(await this.ensureMediaPermission())) {
+      p.feed([
+        Skeletons.Note({
+          className: `device-heading`,
+          content: LOCALE.MICROPHONE,
+        }),
+        Skeletons.Note({
+          className: `device-label`,
+          content: LOCALE.DEVICES_PERMISSION_DENIED,
+        }),
+      ]);
+      p.$el.fadeIn();
+      return;
+    }
+
     if (JitsiMeetJS.mediaDevices.isDeviceChangeAvailable("input")) {
       JitsiMeetJS.mediaDevices.enumerateDevices(async (devices) => {
         console.log(devices);
@@ -449,10 +467,46 @@ class __webrtc_room extends __interact {
    * these concurrently (the old behaviour) raced the Jingle renegotiation and
    * the Jitsi `audioOutputChanged` flag — hence "no audio until the 2nd-3rd try".
    */
+  /**
+   * enumerateDevices() only fills in real deviceId + label once MICROPHONE
+   * permission is granted; before that every row carries an EMPTY deviceId, so
+   * picking a mic/speaker stores "" and Save silently no-ops on BOTH input and
+   * output (the guards below skip a falsy id) — the "can't change voice setting,
+   * no error" bug. Verify the grant is in place: query first, and only fall
+   * back to a short-lived getUserMedia probe (which triggers the prompt and
+   * refreshes the device ids/labels) when it isn't already granted.
+   */
+  async ensureMediaPermission() {
+    try {
+      if (navigator.permissions && navigator.permissions.query) {
+        const st = await navigator.permissions.query({ name: "microphone" });
+        if (st && st.state === "granted") return true;
+        if (st && st.state === "denied") return false;
+      }
+    } catch (e) {
+      // 'microphone' not queryable on this browser — fall through to the probe.
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      // Release the probe stream immediately; the call keeps its own tracks.
+      stream.getTracks().forEach((t) => t.stop());
+      return true;
+    } catch (e) {
+      this.warn("media permission not granted", e);
+      return false;
+    }
+  }
+
   async confirmDeviceSelection() {
     // Close the picker immediately (it only fades the part out; it does NOT
     // reset selected*), then serialize the device changes in the background.
     this.closeInputDevicesList();
+    // Applying the change re-acquires the device (getUserMedia / setSinkId),
+    // which needs permission — verify up front and fail LOUDLY, not silently.
+    if (!(await this.ensureMediaPermission())) {
+      Wm.alert(LOCALE.DEVICES_PERMISSION_DENIED);
+      return;
+    }
     try {
       if (this.selectedInputDevice) {
         await this.recreateLocalTrackOnDeviceChange();
@@ -468,6 +522,10 @@ class __webrtc_room extends __interact {
       }
     } catch (e) {
       this.warn("confirmDeviceSelection failed", e);
+      // Was silently swallowed before — surface it so a failed change isn't
+      // mistaken for "nothing happened".
+      const details = (e && e.message) || `${e}`;
+      Wm.alert(`${LOCALE.DEVICES_PERMISSION_DENIED} (${details})`);
     }
   }
 

--- a/src/drumee/builtins/webrtc/skin/command.scss
+++ b/src/drumee/builtins/webrtc/skin/command.scss
@@ -241,8 +241,16 @@
       }
 
       &.button-confirm {
-        background-color: var(--btn-commit-background);
+        // --btn-commit-background is malformed in skin/vars/default.scss
+        // (`-primary-500` instead of `var(--primary-500)`) so it computes to
+        // transparent — the Confirm button then rendered white-on-white on the
+        // popup and looked blank. Use the intended commit accent directly.
+        background-color: var(--primary-500);
         @include drumee.typo($line: 18px, $size: 13px, $weight: 300, $color: var(--btn-commit-text));
+
+        &:hover {
+          background-color: var(--primary-600);
+        }
       }
     }
 


### PR DESCRIPTION
## Bug (R4)
In a **team call**, changing the microphone or speaker in the device settings and clicking **Save** does nothing — **both** input and output — with **no error popup**.

## Root cause
`navigator.mediaDevices.enumerateDevices()` only returns a real `deviceId` (and label) once **microphone permission** is granted. Before that, every row in the picker carries an **empty `deviceId`**. So picking a device stores `""` into `selectedInputDevice` / `selectedOutputDevice`, and on Save `confirmDeviceSelection` (webrtc/room/index.js) skips both branches:

```js
if (this.selectedInputDevice) { … }   // "" is falsy → skipped
if (this.selectedOutputDevice) { … }  // "" is falsy → skipped
```

→ a silent no-op on both input and output. Matches the report exactly (both fail, no popup).

## Fix (`webrtc/room/index.js`)
- **`ensureMediaPermission()`** — query the `microphone` permission first (a fast no-op when already granted, so the normal path is untouched); only fall back to a short-lived `getUserMedia({audio:true})` probe (which triggers the prompt and refreshes the device ids/labels) when it isn't granted yet.
- **`updateAudioDevicesList()`** — enumerate the device list **only after** permission is granted, so rows carry real `deviceId`s and selections round-trip. Show a clear note when denied.
- **`confirmDeviceSelection()`** — verify permission before applying, and **surface failures with `Wm.alert`** instead of swallowing them, so a failed change is no longer mistaken for "nothing happened".

No behaviour change on the already-granted path (query → granted → proceeds as before); the gate only helps the not-granted case and makes errors visible.

## Verification
- `node --check` clean; `LOCALE.DEVICES_PERMISSION_DENIED` present in all 6 locales; `Wm` already used in this file.
- Live in-call verification pending — the chrome-devtools MCP Chrome is holding a profile lock, so I couldn't drive a real meeting. Low-risk: the granted-permission path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
