### PR TITLE
hotfix(notifications): one chronological list + real folder-tab name

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -463,6 +463,7 @@
   "WANTS_TO_CONNECT": "wants to connect",
   "ACCEPTED_YOUR_INVITATION": "accepted your invitation",
   "TASK_ASSIGNED_ACTION": "assigned you to ",
+  "TASK_MENTION_ACTION": "mentioned you in ",
   "DECLINED_YOUR_INVITATION": "declined your contact invitation",
   "CREATE_SHARED_FOLDER": "Create an external folder",
   "NOTES": "Notes:",

--- a/src/drumee/builtins/panel/activity/index.js
+++ b/src/drumee/builtins/panel/activity/index.js
@@ -874,6 +874,19 @@ class __panel_activity extends LetcBox {
     }
     const list = [];
     for (const it of dedupedItems) {
+      // Everything except pending access-requests is no longer pinned here: the
+      // server now interleaves the rollups (chat/media/teamchat/contact/ticket +
+      // hub-invites + refused) AND the task @-mention / assignment notifications
+      // chronologically into the activity feed (activity.get_feed), so the panel
+      // shows one single time-sorted list (product request). Rendering any of
+      // them in this pinned box too would double-show them. Only a pending
+      // secure-share access request stays pinned (it's actionable — approve/deny
+      // — with a lasting state). Live meeting invites are added separately below
+      // (this._meetingItems). The unread badge is unchanged: refreshActivity
+      // still fetches all of these (activity.list / list_task_assignments /
+      // channel.list_notifications) for the count — this filter only changes what
+      // renders in the pinned section.
+      if (it.category !== 'access_request') continue;
       if (it.category === 'chat' && activeChats.includes(it.drumate_id)) continue;
       const e = { ...it };
       e.kind = 'activity_item';

--- a/src/drumee/builtins/panel/activity/widget/item/index.js
+++ b/src/drumee/builtins/panel/activity/widget/item/index.js
@@ -99,6 +99,7 @@ class __activity_item extends LetcBox {
     const item_type = opt.category
       || (opt.event === 'hub.invite_received' ? 'hub_invite'
         : opt.event === 'task_assigned' ? 'contact_invite'
+        : opt.event === 'task_mention' ? 'contact_invite'
         : 'mfs');
     const item_key = `${item_type}:${opt.id || opt.hub_id || opt.drumate_id || opt.key_id || ''}`;
     this.mset({ category, sender, autho_id, item_type, item_key })

--- a/src/drumee/builtins/panel/activity/widget/item/skeleton/index.js
+++ b/src/drumee/builtins/panel/activity/widget/item/skeleton/index.js
@@ -86,6 +86,21 @@ function getActivityMeta(ui, data) {
     };
   }
 
+  // 2c. Task @-mention ("{author} mentioned you in {task}"). Like task_assigned
+  // it is a contact_activity row (category resolves to 'contact'); without this
+  // branch a feed-sourced task_mention would fall into the contact branch and
+  // wrongly read "wants to connect". The task title is flattened onto the row
+  // server-side as `task_title`.
+  if (data.event === 'task_mention') {
+    return {
+      before: LOCALE.TASK_MENTION_ACTION || 'mentioned you in ',
+      label: data.task_title || name,
+      after: '',
+      colorClass: 'mention',
+      badge: 'mention',
+    };
+  }
+
   switch (ui.mget(_a.category)) {
     case 'hub_invite':
       // Never fall back to `name` for hub_invite — that resolver chains

--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -99,11 +99,24 @@ class desk_module extends LetcBox {
       win: winInstance,
       minimized: !!winInstance.mget(_a.minimize),
     });
+    // A folder opened from a notification (or any deep-link) launches before its
+    // real name is known — the window resolves its title asynchronously
+    // (get_path → change:hub_name/filename → _syncWindowTitle). Re-render the tab
+    // when that lands so it stops showing the generic LOCALE.FOLDER fallback.
+    // listenTo is auto-scoped to this view + released in _onFolderClose.
+    if (winInstance.model) {
+      this.listenTo(
+        winInstance.model,
+        "change:filename change:hub_name change:name",
+        this._renderFolderTabs,
+      );
+    }
     this._renderFolderTabs();
   }
 
   _onFolderClose(event, winInstance) {
     if (!winInstance) return;
+    if (winInstance.model) this.stopListening(winInstance.model);
     if (this._openFolders.delete(winInstance.cid)) {
       this._renderFolderTabs();
     }
@@ -168,9 +181,13 @@ class desk_module extends LetcBox {
 
   _buildFolderTab(winInstance, minimized, pfx) {
     const cn = `${pfx}__folder-tab`;
+    // Mirror the window's own title resolution (_syncWindowTitle uses
+    // filename || hub_name) so an empty-filename workspace root shows its
+    // workspace name here too, instead of the generic LOCALE.FOLDER fallback.
     const name =
       winInstance.mget(_a.filename) ||
       winInstance.mget(_a.name) ||
+      winInstance.mget("hub_name") ||
       LOCALE.FOLDER ||
       "Folder";
     const area = winInstance.mget(_a.area);


### PR DESCRIPTION
Notification hotfix (branched off preview, carries ONLY these changes).

**#1 — one chronological notification list.** Rollups (chat/media/team-chat/ticket + hub-invites + declined) and task @-mention / assignment notifications now interleave chronologically in the activity feed instead of being pinned in a separate box above it. Only pending secure-share access requests + live meeting invites stay pinned. Pairs with the server-team change (get_feed merge) — the smart list's pagination/toggle/empty state are untouched, and the unread badge is unchanged. Adds a task_mention display branch + routes it through contact_activity_dismiss (also fixes a pre-existing 'wants to connect' mislabel for feed-sourced mentions).

**#2 — desk topbar folder-tab shows the real name.** A folder opened from a notification resolves its name asynchronously; the tab was labelled once at open time and stuck on the generic 'Folder' fallback. Re-render the tab when the name resolves + fall back to hub_name. Covers shared/restricted/personal/public.

Verified on drumee.in. No behavior change beyond the above; badge / Mentions+Shares tabs / dismiss / real-time unchanged.