### PR TITLE
fix(tasks): instant loading feedback on Project Health links / view switches

### DIFF
--- a/src/drumee/builtins/window/tasks/index.js
+++ b/src/drumee/builtins/window/tasks/index.js
@@ -930,7 +930,10 @@ class __tasks_panel extends LetcBox {
         const v = trigger.mget("viewMode");
         if (v && v !== this._view) {
           this._view = v;
-          this._render();
+          // Deferred: paint the loading veil THIS frame so the click gets
+          // instant feedback (Project Health links / viewbar tabs felt dead
+          // while the synchronous full re-feed built the new view).
+          this._renderDeferred();
         }
         return;
       }
@@ -3617,6 +3620,30 @@ class __tasks_panel extends LetcBox {
     const idx = this._tasks.findIndex((t) => t.id === row.id);
     if (idx === -1) this._tasks.push(normalized);
     else this._tasks[idx] = { ...this._tasks[idx], ...normalized };
+  }
+
+  // Heavy view switches: _render() re-feeds the WHOLE panel synchronously, so
+  // on a big task set the browser paints nothing between the click and the
+  // finished new view — the link feels dead. Flag data-view-loading (the skin
+  // shows a veil + spinner over the current view), let that frame PAINT (double
+  // rAF), then run the full render and clear the flag. The attribute lives on
+  // this.el, which feed() never replaces, so the veil survives until cleared.
+  _renderDeferred() {
+    if (this.isDestroyed && this.isDestroyed()) return;
+    if (this.el) this.el.dataset.viewLoading = 1;
+    const run = () => {
+      if (this.isDestroyed && this.isDestroyed()) return;
+      try {
+        this._render();
+      } finally {
+        if (this.el) this.el.dataset.viewLoading = 0;
+      }
+    };
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => requestAnimationFrame(run));
+    } else {
+      setTimeout(run, 16);
+    }
   }
 
   _render() {

--- a/src/drumee/builtins/window/tasks/skin/index.scss
+++ b/src/drumee/builtins/window/tasks/skin/index.scss
@@ -16,6 +16,37 @@
     visibility: visible;
   }
 
+  // Instant feedback for heavy view switches (Project Health links, viewbar
+  // tabs): data-view-loading is set by _renderDeferred the moment the link is
+  // clicked and painted BEFORE the full skeleton rebuild runs — a translucent
+  // veil + spinner over the outgoing view instead of a dead unresponsive click.
+  &[data-view-loading="1"] {
+    position: relative;
+
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: rgba(255, 255, 255, 0.55);
+      z-index: 60;
+    }
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 28px;
+      height: 28px;
+      margin: -14px 0 0 -14px;
+      border-radius: 50%;
+      border: 3px solid rgba(89, 80, 255, 0.2);
+      border-top-color: var(--primary-40, #5950ff);
+      animation: tasks-panel-view-spin 0.7s linear infinite;
+      z-index: 61;
+    }
+  }
+
   // Purely visual overlay (toggled via opacity/visibility, not display, since
   // a Box.Y is forced display:flex). pointer-events:none in both states so it
   // never intercepts the drag — the panel-root listener catches the drop.
@@ -5422,5 +5453,13 @@ html[data-theme="dark"] .tasks-panel__flatpickr.flatpickr-calendar {
   .tasks-panel__gantt-aside-head,
   .tasks-panel__gantt-arow {
     padding: 0 12px;
+  }
+}
+
+// Spinner for the view-switch loading veil (data-view-loading, see the
+// .tasks-panel block above).
+@keyframes tasks-panel-view-spin {
+  to {
+    transform: rotate(360deg);
   }
 }


### PR DESCRIPTION
## Bug (UX)
Clicking the hyperlinks in the folder's **Project Health** view (health-card "View all …" link tails) feels dead — nothing happens for a long moment, then the new view appears.

## Root cause
Those links (and every viewbar view switch) fire `set-view`, which runs `_render()` — a **synchronous full re-feed of the entire tasks panel**. On a big task set the browser paints nothing between the click and the finished new view, so the click has zero feedback.

## Fix
- `set-view` → new `_renderDeferred()`: flag `data-view-loading` on the panel root (which `feed()` never replaces), let that frame **paint** (double `requestAnimationFrame`), then run the full `_render()` and clear the flag.
- Skin: `[data-view-loading="1"]` shows a translucent veil + primary-40 spinner over the outgoing view (same overlay pattern as the existing drop-overlay); auto-removed when the flag clears.

Result: the click gets **same-frame visual feedback** (veil + spinner), and the heavy rebuild happens behind it — on large task sets the spinner simply stays up for the render's duration.

## Verification (live, Bibi stage)
MutationObserver on the attribute: click → `data-view-loading` `"1"` (painted) → render → `"0"` (~39ms on a small set). `node --check` + standalone sass compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
