### PR TITLE
fix(desk): sidebar avatar centers correctly in the collapsed mini rail

### DIFF
--- a/src/drumee/modules/desk/skin/sidebar.scss
+++ b/src/drumee/modules/desk/skin/sidebar.scss
@@ -190,6 +190,22 @@ $rail-collapse-allowed: "(pointer: fine), (max-width: 767px), (min-width: 1025px
   &__rail[data-collapsed="1"] &__main:not(:hover) {
     @media #{$rail-collapse-allowed} {
       @include sidebar-mini-icons;
+
+      // The footer/nav rows stay pinned at their expanded 231px width (see
+      // "Pin the content columns" above) and are just visually clipped to
+      // the 64px rail — every row's icon sits at its normal padding-left:24
+      // offset from that wider row's left edge, which happens to read as
+      // roughly centered for a 20px nav icon (24px vs 16px margins) but
+      // puts the 40px avatar chip flush against the clip window's right
+      // edge (24px vs 0px — no room left). Re-anchor the avatar's own
+      // left offset for the 64px strip specifically: (64 - 40) / 2 = 12px
+      // each side.
+      // Plain descendant selector, not `&__x` — the parent selector here
+      // ends in the pseudo-class :not(:hover), and Sass rejects suffixing
+      // a pseudo-class ("Selector :not(:hover) can't have a suffix").
+      .desk-module-sidebar__footer-user-btn {
+        padding-left: 12px;
+      }
     }
   }
 


### PR DESCRIPTION
Reported live: the sidebar's bottom profile avatar looks skewed/off-center when the desktop rail is collapsed to its 64px mini state.

## Root cause

The footer/nav rows stay pinned at their expanded 231px width and are just visually clipped to the 64px mini rail, so every row's content sits at its normal `padding-left: 24px` offset from that wider row's own left edge. That reads as roughly centered for a 20px nav icon (24px left vs 16px right margin), but the 40px avatar chip ended up flush against the clip window's right edge — 24px on the left, **0px on the right**, no room left at all.

## Fix

Re-anchored the avatar row's own left padding for the 64px collapsed strip specifically: `(64 - 40) / 2 = 12px` each side, giving it the same symmetric centering the small icons only approximate by chance. The expanded/hover state (231px, `padding-left: 24px` from the original rule) is untouched.

## Also caught in the same edit

The first attempt nested `&__footer-user-btn` under a parent selector ending in `:not(:hover)`, which Sass rejects (*"Selector :not(:hover) can't have a suffix"*) — that broke the whole desk module's CSS build (blank page for every user) until switched to a plain descendant selector. Confirmed the final version builds clean and the page loads normally.

## Verified live

- Collapsed rail: avatar now measures `left: 12 / right: 12` (was `left: 24 / right: 0`).
- Hovering to the expanded 231px state still measures `left: 24` — unchanged, matches every other row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
