### PR TITLE
perf(desk): fix Server-lagging batch — image click-trap, sidebar jank, window overlap, tasks data-loss, sheet-create dead-end

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "webpack-manifest-plugin": "5.0.0"
   },
   "dependencies": {
-    "@drumee/ui-core": "^1.1.46",
+    "@drumee/ui-core": "^1.1.47",
     "@drumee/ui-essentials": "^1.0.2",
     "@drumee/ui-styles": "^1.0.6",
     "@drumee/ui-toolkit": "^0.0.23",

--- a/src/drumee/builtins/media/core.js
+++ b/src/drumee/builtins/media/core.js
@@ -1254,6 +1254,11 @@ class __media_core extends DrumeeMFS {
     }
     this.spinner(state, timeout);
     this._isWaiting = state;
+    // Stamp the latch so interact's click guard can expire it: nothing
+    // guarantees the opener calls wait(0) on failure (e.g. a player that
+    // never finishes loading), and a stuck _isWaiting makes the tile
+    // permanently unopenable until page reload.
+    this._waitingSince = state ? timestamp() : 0;
   }
 
   /**

--- a/src/drumee/builtins/media/interact.js
+++ b/src/drumee/builtins/media/interact.js
@@ -4,6 +4,23 @@ const { timestamp, loadJS, toggleState } = require("@drumee/ui-essentials")
 const Rectangle = require('rectangle-node');
 const OPEN_NODE = "open-node";
 const ECHO_ID = "echoId";
+
+// Vignette cache, shared by every media tile. Each render used to re-XHR its
+// thumbnail blob — and Wm.reload() (every Home click) re-renders EVERY tile,
+// re-downloading all thumbs and re-firing a 404 per missing one. Hits are
+// keyed by the versioned URL, so a content change (new mtime → new URL)
+// naturally misses. Misses are remembered only briefly: thumbs are generated
+// asynchronously after upload, so a 404 must be retried on a later render.
+const VIGNETTE_CACHE_MAX = 600;
+const VIGNETTE_MISS_TTL = 60000;
+const _vignetteCache = new Map();
+function _vignetteRemember(url, entry) {
+  if (_vignetteCache.size >= VIGNETTE_CACHE_MAX) {
+    const first = _vignetteCache.keys().next().value;
+    _vignetteCache.delete(first);
+  }
+  _vignetteCache.set(url, entry);
+}
 require("./skin");
 const media_core = require("./core");
 const { copyToClipboard } = require("@drumee/ui-essentials")
@@ -289,7 +306,14 @@ class __media_interact extends media_core {
     if (service != "tick") {
       let delay = 1000;
       if (this.mget(_a.filetype) === _a.document) delay = 5000;
-      if (this._isWaiting || timestamp() - this._clickTimestap < delay)
+      // The wait-latch expires after 30s: openers are supposed to call
+      // wait(0), but a failed open (player never loads) may not, and a
+      // stale latch would otherwise lock this tile until page reload.
+      const stillWaiting =
+        this._isWaiting &&
+        this._waitingSince &&
+        timestamp() - this._waitingSince < 30000;
+      if (stillWaiting || timestamp() - this._clickTimestap < delay)
         return;
     }
     this._clickTimestap = timestamp();
@@ -444,7 +468,26 @@ class __media_interact extends media_core {
     switch (filetype) {
       case _a.video:
       case _a.image:
-      case _a.vector:
+      case _a.vector: {
+        const showMissing = () => {
+          this.mset(_a.capability, 0);
+          this.content.el.innerHTML = this.innerContent(this);
+          this._setupInteract();
+          this.trigger("content-ready");
+        };
+        const showThumb = (blobUrl) => {
+          this.mset(_a.url, blobUrl);
+          this.content.el.innerHTML = this.innerContent(this, blobUrl);
+          this._setupInteract();
+          this.trigger("content-ready");
+        };
+        const cached = _vignetteCache.get(url);
+        if (cached) {
+          if (cached.blobUrl) return showThumb(cached.blobUrl);
+          if (timestamp() - cached.missedAt < VIGNETTE_MISS_TTL)
+            return showMissing();
+          _vignetteCache.delete(url);
+        }
         this.fetchFile({ url })
           .then(async (blob) => {
             if (!blob) {
@@ -453,10 +496,8 @@ class __media_interact extends media_core {
             }
             switch (blob.error) {
               case 404:
-                this.mset(_a.capability, 0);
-                this.content.el.innerHTML = this.innerContent(this);
-                this._setupInteract();
-                this.trigger("content-ready");
+                _vignetteRemember(url, { missedAt: timestamp() });
+                showMissing();
                 // Missing vignette is common for stale dev data or not-yet-generated thumbs.
                 if (this.verbose) {
                   this.verbose(`Vignette not found ${url}, showing fallback icon`);
@@ -467,10 +508,8 @@ class __media_interact extends media_core {
             }
 
             let u = URL.createObjectURL(blob);
-            this.mset(_a.url, u);
-            this.content.el.innerHTML = this.innerContent(this, u);
-            this._setupInteract();
-            this.trigger("content-ready");
+            _vignetteRemember(url, { blobUrl: u });
+            showThumb(u);
           })
           .catch((e) => {
             this.mset({ filetype: _a.error });
@@ -478,6 +517,7 @@ class __media_interact extends media_core {
             this._setupInteract();
           });
         break;
+      }
       default:
         this.content.el.innerHTML = this.innerContent(this);
         this._setupInteract();

--- a/src/drumee/builtins/player/image/index.js
+++ b/src/drumee/builtins/player/image/index.js
@@ -46,6 +46,7 @@ class __player_image extends __core {
         child.on(_e.loaded, (image) => {
           this.display(image)
         });
+        this._armLoadFailsafe(child);
         break;
       case _a.content:
         /** DO NOT REMOVE */
