### PR TITLE
fix(notifications): meeting-notif navigation + created-subfolder reveal & real-time

### DIFF
--- a/src/drumee/builtins/panel/activity/index.js
+++ b/src/drumee/builtins/panel/activity/index.js
@@ -347,6 +347,53 @@ class __panel_activity extends LetcBox {
         this.setState(0);
         return;
       }
+
+      case 'open-meeting-chat': {
+        // Row click on a meeting notification (NOT the green Join button): open the
+        // folder CHAT tab where the meeting is happening (the meeting-start card's
+        // own Join button lets the user join when ready) — do NOT join the call.
+        // If that folder window is already open, raise it and switch to Chat;
+        // otherwise open a fresh window on the Chat tab. Reuse the window rather
+        // than a location.hash reveal, so an already-open folder actually switches
+        // to the conversation instead of just re-focusing whatever tab was showing
+        // (that "reveal a nid" route was why the row appeared to do nothing when a
+        // folder for the hub was already open). The folder window self-heals its
+        // chat-gate privilege on open (see window/folder _healChatPrivilege), so a
+        // full-permission member is never wrongly shown "need admin permission".
+        const item = this._findActivityItem(cmd);
+        const hub_id = (args && args.hub_id) || (item && item.mget && item.mget('hub_id'));
+        const details = (item && item.mget && item.mget('details')) || {};
+        const folderNid = details.nid || details.actual_home_id
+          || (item && item.mget && item.mget('room_id')) || 0;
+        if (hub_id && typeof Wm !== 'undefined') {
+          try {
+            const open = ((Wm.getItemsByKind && Wm.getItemsByKind('window_folder')) || [])
+              .find((w) => !w.isDestroyed() && w.mget(_a.hub_id) == hub_id
+                && `${w.mget(_a.nid)}` === `${folderNid}`);
+            if (open) {
+              if (open.raise) open.raise();
+              if (open.showFolderTab) open.showFolderTab(_a.chat);
+            } else if (Wm.addWindow) {
+              Wm.addWindow({
+                kind: 'window_folder',
+                hub_id,
+                nid: folderNid,
+                filename: details.filename || details.user_filename || '',
+                area: details.area,
+                activeTab: _a.chat,
+              });
+            }
+          } catch (e) { this.warn('open-meeting-chat: open folder failed', e); }
+        }
+        const item_key = item && item.mget && item.mget('item_key');
+        if (item_key) {
+          this._meetingItems = (this._meetingItems || []).filter(m => m.item_key !== item_key);
+          this.refreshActivity(0);
+        }
+        this.activityState = 0;
+        this.setState(0);
+        return;
+      }
     }
   }
 
