### PR TITLE
fix(settings): General page layout matches Figma 2769-277671

### DIFF
--- a/src/drumee/builtins/widget/settings/main/skeleton/index.js
+++ b/src/drumee/builtins/widget/settings/main/skeleton/index.js
@@ -603,28 +603,22 @@ function referralCard(ui) {
 
 function settings_body(ui) {
   const pfx = ui.fig.family;
-  // TEMP: Billing & Subscription card hidden on the Settings page (also removes
-  // the "Manage Subscription" entry point into settings_billing). Flip
-  // SHOW_BILLING to true to restore.
-  const SHOW_BILLING = true;
   return [
     header(ui),
     Skeletons.Box.X({
       className: `${pfx}__row ${pfx}__row-1`,
       kids: [generalProfileCard(ui), preferencesCard(ui)],
     }),
-    SHOW_BILLING
-      ? Skeletons.Box.X({
-          className: `${pfx}__row ${pfx}__row-billing`,
-          kids: [billingCard(ui), referralCard(ui)],
-        })
-      : Skeletons.Box.X({
-          className: `${pfx}__row ${pfx}__row-referral`,
-          kids: [referralCard(ui)],
-        }),
+    // Figma 2769-277671: Billing, Account Credentials and Danger zone sit in
+    // ONE 3-column row. Referral/invite isn't part of that frame — kept as
+    // its own full-width row instead of crowding the trio.
     Skeletons.Box.X({
       className: `${pfx}__row ${pfx}__row-2`,
-      kids: [accountCredentialsCard(ui), dangerZoneCard(ui)],
+      kids: [billingCard(ui), accountCredentialsCard(ui), dangerZoneCard(ui)],
+    }),
+    Skeletons.Box.X({
+      className: `${pfx}__row ${pfx}__row-referral`,
+      kids: [referralCard(ui)],
     }),
     Skeletons.Box.X({
       className: `${pfx}__row ${pfx}__row-3`,

--- a/src/drumee/builtins/widget/settings/main/skin/index.scss
+++ b/src/drumee/builtins/widget/settings/main/skin/index.scss
@@ -148,13 +148,13 @@
     }
   }
 
+  // Figma 2769-277671: Billing + Account Credentials + Danger zone are one
+  // 3-column row, equal thirds.
   &__row-2 {
-    .settings-main__credentials-card {
-      flex: 375 1 0;
-      min-width: 0;
-    }
+    .settings-main__billing-card,
+    .settings-main__credentials-card,
     .settings-main__danger-card {
-      flex: 773 1 0;
+      flex: 1 1 0;
       min-width: 0;
     }
   }
@@ -166,8 +166,8 @@
     }
   }
 
-  &__row-billing {
-    .settings-main__billing-card,
+  // Referral/invite isn't part of the Figma frame — its own full-width row.
+  &__row-referral {
     .settings-main__referral-card {
       flex: 1 1 0;
       min-width: 0;
@@ -468,6 +468,26 @@
       width: 100%;
       gap: var(--spacer-5);
     }
+
+    // Figma 2769-277772/277786: these rows are label-over-value, the
+    // opposite emphasis from the Preferences toggle rows (bold title,
+    // muted description) — the small grey text is the FIELD LABEL
+    // ("Email Address"/"Password") and the bold dark text is the VALUE.
+    &-row {
+      .settings-main__inner-title {
+        font-size: 12px;
+        line-height: 16px;
+        font-weight: 600;
+        color: $ink-600;
+      }
+      .settings-main__inner-description {
+        font-size: 14px;
+        line-height: 20px;
+        font-weight: 600;
+        color: $ink-900;
+      }
+    }
+
     &-row.email-row {
       .settings-main__inner-description {
         max-width: 150px;


### PR DESCRIPTION
Reviewed the account-settings ("General") page against Figma 2769-277671 and fixed two real deviations. The colour-token system (`$purple-deep`, `$ink-900`, `$card-bg`, etc.) was already pixel-accurate against Figma's literal hex values — no changes needed there.

## Fixed

**Row grouping.** Figma puts Billing & subscription, Account Credentials and Danger zone in ONE 3-column row. The code split them into two 2-column rows instead, with a Referral/invite card squeezed in next to Billing (Referral isn't part of this Figma frame at all). Restored the 3-column row and moved Referral to its own full-width row below — the feature stays, it just no longer distorts the primary grid.

**Credentials row hierarchy.** The Email/Password rows had the label/value emphasis backwards: the field name ("Email Address"/"Password") rendered bold and dark while the actual value rendered small and grey — the opposite of Figma, which shows a small grey label above a bold near-black value. Scoped a typography override to the credentials rows only; the Preferences toggle rows (which correctly use the shared title/description pattern) are untouched.

## Explicitly out of scope

Per instruction, the Google-account connect/sign-in row stays hidden — Linked Accounts still renders only the Migrate-from-Google-Drive CTA, unchanged and unverified-against-Figma on purpose.

## Verified live

Cache-cleared reload against a fresh account on stage — 3-column row, credentials label/value hierarchy, and the untouched hidden-Google-row all confirmed against the Figma reference screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
