### PR TITLE
fix(billing): keep the Team card CTA as 'Choose Team' for paying Pro users

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/plans.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/plans.js
@@ -179,12 +179,19 @@ function item(ui, opt, option) {
   // CTA (design: the Free card shows the pill while the user is on Free).
   const isCurrent = (ui.currentPlanName || "free") === opt;
 
-  // Paid subscriber CTAs: Free → cancel at period end; other paid plans →
-  // Billing Portal (upgrade/change). Avoid implying a second Checkout.
+  // Paid subscriber CTAs: Free → cancel at period end; Pro → Billing Portal
+  // (manage/change). Avoid implying a second Checkout.
+  // TEAM is deliberately EXCLUDED: for a paying Pro user, Team is a real
+  // upgrade path (a brand-new org subscription via a fresh Checkout, gated by
+  // the confirm popup in onUiEvent) — NOT a "manage subscription" portal jump.
+  // Relabelling it to "Manage subscription" (which only happened after
+  // _loadSubscription() flipped _hasPaidSub true ~5s in, so the button
+  // visibly changed from "Choose Team") both mislabelled the action and
+  // implied the portal. Keep its "Choose Team" CTA.
   if (!isCurrent && ui._hasPaidSub) {
     if (opt === "free") {
       buttonTitle = LOCALE.CANCEL_PLAN || "Cancel plan";
-    } else if (opt === "pro" || opt === "team") {
+    } else if (opt === "pro") {
       buttonTitle = LOCALE.MANAGE_SUBSCRIPTION || LOCALE.UPGRADE || buttonTitle;
     }
   }


### PR DESCRIPTION
## Report
> On the Team plan card, clicking 'Choose Team' — after ~5s it flips to 'Manage subscription'.

## Root cause
For a paid subscriber, `item()` in plans.js relabels the plan-card CTAs (Free → 'Cancel plan', Pro → 'Manage subscription') to avoid implying a second Checkout. **Team was wrongly included** in that remap. `_hasPaidSub` is false on first paint (it's filled asynchronously by `_loadSubscription()`), so the Team card first renders 'Choose Team'; ~5s later the subscription mirror resolves, `_hasPaidSub` flips true, the grid re-renders, and the Team CTA becomes 'Manage subscription'.

That label is wrong: for a Pro user, **Team is a genuine upgrade** — a brand-new org (per-seat) subscription via a fresh Checkout, gated by the upgrade-confirm popup — not a Billing Portal 'manage' jump.

## Fix
Exclude `team` from the remap. Free→Cancel and Pro→Manage are unchanged; Team keeps its stable 'Choose Team' CTA.

## Verified live (real Pro account, before/after on stage)
- **Before** (buggy remap deployed): Team CTA 'Choose Team' at 3s → **'Manage subscription' at 10s**.
- **After** (fix): Team CTA 'Choose Team' at both 3s and 11s — no flip. Clicking it still opens the upgrade-confirm popup (behavior intact).

> Base is `test`: the remap only exists on `test` (preview's Team card already shows a stable 'Choose Team' — it has no remap). The deployed stage was likewise unaffected; this targets the test-branch remap so it's correct when it reaches preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)