### PR TITLE
fix(billing): plan-card CTA background/hover now fill the full button

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/plans.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/plans.js
@@ -179,8 +179,11 @@ function item(ui, opt, option) {
 
   let buttonBtn;
   if (isCurrent) {
+    // Flat pill (no button() helper — a single element, so there's no
+    // outer/inner split to keep in sync). "-main" matches the family the
+    // button() helper's outer box uses below, so both share one CSS block.
     buttonBtn = Skeletons.Box.X({
-      className: `${fig}-button current`,
+      className: `${fig}-button-main current`,
       dataset: { disabled: 1 },
       kids: [
         Skeletons.Note({
@@ -190,14 +193,27 @@ function item(ui, opt, option) {
       ],
     });
   } else {
+    // The button() toolkit helper renders an OUTER full-width clickable box
+    // (className `${pfx}-main ${priority}`) wrapping an INNER text span
+    // (className `${pfx} btn`) — two elements, not one. Passing buttonKind
+    // embedded in className (`${fig}-button ${buttonKind}`) broke this: pfx
+    // itself became a two-token string, so appending "-main" landed after
+    // the LAST token ("...button dark" + "-main" = "...button dark-main"),
+    // never producing the outer's intended "${fig}-button-main" class. The
+    // outer ended up matching only `priority`'s class, always "secondary"
+    // for non-primary kinds — a full-width grey box with the real (dark)
+    // colour only on the inner, text-width span. Keep className to the bare
+    // base class and let `priority` carry buttonKind directly so BOTH the
+    // outer (`-main` + priority) and inner (bare pfx + priority, still
+    // embedded via pfx here) resolve to real, matching selectors.
     buttonBtn = button(ui, {
       label: buttonTitle,
-      className: `${fig}-button ${buttonKind}`,
+      className: `${fig}-button`,
       service: "select-plan-button",
       value: opt,
       name: opt,
       formItem: 1,
-      priority: buttonKind === "primary" ? "primary" : "secondary",
+      priority: buttonKind,
       uiHandler: [ui],
     });
   }

--- a/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
+++ b/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
@@ -228,8 +228,16 @@
       }
     }
 
-    // ── CTA button (full-width pill) ──────────────────────────────────────
-    &-button {
+    // ── CTA button (full-width pill) ────────────────────────────────────────
+    // The button() toolkit helper renders TWO elements: an outer full-width
+    // clickable box (`&-button-main`, carries the priority/kind class) and an
+    // inner text span (`&-button`, plain — see the .btn rule below). The
+    // "current" pill is the one exception: a flat Box.X with no inner span,
+    // given the SAME `-main` class so it shares this block. Colour/chrome
+    // must live on `-main` — it's the element that's actually width:100%;
+    // putting it on the bare `&-button` only painted the inner, text-width
+    // span, leaving the real full-width box a plain "secondary" grey.
+    &-button-main {
       width: 100%;
       justify-content: center;
       align-items: center;
@@ -278,6 +286,14 @@
         cursor: default;
         pointer-events: none;
       }
+    }
+
+    // Inner text span (button() helper only) — no chrome of its own, just
+    // inherits the outer -main's colour so the label reads correctly
+    // against whichever variant (primary/dark/secondary) is active.
+    &-button.btn {
+      background: transparent;
+      color: inherit;
 
       .note-content,
       .label,


### PR DESCRIPTION
"Contact sales" (Enterprise), "Choose Team" and "Get started" showed a small, text-width coloured pill floating inside a wider grey box — the background (and its hover state) never spanned the actual full-width button, only the label's own width. Reported against Figma 2769-214061.

## Root cause

The shared `button()` toolkit helper renders TWO elements — an outer full-width clickable box (`className: \`${pfx}-main ${priority}\``) and an inner text span (`className: \`${pfx} btn\``). `plans.js` passed the plan's kind embedded in `className` (`` `${fig}-button ${buttonKind}` ``, e.g. `"...plan-button dark"`), making `pfx` itself a two-token string. Appending `"-main"` then landed after the *last* token (`"...button dark"` + `"-main"` = `"...button dark-main"`), never producing the intended `"...plan-button-main"` class.

The outer box was left matching only `priority` (hardcoded to `"primary"`/`"secondary"`, never `"dark"`) — so Team/Enterprise's outer box always rendered as a plain "secondary" grey box, while the correctly-classed *inner* span (which still carried `"dark"` via the embedded `pfx`) painted the real colour, but only across its own text width.

## Fix

- Keep `className` to the bare base class and pass `buttonKind` straight through as `priority` (dropping the primary/secondary-only remapping).
- Move the CSS variants (`.primary`/`.dark`/`.secondary`/`.current`) onto `&-button-main` — the element that's actually `width: 100%`. The inner `.btn` span now just inherits colour with a transparent background.
- The "Your current plan" flat pill (no helper, no inner/outer split) is retargeted to the same `-main` class so it shares the block.

## Verified live

Free/Pro/Enterprise outer boxes all measure the full 261px card-content width with their real background colour (grey / primary-40 / `#282538` — exact Figma match), inner span fully transparent, and hover (`opacity: 0.92` on `.dark`) now applies across the whole box instead of a text-width patch. Screenshot confirms "Contact sales" now renders edge-to-edge dark, matching Figma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
