### PR TITLE
fix(webrtc): stop force-unmuting a muted mic when the 2nd participant joins

### DIFF
--- a/src/drumee/builtins/webrtc/room/index.js
+++ b/src/drumee/builtins/webrtc/room/index.js
@@ -294,8 +294,12 @@ class __webrtc_room extends __interact {
    */
   initCommadPanel(args) {
     if (this.__ctrlAudio) {
-      this.__ctrlAudio.el.dataset.muted = 0;
-      this.__ctrlAudio.setState(1);
+      // Reflect the ACTUAL mic state instead of hardcoding unmuted. This runs
+      // once, from the one-shot "online" watchdog, when the call first goes
+      // online — i.e. when the 2nd participant joins. Forcing setState(1)/
+      // muted=0 here flipped an already-muted user's mic back on at that exact
+      // moment (and only then, because the watchdog is guarded to fire once).
+      this.updateMicroState();
       this.__ctrlAudio.mset(_a.service, _a.settings);
       this.__ctrlAudio.el.dataset.disabled = 0;
     }

--- a/src/drumee/builtins/webrtc/room/jitsi.js
+++ b/src/drumee/builtins/webrtc/room/jitsi.js
@@ -561,29 +561,24 @@ class __webrtc_room extends __room {
    * 
    */
   attachLocalEndpoint(track) {
-    // Only the local AUDIO track drives the sound analyzer + mic control.
-    // onStreamReceived calls this for EVERY local track added — including the
-    // desktop track that screen share adds. Without this guard the block below
-    // force-reset the mic control to unmuted, flipping a muted mic back on when
-    // the user started sharing their screen.
+    // Only the local AUDIO track drives the sound analyzer.
     if (track && typeof track.getType === "function" &&
         track.getType() !== _a.audio) {
       return;
     }
     this.getLocalParts().then((parts) => {
-      let { sound, audio } = parts;
+      let { sound } = parts;
       sound.plug(track.stream);
     });
 
-    this.ensurePart("ctrl-audio").then((p) => {
-      if (track.isMuted()) {
-        p.setState(1);
-        p.el.dataset.muted = "0";
-      } else {
-        p.setState(1);
-        p.el.dataset.muted = "0";
-      }
-    });
+    // NOTE: deliberately does NOT set the mic control state here. This runs on
+    // EVERY local TRACK_ADDED — including the renegotiation Jitsi performs when
+    // a second participant joins — and re-deriving mic state from the transient
+    // event track flipped an already-muted mic pill (window-meeting__ctrl-pill
+    // mic) back to unmuted on join. The mic pill and the self-tile mic badge
+    // are owned solely by the initial render + onTrackMuteChange (real
+    // mute/unmute events), which a peer joining does not trigger — so leaving
+    // the state untouched here keeps a muted mic muted when someone joins.
   }
 
 


### PR DESCRIPTION


Root cause: when the 2nd participant's tile is added, participants manager fires stateMachine('online'); that runs a one-shot watchdog (guarded by `if (this.watchdog) return`) which calls initCommadPanel() once — on the first time the call goes online, i.e. the 2nd join, never again (matching "2nd join only, not the 3rd"). initCommadPanel hardcoded the mic control to unmuted (setState(1)/dataset.muted=0), flipping an already-muted user back on.

- initCommadPanel: reflect the ACTUAL mic state via updateMicroState() (the codebase's own, previously-dead helper that reads the live track) instead of hardcoding unmuted; keep the control-enabling (service + disabled=0).
- attachLocalEndpoint: no longer sets mic control state at all — it runs on every local TRACK_ADDED and should only plug the sound analyzer; mic state is owned by render + onTrackMuteChange + initCommadPanel.