### PR TITLE
fix: trash empty-bin layout flicker + upload-popup close/cancel not dismissing

### DIFF
--- a/src/drumee/builtins/panel/trash/index.js
+++ b/src/drumee/builtins/panel/trash/index.js
@@ -21,8 +21,10 @@ class __panel_trash extends mfsInteract {
     this._refreshStorageUsed = _.debounce(this._refreshStorageUsed.bind(this), 3000, { leading: true, trailing: false });
     this._onOutsideClick = this._onOutsideClick.bind(this);
     // Trash/restore/purge echoes can arrive in bursts (multi-select) — one
-    // list reload per burst is enough.
-    this._wsRefresh = _.debounce(this._wsRefresh.bind(this), 400);
+    // list reload per burst is enough. 600ms (was 400) coalesces echoes that
+    // trickle ~half a second apart as the server processes each file, so a
+    // multi-file delete triggers a single reload instead of one per echo.
+    this._wsRefresh = _.debounce(this._wsRefresh.bind(this), 600);
 
   }
 
@@ -76,7 +78,7 @@ class __panel_trash extends mfsInteract {
 
   _wsRefresh() {
     if (!this.el || this.isDestroyed()) return;
-    // Don't clobber the empty-bin confirm overlay mid-decision — feed()
+    // Don't clobber the empty-bin confirm overlay mid-decision — a rebuild
     // replaces the whole subtree, overlay included. Flag it and replay once
     // the overlay closes (cancel handler; confirm re-feeds anyway).
     const overlay = this.getPart && this.getPart('overlay');
@@ -85,7 +87,21 @@ class __panel_trash extends mfsInteract {
       return;
     }
     this._pendingWsRefresh = false;
-    this.feed(require('./skeleton')(this));
+    // Reload the LIST in place instead of re-feeding the whole panel. A full
+    // feed() tore down + rebuilt the topbar/list/footer scaffold on every WS
+    // echo, so deleting several files (each purge/restore echo lands more than
+    // one debounce window apart) blinked the entire layout repeatedly — the
+    // empty-state placeholder flickered out and back on each rebuild. restart()
+    // re-fetches the bin while the panel frame stays put (topbar/footer keep
+    // their DOM nodes); refresh the count once the reload settles.
+    const list = this.getPart && this.getPart(_a.list);
+    if (list && typeof list.restart === 'function') {
+      list.once(_e.eod, () => this._updateItemsCount());
+      list.restart();
+    } else {
+      // List not mounted yet (first render / mid-teardown) — fall back.
+      this.feed(require('./skeleton')(this));
+    }
   }
 
   _refreshStorageUsed() {

--- a/src/drumee/builtins/window/upload-progress/index.js
+++ b/src/drumee/builtins/window/upload-progress/index.js
@@ -1016,6 +1016,11 @@ class __window_upload_progress extends __window_core {
       this._uploading = false;
       this._renderAggregate();
       this._renderProgressList();
+      // Dismiss the popup after cancelling — the X, footer "Close" and
+      // "Cancel all" all route here, and this bundle-mode path used to return
+      // without ever calling goodbye(), so none of them could close the window
+      // (the non-bundle path below already closes via the delayed goodbye).
+      _.delay(() => this.goodbye(), 500);
       return;
     }
     if (this._job && this._job.cancel) this._job.cancel();
@@ -1421,6 +1426,10 @@ class __window_upload_progress extends __window_core {
         if (actionPart.el.dataset) {
           actionPart.el.dataset.service = newService;
         }
+        // Keep the widget model in sync — onUiEvent resolves the service from
+        // the model first, so a DOM-only update left "Close" firing the stale
+        // "cancel-all" service.
+        if (actionPart.mset) actionPart.mset(_a.service, newService);
       }
     } else {
       // If element not ready, just update the part
@@ -1954,6 +1963,10 @@ class __window_upload_progress extends __window_core {
       p.el.className = `${this.fig.family}__close`;
       p.el.setAttribute(_a.service, "close");
       if (p.el.dataset) p.el.dataset.service = "close";
+      // Also flip the widget MODEL — onUiEvent resolves the service from the
+      // model before the DOM attribute, so without this the relabeled "Close"
+      // button still fired the stale "cancel-all" service.
+      if (p.mset) p.mset(_a.service, "close");
     });
     this._maybeArmAutoMinimize();
   }


### PR DESCRIPTION
## Bug
Deleting several files from **Trash** blinks the whole panel repeatedly — most visibly the empty-state placeholder flickering out and back — i.e. the layout flickers multiple times.

## Root cause (confirmed live)
Every trash/restore/purge WebSocket echo runs `_wsRefresh`, which did a **full `feed(require('./skeleton'))`** — tearing down and rebuilding the entire panel scaffold (topbar + list + footer) on each echo. A multi-file delete emits echoes that trickle in **more than one debounce window apart**, so the 400 ms debounce doesn't coalesce them.

Instrumented on the live app (5 simulated purge echoes 500 ms apart):
```
feedCalls: 5   @ [403, 903, 1407, 1903, 2402] ms
placeholder timeline: -P  -P  --  -P  -P  --  -P ...   ← blinks out (--) and back on every echo
```
Each full feed rebuilds the whole panel → the layout blinks once per echo.

## Fix (`panel/trash/index.js`)
- `_wsRefresh` now reloads only the **list** in place (`list.restart()`) and refreshes the count once it settles, instead of re-feeding the whole panel. The panel frame keeps its DOM nodes — verified live: `topbarSameNode: true, footerSameNode: true` after a reload — so the layout no longer blinks. Falls back to a full feed only when the list isn't mounted yet.
- Debounce **400 → 600 ms** so echoes landing ~half a second apart coalesce into a single reload.

## Verification
- `node --check` clean.
- Root cause + fix mechanism both confirmed via live instrumentation (old path blinks the layout 5×; `list.restart()` keeps the topbar/footer nodes stable while re-rendering the empty state correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this branch — fix(upload): progress popup X / Close / Cancel-all don't dismiss (bundle mode)
For a drag-drop (bundle) upload, none of the popup's close controls closed the window. All three route to `cancelAll()`, whose **bundle-mode branch cancelled the jobs then `return`ed without calling `goodbye()`** (only the non-bundle path closed). Compounding it, the footer button is relabeled "Close" on completion by mutating the DOM only, but `onUiEvent` resolves the service from the widget **model** first → the relabeled "Close" fired the stale `"cancel-all"`.
- `cancelAll()` bundle branch now dismisses the popup (delayed `goodbye()`), matching the non-bundle path.
- Sync the widget model service wherever the footer is relabeled (`_refreshFooter` + bundle-complete relabel).

Both fixes: `node --check` clean. Trash fix confirmed live (5 echoes → 5 full feeds blink the layout; `list.restart()` keeps topbar/footer nodes stable). Upload fix root-caused from code.
