### PR TITLE
style(meeting): styled hover tooltips for in-topbar controls

### DIFF
--- a/src/drumee/builtins/webrtc/skeleton/topbar.js
+++ b/src/drumee/builtins/webrtc/skeleton/topbar.js
@@ -88,7 +88,7 @@ module.exports = function (_ui_) {
     service: "hand-raise",
     uiHandler: [_ui_],
     className: `${pfx}__ctrl-btn hand-raise`,
-    attrOpt: { title: LOCALE.RAISE_HAND },
+    attrOpt: { "data-tip": LOCALE.RAISE_HAND },
     dataset: { raised: 0 },
   });
 
@@ -141,7 +141,7 @@ module.exports = function (_ui_) {
     trigger: Skeletons.Button.Svg({
       ico: "meet-smiley",
       className: `${pfx}__ctrl-btn reactions`,
-      attrOpt: { title: LOCALE.REACTIONS },
+      attrOpt: { "data-tip": LOCALE.REACTIONS },
     }),
     items: Skeletons.Box.X({
       className: `${pfx}__reactions-bar`,
@@ -177,7 +177,7 @@ module.exports = function (_ui_) {
         service: _a.chat,
         uiHandler: [_ui_],
         className: `${pfx}__ctrl-btn chat`,
-        attrOpt: { title: LOCALE.CHAT },
+        attrOpt: { "data-tip": LOCALE.CHAT },
       }),
       Skeletons.Note({
         className: `${pfx}__in-topbar-chat-badge`,
@@ -193,7 +193,7 @@ module.exports = function (_ui_) {
     service: "show-people",
     uiHandler: [_ui_],
     className: `${pfx}__ctrl-btn people`,
-    attrOpt: { title: LOCALE.PARTICIPANTS },
+    attrOpt: { "data-tip": LOCALE.PARTICIPANTS },
   });
 
   // Window-resize dropdown: Full screen / Tile left / Tile right / Reframe.
@@ -218,7 +218,7 @@ module.exports = function (_ui_) {
     trigger: Skeletons.Button.Svg({
       ico: "meet-expand",
       className: `${pfx}__ctrl-btn fullscreen`,
-      attrOpt: { title: LOCALE.FULL_SCREEN },
+      attrOpt: { "data-tip": LOCALE.FULL_SCREEN },
     }),
     items: Skeletons.Box.Y({
       className: `${pfx}__resize-items`,
@@ -307,7 +307,7 @@ module.exports = function (_ui_) {
     sys_pn: "ctrl-screen",
     name: _a.screen,
     service: "start-screenshare",
-    attrOpt: { title: LOCALE.SHARE_SCREEN },
+    attrOpt: { "data-tip": LOCALE.SHARE_SCREEN },
     dataset: { muted: 1 },
   });
 

--- a/src/drumee/builtins/webrtc/skin/command.scss
+++ b/src/drumee/builtins/webrtc/skin/command.scss
@@ -622,8 +622,9 @@
   }
 
   // ── Styled hover tooltip (dark pill) for controls carrying data-tip ─────────
-  // Used on the blur controls (device-list row + panel tile) and the upload
-  // tile. ::before is free here (the loading spinner uses ::after).
+  // Used on the blur controls (device-list row + panel tile), the upload tile,
+  // and the in-topbar controls (hand / reactions / chat / people / fullscreen /
+  // screen-share). ::before is free here (the loading spinner uses ::after).
   [data-tip] {
     position: relative;
   }
@@ -635,7 +636,7 @@
     left: 50%;
     transform: translateX(-50%);
     padding: 5px 10px;
-    border-radius: 8px;
+    border-radius: 4px;
     background-color: #1f2130;
     color: #fff;
     font-size: 12px;
@@ -645,5 +646,12 @@
     pointer-events: none;
     z-index: 3000;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  }
+
+  // In-topbar controls sit at the very top of the window, so their tooltip must
+  // drop BELOW the control instead of above (which would clip off-screen).
+  &__in-topbar-controls [data-tip]:hover::before {
+    top: calc(100% + 8px);
+    bottom: auto;
   }
 }


### PR DESCRIPTION
Convert the in-topbar controls (raise hand, reactions, chat, participants, fullscreen, share screen) from the native `title` tooltip to the meeting's styled dark-pill `data-tip` tooltip, and add a scoped override so it drops below the control (they sit at the top of the window, where the default above-position would clip off-screen).