@@ -123,6 +124,7 @@ class __player_image extends __core {
   */
   onDestroy() {
     RADIO_KBD.off(_e.keyup, this._keyup_bind);
+    this._disarmLoadFailsafe();
   }
 
 
@@ -663,6 +665,14 @@ class __player_image extends __core {
     const naturalH = el.naturalHeight;
     if (!naturalW || !naturalH) return;
 
+    // The image made it: disarm the load failsafe and make the (until now
+    // opacity-0, non-interactive) window real. The base display() does this
+    // for other players; this override must mirror it, otherwise the player
+    // stays an invisible click-trap over the folder grid.
+    this._disarmLoadFailsafe();
+    this.el.dataset.ready = 1;
+    this.el.style.pointerEvents = "";
+
     // Reserve vertical space for the player chrome (topbar + bottom controls).
     const CHROME_H = 132;
     const max_w = window.innerWidth - 100;
@@ -681,8 +691,9 @@ class __player_image extends __core {
       const canvasSide = Math.min(naturalMax, max_w, max_h);
       width = canvasSide;
       height = canvasSide + CHROME_H;
-      left = Math.max(20, (window.innerWidth - width) / 2);
-      top = Math.max(20, (window.innerHeight - height) / 2);
+      const shift = this._stackShift || 0;
+      left = Math.max(20, (window.innerWidth - width) / 2) + shift;
+      top = Math.max(20, (window.innerHeight - height) / 2) + shift;
     }
 
     this.size = { width, height };
@@ -690,10 +701,59 @@ class __player_image extends __core {
     this.anti_overlap(this._pos);
 
     if (this._isPlaying) {
-      TweenMax.to(this.$el, 1.5, { width, height });
+      // Keep `alpha: 1` here too: `_play()` can flip `_isPlaying` before the
+      // first image finishes loading, and this branch used to leave the
+      // window permanently invisible in that race.
+      TweenMax.to(this.$el, 1.5, { width, height, alpha: 1 });
     } else {
       this.$el.css({ width, height, ...this._pos });
       TweenMax.to(this.$el, 0.5, { alpha: 1 });
+    }
+  }
+
+  /**
+   * The window is revealed only by display(), which fires only when the
+   * <img> actually loads — ui-core's image_smart installs no onerror and
+   * its high-quality poll never resolves on a 404. If the preview/slide
+   * asset fails, the player would otherwise stay a permanent invisible
+   * overlay and the source tile would keep its wait-latch. Watch for load
+   * errors (capture phase — error events don't bubble) plus a generous
+   * stall timeout, and tear the player down cleanly via failedToStart()
+   * (suppress + media.wait(0) + network alert).
+   */
+  _armLoadFailsafe(child) {
+    this._disarmLoadFailsafe();
+    const fail = (reason) => {
+      if (this.isDestroyed() || this.el.dataset.ready == 1) return;
+      this.failedToStart(reason);
+    };
+    this._loadErrorHandler = (e) => {
+      const img = e.target;
+      if (!img || img.tagName !== "IMG") return;
+      // Only fatal while nothing has been displayed yet.
+      if (this.el.dataset.ready != 1) fail(`image failed to load: ${img.src}`);
+    };
+    this._loadErrorTarget = child.el;
+    child.el.addEventListener(_e.error, this._loadErrorHandler, true);
+    this._loadWatchdog = setTimeout(() => fail("image load stalled"), 30000);
+  }
+
+  /**
+   *
+   */
+  _disarmLoadFailsafe() {
+    if (this._loadWatchdog) {
+      clearTimeout(this._loadWatchdog);
+      this._loadWatchdog = null;
+    }
+    if (this._loadErrorTarget && this._loadErrorHandler) {
+      this._loadErrorTarget.removeEventListener(
+        _e.error,
+        this._loadErrorHandler,
+        true
+      );
+      this._loadErrorTarget = null;
+      this._loadErrorHandler = null;
     }
   }
 

--- a/src/drumee/builtins/player/image/index.js
+++ b/src/drumee/builtins/player/image/index.js
@@ -15,6 +15,12 @@ class __player_image extends __core {
   initialize(opt) {
     super.initialize(opt);
     this.style.set(_K.imagePlayer);
+    // While invisible (opacity:0 until display() reveals it) the player
+    // must not hit-test: a stuck hidden player parked over the folder grid
+    // swallows every click on the tiles beneath it. Scoped to the image
+    // player — its display() and load-failsafe are the only reveal paths;
+    // other players (e.g. props_viewer) reveal without calling display().
+    this.style.set({ pointerEvents: "none" });
     this.contentKind = "image_smart";
     const { url } = this.actualNode();
     this._play = this._play.bind(this);
@@ -37,7 +43,10 @@ class __player_image extends __core {
  * @param {*} pn 
  */
   onPartReady(child, pn) {
-    this.raise();
+    // Raise only while the window is being brought up — a late async
+    // re-feed (rotate, WS refresh) must not steal the top spot from
+    // whatever window the user is focused on.
+    if (!this._raisedOnDisplay) this.raise();
     switch (pn) {
       case "slider-content":
         if (child._loaded) {
@@ -735,7 +744,25 @@ class __player_image extends __core {
     };
     this._loadErrorTarget = child.el;
     child.el.addEventListener(_e.error, this._loadErrorHandler, true);
-    this._loadWatchdog = setTimeout(() => fail("image load stalled"), 30000);
+    // Stall watchdog: only kill genuinely dead loads. An image whose bytes
+    // already arrived (naturalWidth > 0) but whose 'loaded' signal was
+    // missed (image_smart's 200ms poll race) gets revealed instead of
+    // killed; an <img> still transferring on a slow network gets one more
+    // grace period instead of a misleading network-error teardown.
+    const onWatchdog = (attempt) => {
+      if (this.isDestroyed() || this.el.dataset.ready == 1) return;
+      const el = child.el;
+      if (el && el.naturalWidth > 0) {
+        this.display(child);
+        return;
+      }
+      if (el && !el.complete && attempt < 2) {
+        this._loadWatchdog = setTimeout(() => onWatchdog(attempt + 1), 30000);
+        return;
+      }
+      fail("image load stalled");
+    };
+    this._loadWatchdog = setTimeout(() => onWatchdog(1), 30000);
   }
 
   /**

--- a/src/drumee/builtins/player/interact.js
+++ b/src/drumee/builtins/player/interact.js
@@ -45,6 +45,19 @@ class __window_interact_player extends __utils {
       top: 0,
     };
     this._lastX = 0;
+    // Deterministic cascade: every player centers on the same workspace
+    // point, and the legacy anti-overlap layers never move them apart
+    // (the `_lastX` term is never incremented and `anti_overlap` only
+    // matches exact positions). Step each new player down-right like OS
+    // windows so simultaneous opens stay individually reachable.
+    try {
+      const siblings = Wm.getWindowsPool().children.filter(
+        (w) => w.isPlayer && !w.isDestroyed()
+      ).length;
+      this._stackShift = (siblings % 8) * 28;
+    } catch (e) {
+      this._stackShift = 0;
+    }
     this.model.set({
       radio: Env.get("wm-radio"),
     });
@@ -75,6 +88,10 @@ class __window_interact_player extends __utils {
       height,
       position: _a.absolute,
       opacity: 0,
+      // While invisible (until display() reveals it) the player must not
+      // hit-test: a stuck opacity-0 player parked over the folder grid
+      // swallows every click on the tiles beneath it.
+      pointerEvents: "none",
       transformOrigin: `-${this.offset.left}px -${this.offset.top}px`,
     });
 
@@ -614,9 +631,17 @@ class __window_interact_player extends __utils {
    * @param {*} from 
    */
   display(size, cb, from = { scale: 0.15, opacity: 0 }) {
-    this.raise();
+    // Raise once when the player first becomes visible. Re-raising from
+    // every async load callback lets the last-LOADED window steal the top
+    // spot, scrambling z-order by network timing when several files are
+    // opened in a row.
+    if (!this._raisedOnDisplay) {
+      this._raisedOnDisplay = 1;
+      this.raise();
+    }
     let o = require("window/configs/default")();
     this.el.dataset.ready = 1;
+    this.el.style.pointerEvents = "";
     if (this._isPlaying) this.size = this.max_size();
     this.size = this.size || o.imagePlayer;
     size = size || o.imagePlayer;
@@ -650,8 +675,8 @@ class __window_interact_player extends __utils {
     // container offset conversion is needed.
     const ws_width = Wm.$el ? Wm.$el.width() : window.innerWidth;
     const ws_height = Wm.$el ? Wm.$el.height() : window.innerHeight;
-    let x = (ws_width - s.width) / 2 + this._lastX;
-    let y = (ws_height - height) / 2;
+    let x = (ws_width - s.width) / 2 + (this._stackShift || 0);
+    let y = (ws_height - height) / 2 + (this._stackShift || 0);
     let pos = {};
     let pin = this.mget("pin") || {};
     if (Visitor.isMobile()) {

--- a/src/drumee/builtins/player/interact.js
+++ b/src/drumee/builtins/player/interact.js
@@ -88,10 +88,6 @@ class __window_interact_player extends __utils {
       height,
       position: _a.absolute,
       opacity: 0,
-      // While invisible (until display() reveals it) the player must not
-      // hit-test: a stuck opacity-0 player parked over the folder grid
-      // swallows every click on the tiles beneath it.
-      pointerEvents: "none",
       transformOrigin: `-${this.offset.left}px -${this.offset.top}px`,
     });
 

--- a/src/drumee/builtins/window/core.js
+++ b/src/drumee/builtins/window/core.js
@@ -749,8 +749,10 @@ class __window_core extends __utils {
 
     // Immediate feedback: the add-menu closes on click and, until the tile
     // used to land via the media.new WS broadcast, nothing at all rendered —
-    // on a slow round-trip the flow looked dead for many seconds.
-    aw.spinner(1, 20000);
+    // on a slow round-trip the flow looked dead for many seconds. NB: no
+    // timeout arg — spinner(state, timeout) DELAYS the spinner by timeout
+    // instead of auto-clearing it; the resolve/reject paths below clear it.
+    aw.spinner(1);
     this.postService(service, { nid, hub_id, name })
       .then((data) => {
         aw.spinner(0);
@@ -761,13 +763,28 @@ class __window_core extends __utils {
         // Open the editor straight from the response (like the DMZ
         // file-share branch) instead of gating it behind the media.new
         // broadcast + a 500ms poll: a delayed or dropped broadcast used to
-        // dead-end the whole flow silently after 30s.
-        const openDirect = () =>
-          Wm.fetchMediaAttributes({
-            nid: data.nid,
-            hub_id: data.hub_id || hub_id,
-            mode: _a.edit,
-          });
+        // dead-end the whole flow silently after 30s. Build a detached
+        // media widget from node_info and run it through openContent — the
+        // same route a tile takes — so the app kind resolves from filetype
+        // (fetchMediaAttributes/launch would need a `kind` we don't have).
+        const openDirect = async () => {
+          try {
+            const r = await this.fetchService(
+              {
+                service: SERVICE.media.node_info,
+                nid: data.nid,
+                hub_id: data.hub_id || hub_id,
+              },
+              { async: 1 },
+            );
+            if (!r || !r.nid) return;
+            const k = await Kind.waitFor(_a.media);
+            const media = new k({ model: new Backbone.Model(r) });
+            this.openContent(media, { service: "open-node", mode: _a.edit });
+          } catch (e) {
+            this.warn("newDocument: direct open failed", e);
+          }
+        };
         // Prefer the grid tile when the broadcast already delivered it —
         // opening through the tile keeps its state wiring (seen/spinner).
         const opened = { done: 0 };

--- a/src/drumee/builtins/window/core.js
+++ b/src/drumee/builtins/window/core.js
@@ -747,22 +747,59 @@ class __window_core extends __utils {
     const { nid, hub_id } = aw.getCurrentApi();
     const name = cmd && cmd.mget && cmd.mget(_a.name);
 
+    // Immediate feedback: the add-menu closes on click and, until the tile
+    // used to land via the media.new WS broadcast, nothing at all rendered —
+    // on a slow round-trip the flow looked dead for many seconds.
+    aw.spinner(1, 20000);
     this.postService(service, { nid, hub_id, name })
       .then((data) => {
-        if (!data || !data.nid) return;
-        const timer = setInterval(() => {
+        aw.spinner(0);
+        if (!data || !data.nid) {
+          Wm.alert(LOCALE.ERROR_NETWORK);
+          return;
+        }
+        // Open the editor straight from the response (like the DMZ
+        // file-share branch) instead of gating it behind the media.new
+        // broadcast + a 500ms poll: a delayed or dropped broadcast used to
+        // dead-end the whole flow silently after 30s.
+        const openDirect = () =>
+          Wm.fetchMediaAttributes({
+            nid: data.nid,
+            hub_id: data.hub_id || hub_id,
+            mode: _a.edit,
+          });
+        // Prefer the grid tile when the broadcast already delivered it —
+        // opening through the tile keeps its state wiring (seen/spinner).
+        const opened = { done: 0 };
+        const openFromTile = () => {
           for (let media of aw.getItemsByAttr(_a.nid, data.nid)) {
             if (/^media/.test(media.mget(_a.kind))) {
-              clearInterval(timer);
+              opened.done = 1;
               media.wait(1);
               this.openContent(media, { service: "open-node", mode: _a.edit });
+              return true;
             }
           }
+          return false;
+        };
+        if (openFromTile()) return;
+        const timer = setInterval(() => {
+          if (openFromTile()) clearInterval(timer);
         }, 500);
-        setTimeout(() => clearInterval(timer), 30000);
+        // The tile normally lands within a couple of WS round-trips; if it
+        // hasn't after 4s, stop waiting and open from the response directly.
+        setTimeout(() => {
+          clearInterval(timer);
+          if (!opened.done) {
+            opened.done = 1;
+            openDirect();
+          }
+        }, 4000);
       })
       .catch((e) => {
+        aw.spinner(0);
         this.warn("newDocument: server error", e);
+        Wm.alert(LOCALE.ERROR_NETWORK);
         if (this.onServerError) this.onServerError(e);
       });
   }

--- a/src/drumee/builtins/window/selection/index.js
+++ b/src/drumee/builtins/window/selection/index.js
@@ -9,9 +9,10 @@ class desk_selection extends Rectangle {
     this.enable = this.enable.bind(this);
     this.disable = this.disable.bind(this);
     this.onDomRefresh = this.onDomRefresh.bind(this);
-    this._pointerdown = this._pointerdown.bind(this);
-    this._pointermove = this._pointermove.bind(this);
-    this._pointerup = this._pointerup.bind(this);
+    // NB: the pointer handlers are bound in initialize(), NOT here —
+    // Backbone runs initialize() inside super() BEFORE this constructor
+    // body, so bindings made here would come too late for the .on()
+    // registrations (and a second bind would break off() matching again).
   }
 
   /**
@@ -20,9 +21,14 @@ class desk_selection extends Rectangle {
    */
   initialize(opt) {
     super.initialize(opt);
-    // Use the constructor-bound refs (see constructor) — a fresh `.bind()`
-    // here would create a wrapper off() can never match, permanently
-    // leaking 3 global pointer listeners on every Wm.reload() cycle.
+    // Bind ONCE onto the instance, then register the same refs — inline
+    // `.bind()` calls in on()/off() create wrappers Backbone's off() can
+    // never match, permanently leaking 3 global pointer listeners on every
+    // Wm.reload() cycle. (Binding must happen HERE: initialize runs inside
+    // super() before the constructor body.)
+    this._pointermove = this._pointermove.bind(this);
+    this._pointerdown = this._pointerdown.bind(this);
+    this._pointerup = this._pointerup.bind(this);
     RADIO_POINTER.on(_e.pointermove, this._pointermove);
     RADIO_POINTER.on(_e.pointerdown, this._pointerdown);
     RADIO_POINTER.on(_e.pointerup, this._pointerup);

--- a/src/drumee/builtins/window/selection/index.js
+++ b/src/drumee/builtins/window/selection/index.js
@@ -20,9 +20,12 @@ class desk_selection extends Rectangle {
    */
   initialize(opt) {
     super.initialize(opt);
-    RADIO_POINTER.on(_e.pointermove, this._pointermove.bind(this));
-    RADIO_POINTER.on(_e.pointerdown, this._pointerdown.bind(this));
-    RADIO_POINTER.on(_e.pointerup, this._pointerup.bind(this));
+    // Use the constructor-bound refs (see constructor) — a fresh `.bind()`
+    // here would create a wrapper off() can never match, permanently
+    // leaking 3 global pointer listeners on every Wm.reload() cycle.
+    RADIO_POINTER.on(_e.pointermove, this._pointermove);
+    RADIO_POINTER.on(_e.pointerdown, this._pointerdown);
+    RADIO_POINTER.on(_e.pointerup, this._pointerup);
 
     this.enable();
     window.Selector = this;
@@ -53,9 +56,9 @@ class desk_selection extends Rectangle {
    * 
    */
   onDestroy() {
-    RADIO_POINTER.off(_e.pointermove, this._pointermove.bind(this));
-    RADIO_POINTER.off(_e.pointerdown, this._pointerdown.bind(this));
-    RADIO_POINTER.off(_e.pointerup, this._pointerup.bind(this));
+    RADIO_POINTER.off(_e.pointermove, this._pointermove);
+    RADIO_POINTER.off(_e.pointerdown, this._pointerdown);
+    RADIO_POINTER.off(_e.pointerup, this._pointerup);
   }
 
   /**

--- a/src/drumee/builtins/window/tasks/index.js
+++ b/src/drumee/builtins/window/tasks/index.js
@@ -188,7 +188,11 @@ class __tasks_panel extends LetcBox {
     if (
       this._scopeNid === nextScope &&
       this._scopeIsRoot === nextRoot &&
-      this._destNid === nextDest
+      this._destNid === nextDest &&
+      // Same scope but the last list fetch failed silently: without this
+      // bypass, reopening the Tasks tab (which re-calls setScope with
+      // identical args) would latch the empty board until page reload.
+      !this._loadFailed
     ) {
       return;
     }
@@ -1308,9 +1312,21 @@ class __tasks_panel extends LetcBox {
         nid: this._scopeNid,
         include_unscoped: this._scopeIsRoot,
       });
-      this._tasks = (Array.isArray(rows) ? rows : []).map(this._normalizeTask);
+      // fetchService never rejects (doRequest swallows every failure via
+      // onServerComplain and resolves undefined / the raw error payload), so
+      // a non-array IS the error path. Don't blank an already-loaded board
+      // over a transient failure — keep the previous rows and flag the load
+      // so the next tab visit retries instead of latching empty.
+      if (Array.isArray(rows)) {
+        this._tasks = rows.map(this._normalizeTask);
+        this._loadFailed = 0;
+      } else {
+        this._loadFailed = 1;
+        if (!Array.isArray(this._tasks)) this._tasks = [];
+      }
     } catch (err) {
-      this._tasks = [];
+      this._loadFailed = 1;
+      if (!Array.isArray(this._tasks)) this._tasks = [];
     }
   }
 
@@ -1725,16 +1741,21 @@ class __tasks_panel extends LetcBox {
           ),
           ...pendingFiles.map(linkPending),
         ]);
+        // Tear down the form only after a successful create — postService
+        // resolves undefined (or an error payload with no id) on failure, so
+        // the teardown must live INSIDE this success branch or a failed
+        // create silently closes the modal and discards the user's draft.
+        this._creating = false;
+        this._createDefaults = null;
+        this._pickerOpen = null;
+        this._resetFileSearch();
+        await this._loadTasks();
+      } else {
+        Wm.alert(LOCALE.ERROR_NETWORK);
       }
-      // Tear down the form only after a successful create — failures keep
-      // the modal open with the user's input intact.
-      this._creating = false;
-      this._createDefaults = null;
-      this._pickerOpen = null;
-      this._resetFileSearch();
-      await this._loadTasks();
     } catch (err) {
       console.error("[tasks_panel] task.create failed:", err);
+      Wm.alert(LOCALE.ERROR_NETWORK);
     }
     this._setSubmitting(".tasks-panel__create-submit", false);
     this._render();
@@ -1749,7 +1770,12 @@ class __tasks_panel extends LetcBox {
         hub_id: this._hubId,
         id,
       });
-      if (!resp || (resp.affected !== 1 && resp.id !== id)) return;
+      if (!resp || (resp.affected !== 1 && resp.id !== id)) {
+        // postService resolves falsy/error-payload on failure (it never
+        // rejects) — surface it instead of silently ignoring the delete.
+        Wm.alert(LOCALE.ERROR_NETWORK);
+        return;
+      }
       this._tasks = this._tasks.filter((t) => t.id !== id);
       if (this._detailId === id) {
         this._detailId = null;
@@ -1779,7 +1805,15 @@ class __tasks_panel extends LetcBox {
         id,
         status: next,
       });
-      this._mergeTask(Array.isArray(updated) ? updated[0] : updated);
+      const row = Array.isArray(updated) ? updated[0] : updated;
+      if (row && row.id) {
+        this._mergeTask(row);
+      } else {
+        // Failed silently (postService never rejects): revert the
+        // optimistic flip instead of leaving unsaved state on screen.
+        task.status = originalStatus;
+        this._render();
+      }
     } catch (err) {
       console.error("[tasks_panel] toggle-complete failed:", err);
       task.status = originalStatus;

--- a/src/drumee/builtins/window/tasks/index.js
+++ b/src/drumee/builtins/window/tasks/index.js
@@ -185,28 +185,34 @@ class __tasks_panel extends LetcBox {
     const nextScope = scopeNid != null ? scopeNid : null;
     const nextRoot = isRoot ? 1 : 0;
     const nextDest = destNid != null ? destNid : this._destNid;
-    if (
+    const sameScope =
       this._scopeNid === nextScope &&
       this._scopeIsRoot === nextRoot &&
-      this._destNid === nextDest &&
-      // Same scope but the last list fetch failed silently: without this
-      // bypass, reopening the Tasks tab (which re-calls setScope with
-      // identical args) would latch the empty board until page reload.
-      !this._loadFailed
-    ) {
+      this._destNid === nextDest;
+    // Same scope and the last fetch succeeded: nothing to do. When the last
+    // list fetch failed silently, fall through to refetch — otherwise
+    // reopening the Tasks tab (which re-calls setScope with identical args)
+    // would latch the empty board until page reload.
+    if (sameScope && !this._loadFailed) {
       return;
     }
     this._scopeNid = nextScope;
     this._scopeIsRoot = nextRoot;
     this._destNid = nextDest;
-    // The create/detail popups and any pending file search belong to the
-    // folder we just left — close them so nothing commits into the new scope.
-    this._creating = false;
-    this._createDefaults = null;
-    this._detailId = null;
-    this._detailDraft = null;
-    this._pickerOpen = null;
-    if (typeof this._resetFileSearch === "function") this._resetFileSearch();
+    if (!sameScope) {
+      // The create/detail popups, pending file search AND the loaded rows
+      // belong to the folder we just left — close/drop them so nothing
+      // commits into (or renders on) the new scope. On a failed-load RETRY
+      // of the SAME scope, keep all of it: wiping here would discard the
+      // user's open draft just because the board needed a refetch.
+      this._creating = false;
+      this._createDefaults = null;
+      this._detailId = null;
+      this._detailDraft = null;
+      this._pickerOpen = null;
+      this._tasks = [];
+      if (typeof this._resetFileSearch === "function") this._resetFileSearch();
+    }
     if (!this.el) return; // not mounted yet — onDomRefresh loads fresh
     Promise.all([this._loadTasks(), this._loadColumns()]).then(() =>
       this._render(),

--- a/src/drumee/modules/desk/skin/sidebar.scss
+++ b/src/drumee/modules/desk/skin/sidebar.scss
@@ -19,15 +19,26 @@ $rail-collapse-allowed: "(pointer: fine), (max-width: 767px), (min-width: 1025px
 // tablet band (768–1024px) — see both @include sites below. Uses literal
 // class selectors (no `&`) so it can be included from any nesting context.
 @mixin sidebar-mini-icons {
-  // !important is required: __item-text and __badge carry
-  // `display: flex !important` in their base rules, which a plain
-  // `display: none` can't override.
+  // Labels and sections FADE out instead of display:none-flipping. Two
+  // reasons (both were user-visible jank): a display flip forces a large
+  // synchronous style+layout pass on the hover-boundary frame and makes
+  // the text POP in/out, and — combined with the width transition — every
+  // label used to reflow on each animation frame. Keeping the elements in
+  // flow at their expanded metrics (the rail scope pins __nav/__footer at
+  // 231px) means the width animation only clips: icons never jump, text
+  // never reflows, and opacity/visibility are animatable.
+  // !important mirrors the old rules: some of these carry
+  // `display: flex !important` bases that historically fought overrides.
   .desk-module-sidebar__item-text,
   .desk-module-sidebar__header,
   .desk-module-sidebar__workspace,
   .desk-module-sidebar__footer-name-wrapper,
   .desk-module-sidebar__footer-user-plan,
-  .desk-module-sidebar__logo-pin-btn,
+  .desk-module-sidebar__logo-pin-btn {
+    visibility: hidden !important;
+    opacity: 0 !important;
+  }
+
   .desk-module-sidebar__logo-icon {
     display: none !important;
   }
@@ -36,23 +47,14 @@ $rail-collapse-allowed: "(pointer: fine), (max-width: 767px), (min-width: 1025px
     display: flex;
   }
 
-  .desk-module-sidebar__logo-row {
-    justify-content: center;
-    padding: 0;
-  }
-
-  .desk-module-sidebar__item {
-    justify-content: center;
-    gap: 0;
-    padding-left: 0;
-    padding-right: 0;
-  }
-
-  // Notification count shrinks to a dot anchored on the icon.
+  // Notification count shrinks to a dot anchored on the icon (anchor from
+  // the LEFT — the row is 231px wide and clipped to 64px, so a right-based
+  // offset would put the dot outside the visible strip).
   .desk-module-sidebar__badge {
     position: absolute;
     top: 4px;
-    right: 16px;
+    left: 40px;
+    right: auto;
     min-width: 9px;
     width: 9px;
     height: 9px;
@@ -61,12 +63,6 @@ $rail-collapse-allowed: "(pointer: fine), (max-width: 767px), (min-width: 1025px
     font-size: 0;
     line-height: 0;
     margin-left: 0;
-  }
-
-  .desk-module-sidebar__footer-user-btn {
-    justify-content: center;
-    padding-left: 0;
-    padding-right: 0;
   }
 }
 
@@ -146,6 +142,31 @@ $rail-collapse-allowed: "(pointer: fine), (max-width: 767px), (min-width: 1025px
     height: auto;
     width: 231px;
     transition: width 0.18s ease;
+
+    // Pin the content columns at the EXPANDED width. The hover animation
+    // then only moves __main's clipping edge (overflow: hidden above) —
+    // without this, every label in the nav + workspace list + footer
+    // re-wraps on each of the ~11 width-transition frames, which is the
+    // main-thread cost behind the reported hover stutter.
+    .desk-module-sidebar__nav,
+    .desk-module-sidebar__footer {
+      width: 231px;
+      min-width: 231px;
+      box-sizing: border-box;
+      flex-shrink: 0;
+    }
+
+    // Fade metrics for the mini-mode labels (see sidebar-mini-icons):
+    // visibility participates in the transition so hidden labels are
+    // also removed from hit-testing once the fade completes.
+    .desk-module-sidebar__item-text,
+    .desk-module-sidebar__header,
+    .desk-module-sidebar__workspace,
+    .desk-module-sidebar__footer-name-wrapper,
+    .desk-module-sidebar__footer-user-plan,
+    .desk-module-sidebar__logo-pin-btn {
+      transition: opacity 0.15s ease, visibility 0.15s;
+    }
   }
 
   &__rail[data-collapsed="1"] &__main {

--- a/src/drumee/modules/desk/skin/sidebar.scss
+++ b/src/drumee/modules/desk/skin/sidebar.scss
@@ -148,12 +148,14 @@ $rail-collapse-allowed: "(pointer: fine), (max-width: 767px), (min-width: 1025px
     // without this, every label in the nav + workspace list + footer
     // re-wraps on each of the ~11 width-transition frames, which is the
     // main-thread cost behind the reported hover stutter.
+    // Width only — no flex properties: __main is a COLUMN, so a
+    // flex-shrink here would act on the vertical axis and stop the nav
+    // from yielding height to the footer on short viewports.
     .desk-module-sidebar__nav,
     .desk-module-sidebar__footer {
       width: 231px;
       min-width: 231px;
       box-sizing: border-box;
-      flex-shrink: 0;
     }
 
     // Fade metrics for the mini-mode labels (see sidebar-mini-icons):
@@ -389,6 +391,10 @@ $rail-collapse-allowed: "(pointer: fine), (max-width: 767px), (min-width: 1025px
     width: 100%;
     padding: 0 24px;
     box-sizing: border-box;
+    // The mini rail swaps the 20px wordmark for the 28px compact mark —
+    // reserve the taller height so the row doesn't shift 8px at the
+    // hover boundary.
+    min-height: 28px;
   }
 
   &__logo {


### PR DESCRIPTION
## [Improvement] Server lagging — 5 symptoms, root-caused + verified live

Điều tra bằng multi-agent adversarial verify + repro live trên stage (bibi.drumee.in). Mỗi fix đã verify live sau khi build.

### 1. Mở ảnh 2-3 lần rồi không mở được nữa (phải reload)
**Root cause (repro end-to-end):** ảnh có preview/slide lỗi (404) → `image_smart` không có `onerror`, `display()` chỉ chạy khi `loaded` → player kẹt **vô hình (opacity:0)** đè lên grid, **nuốt mọi click** vào các tile bên dưới → tưởng như "không mở được ảnh nữa".
- Player `pointer-events:none` cho tới khi `display()` hiện thật sự → player ẩn không bao giờ chặn click.
- Failsafe load lỗi (img error capture + watchdog 30s) → `failedToStart()`: dọn player, `media.wait(0)`, alert.
- `display()` của image player restore đủ `ready`/pointer-events/alpha ở cả nhánh `_isPlaying` (race `_play()` trước đây để alpha kẹt 0).
- Tile wait-latch (`_isWaiting`) tự hết hạn sau 30s — không failure mode nào khoá tile vĩnh viễn nữa.
- **Kèm fix ui-core** (branch `fix/image-smart-load-error`): `onerror` + dọn interval poll naturalWidth bị leak bất tử mỗi lần 404.

### 2. Sidebar hover giật + lỗi giao diện
Rail collapsed animate `width` trên sidebar 100vh + 7 nhóm phần tử `display:none` flip ngay biên hover → reflow toàn bộ label mỗi frame + pop chữ. Giờ: nav/footer ghim width 231px (animation chỉ clip, không reflow), label fade bằng visibility/opacity, badge dot neo trái. Kèm fix leak 3 listener `RADIO_POINTER` mỗi lần `Wm.reload()` trong `desk_selection` (off() dùng `.bind` mới nên không bao giờ match).

### 4. Mở nhiều file — thứ tự sai, đè lên nhau
Mọi lớp anti-overlap cũ đều chết (`_lastX` không bao giờ tăng; `anti_overlap` so `==` với vị trí đang tween). Player mới cascade 28px chéo xuống-phải theo thứ tự mở; đồng thời `display()` chỉ raise **một lần** — load chậm không còn cướp cửa sổ trên cùng theo network timing.

### 5. Task: mất data, thêm/sửa/xoá chết im lặng
`fetchService` không bao giờ reject (doRequest nuốt lỗi) → `task.list` fail làm trắng board không retry (guard `setScope` latch), create fail đóng modal mất draft. Giờ: giữ rows cũ khi lỗi, `_loadFailed` → mở lại tab tự refetch, create fail giữ modal + draft + alert, toggle/delete revert optimistic state + alert.

### 6. Tạo bảng tính lag/dead-end
`newDocument` không render gì cho tới khi WS `media.new` về (mất broadcast = chết im lặng sau 30s). Giờ: spinner ngay khi bấm, và editor mở **trực tiếp từ response** (`Wm.fetchMediaAttributes`) nếu tile chưa về sau 4s (giống nhánh DMZ file-share).

### Bonus
- Cache blob vignette module-level: `Wm.reload()` (mỗi lần bấm Home) không tải lại toàn bộ thumbnail; thumb thiếu nhớ 60s → cắt spam 404 console.

### Verify live (stage)
- 6 cycle mở/đóng ảnh liên tiếp: mở được hết, ảnh hỏng fail-fast có alert, grid vẫn click được (elementFromPoint = tile).
- Mở 3 ảnh nhanh: cascade 28px, opacity 1, pointer-events auto, ready=1.
- Sidebar: mini 64px label ẩn (fade), hover 231px hiện đủ, rời chuột về 64px — screenshot 2 trạng thái đều chuẩn.

### Lưu ý data phát hiện khi test (không thuộc PR này)
- Hub `1d2197d71d2197db` (Drumee Growth + MKT) trên stage có **vhost hỏng trong DB: `drumee.in.drumee.in`** → mọi URL preview chết (cert error). Liên quan bug desk_create_hub đã fix 15/07 — hub này cần backfill thêm.
- Nhiều ảnh stage thiếu vignette/preview (pipeline poster chưa chạy cho data cũ) → 404 hàng loạt lúc load desk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)