### PR TITLE
fix(tasks): assignee chip ✕ removes the member in the create modal

### DIFF
--- a/src/drumee/builtins/window/tasks/index.js
+++ b/src/drumee/builtins/window/tasks/index.js
@@ -3198,7 +3198,11 @@ class __tasks_panel extends LetcBox {
       .then((btn) => {
         if (!btn || btn.isDestroyed?.()) return;
         btn.feed(
-          require("./skeleton").buildAssigneeButtonContent(this, assignees),
+          require("./skeleton").buildAssigneeButtonContent(
+            this,
+            assignees,
+            kind === "create-assignee" ? "create-assignee" : "set-assignee",
+          ),
         );
       })
       .catch(() => {


### PR DESCRIPTION
## Problem
In the **New task** create modal, clicking the ✕ on an assignee chip did **not** remove the assignee — it re-opened the member dropdown instead. In the already-created task detail view the ✕ worked correctly.

## Root cause
`_applyAssigneeChange` re-renders the assignee chips via `buildAssigneeButtonContent(this, assignees)` — **without the 3rd `removeService` argument**. Every re-rendered chip's ✕ therefore got `service: undefined`; clicking it fell through to the ancestor `toggle-picker` button and re-opened the dropdown.

It only surfaced in the **create** modal because there the assignee set starts empty, so every chip is born through this re-feed path. The detail view renders its initial chips with the correct service, so its ✕ already worked.

## Fix
Pass the same `removeService` the initial render uses (`skeleton/index.js` `assigneeButton`):
`create-assignee → "create-assignee"`, `detail-assignee → "set-assignee"` — both already handled in `onUiEvent`.

One-line-logic change; no propagation/`bubble` changes. Also hardens the detail view against a second in-session removal (which used the same re-feed path).

## Test / verification (drumee.in)
- Create modal: add 2 assignees → ✕ on one removes it (dropdown no longer reopens); remove last → placeholder; click chip area still opens dropdown; **Create** saves the correct assignees; 3+ assignees ("+N") remove correctly.
- Detail view: ✕ still removes (no regression), including a 2nd removal.

UI-only, no DB change.
