### PR TITLE
fix(meeting): shared-folder members' Join actually joins the live room

### DIFF
--- a/src/drumee/builtins/panel/activity/index.js
+++ b/src/drumee/builtins/panel/activity/index.js
@@ -314,16 +314,28 @@ class __panel_activity extends LetcBox {
         if (hub_id && typeof Wm !== 'undefined' && Wm.addWindow) {
           const folderNid = details.nid || details.actual_home_id || room_id;
           try {
-            Wm.addWindow({
-              kind: 'window_folder',
-              hub_id,
-              nid: folderNid,
-              filename: details.filename || details.user_filename || '',
-              area: details.area,
-              activeTab: 'meeting',
-              room_id,
-              room_type,
-            });
+            // Reuse an already-open folder window for this hub and JOIN the
+            // live room on it — addWindow has no dedup, so it used to stack a
+            // duplicate folder window; and only a fresh window's buildContent
+            // honors activeTab:'meeting', so the duplicate was also the only
+            // reason the join fired at all.
+            const open = ((Wm.getItemsByKind && Wm.getItemsByKind('window_folder')) || [])
+              .find((w) => !w.isDestroyed() && w.mget(_a.hub_id) == hub_id);
+            if (open && typeof open._launchMeetingInPanel === 'function') {
+              if (open.raise) open.raise();
+              open._launchMeetingInPanel();
+            } else {
+              Wm.addWindow({
+                kind: 'window_folder',
+                hub_id,
+                nid: folderNid,
+                filename: details.filename || details.user_filename || '',
+                area: details.area,
+                activeTab: 'meeting',
+                room_id,
+                room_type,
+              });
+            }
           } catch (e) { this.warn('join-meeting: addWindow failed', e); }
         }
         const item_key = item && item.mget && item.mget('item_key');

--- a/src/drumee/builtins/widget/chat-item/index.js
+++ b/src/drumee/builtins/widget/chat-item/index.js
@@ -979,19 +979,26 @@ class ___widget_chatItem extends LetcBox {
           this._joiningMeeting = false;
         }, 800);
 
-        // Prefer to switch the tab on the folder window the user is already in.
-        // Walk up to the containing window_folder; if it matches, just switch
-        // to the meeting tab — no Wm.launch, no reload.
+        // Reuse the folder window the user is already in (or any open one for
+        // the same hub) — but actually JOIN the live room. showFolderTab
+        // ("meeting") only renders the schedule calendar, so members of a
+        // shared folder who clicked Join with the folder open got a tab
+        // switch instead of the call — and a dead click once already on the
+        // meeting tab. _launchMeetingInPanel is re-click safe: it raises the
+        // existing call window (with an "already in a call" alert) when one
+        // is open, and debounces via _launchingMeeting.
+        const joinVia = (folder) => {
+          if (folder.raise) folder.raise();
+          if (typeof folder._launchMeetingInPanel === "function") {
+            folder._launchMeetingInPanel();
+          } else if (folder.showFolderTab) {
+            folder.showFolderTab("meeting"); // legacy fallback
+          }
+        };
         const ownFolder =
           this.getParentByKind && this.getParentByKind("window_folder");
-        if (
-          ownFolder &&
-          ownFolder.mget(_a.hub_id) == hub_id &&
-          ownFolder.showFolderTab
-        ) {
-          if (ownFolder.activeTab === "meeting") return;
-          ownFolder.showFolderTab("meeting");
-          if (ownFolder.raise) ownFolder.raise();
+        if (ownFolder && ownFolder.mget(_a.hub_id) == hub_id) {
+          joinVia(ownFolder);
           return;
         }
 
@@ -1001,9 +1008,8 @@ class ___widget_chatItem extends LetcBox {
           (Wm.getItemsByKind && Wm.getItemsByKind("window_folder")) ||
           []
         ).find((w) => !w.isDestroyed() && w.mget(_a.hub_id) == hub_id);
-        if (existing && existing.showFolderTab) {
-          existing.showFolderTab("meeting");
-          if (existing.raise) existing.raise();
+        if (existing) {
+          joinVia(existing);
           return;
         }
 


### PR DESCRIPTION
## Bug
Share folder — one member starts a meeting → other members can't join (clicking Join does nothing).

## Root cause
Members see the "X started a meeting **[Join]**" card in the shared folder's chat panel — i.e. with that folder window **already open**. `chat-item`'s `join-meeting` handler special-cased exactly that situation to a plain `showFolderTab("meeting")`, which only renders the schedule **calendar** — it never launches the call. Worse, once the tab was already `"meeting"` the handler **early-returned**, so every further click was completely dead. Only the no-folder-open path worked (a fresh window's `buildContent` honors `activeTab:"meeting"` and launches).

## Fix
- **chat-item `join-meeting`**: both reuse branches (containing folder + any open folder for the hub) now raise the window and call `_launchMeetingInPanel()` — the real join — instead of a tab switch (`showFolderTab` kept as legacy fallback). Dead-click early-return removed; re-clicks are safe (`_launchMeetingStandalone` raises the existing call window / alerts when already in a call, and debounces).
- **activity panel `join-meeting`**: same reuse-then-join treatment. It used `Wm.addWindow` unconditionally (no dedup) — every click stacked a **duplicate folder window** (that duplicate's `buildContent` being the only reason join fired at all). Now reuses the open folder and joins on it.

## Verification (live, Bibi stage)
- Started a meeting in the shared folder, left it, then invoked the exact reused-folder join call the fixed handlers now make (`_launchMeetingInPanel` on the open folder window) → the meeting window opened and joined the room. The old code never made this call when a folder was open.
- `node --check` clean ×2.
- **Recommend a 2-account pass on review**: A starts the meeting, B (folder open) clicks Join from the chat card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
