### PR TITLE
fix(billing): checkout page scroll + max-width 1280

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
+++ b/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
@@ -614,6 +614,13 @@
     // affordance — users clicking where the button *used to be* land on
     // nothing and nothing happens. Pinning the panel keeps the CTA reachable
     // regardless of how long the left column gets.
+    // No independent max-height/overflow here: the panel's own content
+    // (price + a handful of breakdown rows) never grows tall enough to need
+    // its own scroll, and giving it one nested a scrollable region inside
+    // the page's own scroll container — the mouse wheel would get captured
+    // by this panel and the storage-bundles content below the left column
+    // became unreachable. Position: sticky alone keeps it pinned while the
+    // OUTER page scrolls.
     &-right {
       width: 480px;
       gap: var(--spacer-5);
@@ -624,8 +631,6 @@
       position: sticky;
       top: var(--spacer-6);
       align-self: flex-start;
-      max-height: calc(100vh - var(--spacer-6) * 2);
-      overflow-y: auto;
     }
 
     &-section {
@@ -1092,11 +1097,11 @@
     display: none;
   }
 
-  // Content block centred (max-width 1600) so it doesn't hug the left with a
-  // big empty gap on the right on wide screens.
+  // Content block centred (max-width 1280) so it doesn't hug the left with a
+  // big empty gap on the right, or overflow, on wide screens.
   .settings-billing__main {
     width: 100%;
-    max-width: 1600px;
+    max-width: 1280px;
     margin: 0 auto;
   }
 
@@ -1170,6 +1175,13 @@
   }
 
   .settings-billing__body {
+    // flex:1 + min-height:0 is what actually lets overflow-y:auto engage:
+    // without it, a flex column child sizes to its own content height and
+    // never shrinks to the space __main's max-height leaves it, so this
+    // never becomes a scroll container and content past the popup-header
+    // is clipped (by the root's overflow:hidden) with no way to reach it.
+    flex: 1 1 0;
+    min-height: 0;
     overflow-y: auto;
     padding: var(--spacer-6);
     gap: var(--spacer-2);


### PR DESCRIPTION
Two real bugs on the Checkout tab, reported live: vertical scroll couldn't reach content below the fold, and the content block could overflow real (non-ultrawide) screens.

## Root cause — nested scroll region

The sticky order-summary panel (`-right`) had its own `max-height` + `overflow-y:auto` nested inside the page's own scroll container. Its content never needs its own internal scroll (a short, fixed set of price rows), but the nested scrollable region still captured the mouse wheel — on shorter viewports the storage-bundles section and the "Proceed to Checkout" button below the left column became unreachable, with no visible way to get to them.

**Fix**: dropped the inner `max-height`/`overflow-y`; `position: sticky` alone keeps the panel pinned while the OUTER page scrolls, and the mouse wheel now always reaches the single real scroll container.

Applied the same class of fix to popup mode's `__body`: without `flex: 1 1 0; min-height: 0`, `overflow-y: auto` on a flex-column child never actually engages (the child sizes to its own content height instead of shrinking to the space `__main`'s `max-height` leaves it) — the same "clipped by the root's `overflow: hidden`, no way to reach it" bug would reproduce there too.

## Max-width

Full-page mode's content block was capped at `max-width: 1600px`, wide enough to overflow on real screens. Capped at **1280px** per request.

## Verified live

Wheel-scrolled from top to bottom at 1440×750 (a realistic non-maximized window) — reaches `scrollTop` 185/185 (max), landing on the +1TB bundle card and the checkout button, both fully visible. Content block measured at exactly 1280px wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
