### PR TITLE
fix(folder/list-view): restore file-type filter bar + fix edit-pencil visibility & alignment

### DIFF
--- a/src/drumee/builtins/media/row/skin/index.scss
+++ b/src/drumee/builtins/media/row/skin/index.scss
@@ -191,14 +191,20 @@
         margin-right: 10px;
 
         &.icon {
-          fill: white;
+          // Was `fill: white` → invisible on the white row background. Use the
+          // dark default icon/text colour so the edit pencil is visible.
+          fill: var(--default-text-color);
           padding: 5px;
           margin-left: 0px;
-          margin-top: 4px;
+          // The .edit wrapper is already vertically centred in the 32px row; a
+          // 4px top margin here pushed the 24px svg 4px below that centre, so
+          // the pencil sat lower than the filename/date/size columns. Drop it
+          // so the icon lines up with the row content.
+          margin-top: 0;
           cursor: pointer;
 
           &:hover {
-            fill: white;
+            fill: var(--default-icon-hover);
             visibility: visible;
             z-index: 100;
           }

--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -1133,7 +1133,13 @@ class __window_folder extends mfsInteract {
       // swaps the visible glyph. (The old splitBtn used changeState, which only
       // exists on the svg widget — the box needs setState.)
       if (mode === _a.row) {
-        content.feed(require("../skeleton/content/row")(this));
+        // Keep the file-type filter bar (All/Docs/PDF/Images/Other) in list
+        // view too — mirrors the grid branch below and the initial-render
+        // folderFilesRowContainer. content/row adds the column header + list.
+        content.feed([
+          fileTypeFilterBar(this),
+          require("../skeleton/content/row")(this),
+        ]);
         cmd?.setState?.(1);
         return;
       }

--- a/src/drumee/builtins/window/skeleton/toolkit/index.js
+++ b/src/drumee/builtins/window/skeleton/toolkit/index.js
@@ -840,7 +840,13 @@ export function folderFilesRowContainer(ui) {
     className: `${ui.fig.family}__files-panel ${ui.fig.group}__files-panel`,
     sys_pn: _a.content,
     type: _a.type,
-    kids: [require("../content/row")(ui)],
+    // Row/list view must carry the same file-type filter bar (All/Docs/PDF/
+    // Images/Other) as the grid view (see filesContainer) — it was missing in
+    // list mode. The filter is view-agnostic: clicking a tab sets _filterType
+    // and loadContent() re-fetches via getCurrentApi(), which the row list's
+    // `() => ui.getCurrentApi()` api already honors. content/row supplies the
+    // column-title header + list below the bar.
+    kids: [fileTypeFilterBar(ui), require("../content/row")(ui)],
   });
 }
 


### PR DESCRIPTION
## Bugs (files list / row view)
When viewing files in **list (vertical) mode**:
1. **File-type filter missing** — the `All / Docs / PDF / Images / Other` bar that grid view shows was absent in list view.
2. **Edit pencil invisible** — the row rename pencil was `fill: white`, invisible on the light row background.
3. **Edit pencil misaligned** — the pencil sat ~4px below the filename/date/size columns.
4. Column header (Last name / Last change at / Size / Type) — verified it already renders via `content/row`; no regression.

## Root causes
- The row view is built by `folderFilesRowContainer` (initial saved-row render) and `toggleFilesLayout`'s row branch (toggle to list). **Both fed only `content/row`** (header + list), whereas the grid paths feed `[fileTypeFilterBar, gridFilesBrowser]` — so the filter bar only ever existed in grid.
- `media/row/skin`: `.edit.icon { fill: white; margin-top: 4px }` — white glyph on a light row, and the 4px top margin pushed the 24px svg below the already-centred `.edit` wrapper.

## Fix
- Add `fileTypeFilterBar(ui)` above `content/row` in **both** row-view paths. The filter is view-agnostic: `getCurrentApi()` honors `_filterType` and the row list uses `() => ui.getCurrentApi()`, so tabs re-fetch the row listing exactly like the grid.
- `.edit.icon`: `fill: white` → `var(--default-text-color)` (hover `var(--default-icon-hover)`); `margin-top: 4px` → `0` so the pencil centres on the row baseline.

## Verification (live, vudangnt stage)
- List view now renders filter bar `[All, Docs, PDF, Images, Other]` + column header `[Last name, Last change at, Size, Type]`.
- Pencil dark (`fill rgb(47,47,47)`) and cy-aligned: pencil 330 = filename 330 = row 330 (was 252 vs 248).
- `node --check` clean; 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