@@ -719,6 +766,19 @@ class __panel_activity extends LetcBox {
    * (chat, contact, media, teamchat, ticket, hub_invite). The badge count is
    * the sum of cnt across all undismissed rows.
    */
+  // Re-fetch the chronological feed list (activity.get_feed). Called when the
+  // bell is opened (desk toggle-activity) so a notification that arrived while
+  // the panel was closed shows immediately — the panel is hidden, not destroyed,
+  // on close, and the list is otherwise only restarted by refreshActivity WHILE
+  // already open. Same restart the unread toggle uses; a cheap page-1 re-fetch
+  // that respects the current filter/unread state. Safe no-op if the list part
+  // isn't mounted yet (first open renders it fresh anyway).
+  refreshFeed() {
+    return this.ensurePart(_a.list).then((list) => {
+      if (list && list.restart && !list.isDestroyed()) list.restart();
+    });
+  }
+
   async refreshActivity(timeout = 2000) {
     if (!Visitor.id || !Visitor.isOnline()) {
       Visitor.once('online', () => {
@@ -1196,7 +1256,13 @@ class __panel_activity extends LetcBox {
       event_type: 'meeting',
       item_type: 'meeting',
       item_key: key,
-      service: 'join-meeting',
+      // NOTE: do NOT set a model-level `service` here. The item's onUiEvent
+      // resolves `args.service || this.get('service') || cmd.get('service')`, so
+      // a model `service` would SHADOW the per-element service and every click
+      // (row + green button) would resolve to it. The two triggers carry their
+      // own services in the skeleton — the row text = 'open-meeting-chat' (open
+      // the folder chat), the green button = 'join-meeting' (join the call) —
+      // so leaving this unset lets each element route correctly.
       timestamp: Math.floor(Date.now() / 1000),
       uiHandler: this,
       logicalParent: this,

--- a/src/drumee/builtins/panel/activity/widget/item/index.js
+++ b/src/drumee/builtins/panel/activity/widget/item/index.js
@@ -281,6 +281,17 @@ class __activity_item extends LetcBox {
       }
       return;
     }
+    if (service === 'join-meeting' || service === 'open-meeting-chat') {
+      // Meeting notification. The green button joins the call directly
+      // ('join-meeting'); clicking the row opens the folder chat where the
+      // meeting is happening ('open-meeting-chat'). Both are owned by the
+      // activity panel (logicalParent) — it holds the live meeting-item list —
+      // so forward via triggerHandlers to navigate + clear the item there.
+      // (Previously these fell through to _dispatchService, which handles only
+      // toggle-favorite/dismiss-activity, so the click did nothing.)
+      this.triggerHandlers({ service, hub_id: this.mget('hub_id') });
+      return;
+    }
     if (service) {
       this._dispatchService(cmd, args)
       return;
@@ -321,6 +332,18 @@ class __activity_item extends LetcBox {
       return;
     }
     switch (category) {
+      case 'meeting':
+        // A meeting-notification ROW click lands on a serviceless inner Note
+        // (same as access_request below), so `service` is undefined and routing
+        // falls through to here. Open the folder chat where the meeting is
+        // happening — NOT join the call. (Joining is the GREEN button, a Button
+        // leaf that carries its own 'join-meeting' service and is handled by the
+        // forward branch above; the row must never join.) Forward to the panel
+        // (logicalParent), which owns the live meeting-item list and opens the
+        // folder on its Chat tab.
+        this.triggerHandlers({ service: 'open-meeting-chat', hub_id });
+        break;
+
       case _a.media:
         // highlight=1 → reveal the file in its folder (scroll + select + flash)
         // instead of opening it in a player. Scoped to notification clicks.

--- a/src/drumee/builtins/panel/activity/widget/item/skeleton/index.js
+++ b/src/drumee/builtins/panel/activity/widget/item/skeleton/index.js
@@ -302,7 +302,9 @@ module.exports = function (ui) {
 
   const textBlockService = data.category === 'access_request'
     ? 'open-access-request'
-    : data.service;
+    : data.category === 'meeting'
+      ? 'open-meeting-chat'
+      : data.service;
   const textBlock = Skeletons.Box.Y({
     className: `${pfx}__text-block`,
     // Access-request rows open the approve popup; other rows route by category.

--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -481,6 +481,17 @@ class __window_folder extends mfsInteract {
     // live role changes re-run this via _applyLivePrivilege. Deferred until the
     // body is rendered so the chat-panel part exists.
     this.ensurePart("folder-view").then(() => this._syncChatGate());
+    // A folder opened WITHOUT a privilege value gates the chat for everyone —
+    // even a full-permission member — because _privilegeGrantsChat reads
+    // mget(privilege). This happens when the window is opened from a context
+    // whose payload carries no privilege (e.g. a meeting notification, whose
+    // mfs_node_attr payload has no privilege field). Self-heal: fetch this
+    // node's attributes for the CURRENT viewer (mfs_access_node → their real
+    // privilege) and re-sync the gate. Guarded to run ONLY when privilege is
+    // missing, so normally-opened folders (which already carry privilege) are
+    // untouched — no extra request, no behaviour change, and it can never grant
+    // more than the viewer actually has (view-only members stay correctly gated).
+    if (this.mget(_a.privilege) == null) this._healChatPrivilege();
     // Honor a launch-time file-chat scope (opened from a "file.thread" card
     // outside any folder window): scope the chat to that file IN PLACE — no
     // auto-switch to the full Chat tab (the window opens on its default tab and
@@ -3391,6 +3402,32 @@ class __window_folder extends mfsInteract {
     // Attribute is data-chat_gated (underscore): the skeleton sets it via
     // dataset:{chat_gated}, which the framework renders literally as data-${k}.
     this.$el.find(".window__chat-panel").attr("data-chat_gated", gated);
+  }
+
+  // Resolve the viewer's real privilege for this node when the window opened
+  // without one (see buildContent), then re-sync the chat gate. Uses the same
+  // read-only node-attributes fetch the desk reveal path uses
+  // (media.attributes → mfs_access_node → user_permission(this.uid, node)); it
+  // returns THIS viewer's own privilege only, so it can never elevate access —
+  // a view-only member still resolves a non-chat privilege and stays gated.
+  async _healChatPrivilege() {
+    const nid = this.mget(_a.nid);
+    const hub_id = this.mget(_a.hub_id);
+    if (nid == null || `${nid}` === "" || `${nid}` === "0") return;
+    try {
+      const node = await this.fetchService(
+        { service: SERVICE.media.attributes, nid, hub_id },
+        { async: 1 },
+      );
+      // Apply only if a real bitmask came back AND privilege is still unset
+      // (don't clobber a value a live set_privilege may have set meanwhile).
+      if (node && node.privilege != null && this.mget(_a.privilege) == null) {
+        this.mset(_a.privilege, Number(node.privilege));
+        this.ensurePart("folder-view").then(() => this._syncChatGate());
+      }
+    } catch (e) {
+      if (this.warn) this.warn("[folder] chat-privilege heal failed", e && e.message);
+    }
   }
 
   // Show / clear the inline validation message in the invite-error slot below

--- a/src/drumee/builtins/window/utils.js
+++ b/src/drumee/builtins/window/utils.js
@@ -1111,7 +1111,7 @@ class __window_mfs extends DrumeeMFS {
       // Already rendered in an open window: a reveal just scrolls/flashes/
       // highlights in place; a normal open triggers the node's open action.
       if (highlight) {
-        this._revealFromNotification(nid, filetype);
+        this._revealFromNotification(nid, filetype, pid);
         return;
       }
       found.triggerHandlers({ service: "open-node" });
@@ -1151,7 +1151,7 @@ class __window_mfs extends DrumeeMFS {
       { ...opt, ...parent, kind: "window_folder" },
       { explicit: 1 },
     );
-    if (highlight) this._revealFromNotification(nid, filetype);
+    if (highlight) this._revealFromNotification(nid, filetype, pid);
     return opened;
   }
 
@@ -1162,8 +1162,21 @@ class __window_mfs extends DrumeeMFS {
    *    contains (the files the notification is about). The opened window's nid
    *    matches the container itself, so there is no single file cell to reveal.
    */
-  _revealFromNotification(nid, filetype) {
-    if (filetype === _a.folder || filetype === _a.hub) {
+  _revealFromNotification(nid, filetype, pid) {
+    // The reveal always opens the PARENT folder (pid). When the notification
+    // target is a distinct child of that parent (nid !== pid) — a created file
+    // OR a created sub-folder — it is a single grid cell inside the opened
+    // parent, so highlight that one cell (works for files and folder cells
+    // alike; both extend media_core and expose _setNotifyHighlight). Only when
+    // the opened window IS the target container itself (nid === pid, e.g.
+    // "uploaded N files in <folder>") do we highlight the NEW files it contains.
+    // Previously a folder target always took the _highlightFolderNewFiles branch,
+    // so a created sub-folder (nid !== pid) matched no open window and nothing
+    // was highlighted.
+    const isContainer = filetype === _a.folder || filetype === _a.hub;
+    const targetIsChildCell = nid && pid
+      && `${nid}` !== '0' && `${pid}` !== '0' && `${nid}` !== `${pid}`;
+    if (isContainer && !targetIsChildCell) {
       this._highlightFolderNewFiles(nid);
     } else {
       this._highlightNode(nid);

--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -1359,6 +1359,11 @@ class desk_module extends LetcBox {
           p.setState(state);
           if (state) {
             this.closeOtherSidebarPanels("activity-panel");
+            // Bell opened: re-fetch the feed so a notification that arrived while
+            // it was closed shows without a full page reload. Opening goes through
+            // this desk toggle (setState directly), not the panel's own open
+            // handler, so the refresh must be triggered here.
+            if (typeof p.refreshFeed === "function") p.refreshFeed();
           }
         });
 


### PR DESCRIPTION
Lexis notification hotfix — 2 issues. **UI-only; no server/schema change.** Branched off `preview`, verified on drumee.in (test).

## Issue #4 — meeting notification
- **Row click** opens the folder's **Chat tab** (was: did nothing). The row click lands on a serviceless inner Note, so it's routed via the item's category switch (`case 'meeting'`) → panel forwards `open-meeting-chat` → reuses the open folder window (or opens one) on the Chat tab. It never joins the call.
- **Green button** joins the call directly (existing handler). Removed the model-level `service` on the live meeting item that had made the row join too.
- The folder opened from a meeting notification **self-heals its chat-gate privilege** — `mfs_node_attr` carries no `privilege`, so a full-permission member was wrongly shown "You need admin permission to chat". `window_folder` now fetches the viewer's own privilege (read-only, `media.attributes`) when it opens without one, then re-syncs the gate. Never elevates access (view-only members stay gated).

## Issue #6 — created-subfolder notification
- Clicking reveals the new sub-folder **highlighted in its parent**, like a created file (`_revealFromNotification` now highlights the child cell when `nid != pid`; the `nid == pid` "new files inside a folder" case is preserved).
- The bell **re-fetches the feed on open** (desk `toggle-activity` → panel `refreshFeed`) so a notification that arrived while the bell was closed shows without a full page reload.

## Scope / safety
- 6 files, all UI. No server, schema, or DB change. Nothing touches the secure-share/session surface.
- Vu's `join-meeting` rework (`fce4a9e9`) is not on preview; this PR does not touch the `join-meeting` handler.

## Left as-is (product decision — both are feed stored-procedure/schema matters, out of scope for this UI hotfix)
- Duplicate "posted in {folder}" notification on meeting start.
- Members not being notified of an owner's folder-create (feed proc builds accessible-hubs from the viewer's own permission rows; a member's shared-hub membership isn't matched).

## Testing
Verified on drumee.in: row → folder chat (un-gated); green → join; subfolder click → parent opens with the new subfolder highlighted; subfolder notification shows on bell open without a page reload.