### PR TITLE
fix(desk): WM confirm dialog is unclickable when raised from inside a window

### DIFF
--- a/src/drumee/modules/desk/skin/index.scss
+++ b/src/drumee/modules/desk/skin/index.scss
@@ -237,8 +237,21 @@ html {
     z-index: auto;
   }
 
+  // 30000 was enough to clear the settings/apps slot, but NOT the window
+  // layer: `.window-manager__layer:has(> [data-state="1"])` lifts to
+  // `50001 !important` (wm/skin) while it hosts the focused window. That layer
+  // carries the window's own `dialog__wrapper` — transparent, `inset: 0`, so it
+  // covers the whole work area without being visible. The confirm therefore
+  // PAINTS (you can see it) but every click lands on that wrapper instead of
+  // the Confirm button: Wm.confirm can be raised from inside a window but never
+  // answered, so the awaited action silently never runs (folder settings →
+  // change member role did nothing).
+  //
+  // `!important` is required to out-cascade the global
+  // `[data-state="open"] { z-index: var(--z-index-context) !important }` in
+  // skin/lib/utils.scss, which otherwise pins this wrapper to 50000.
   .window-manager__wrapper-modal[data-state="open"] {
-    z-index: 30000;
+    z-index: var(--z-index-modal, 100000) !important;
   }
 }
 


### PR DESCRIPTION
## Problem

In **Folder Settings → Permissions Matrix**, changing a member's role showed the confirm dialog, but clicking **Confirm** did nothing — no request was sent and the role never changed.

## Root cause

Not the permission code — a stacking/hit-testing conflict.

`Wm.confirm` renders into `.window-manager__wrapper-modal`, which the global rule in `skin/lib/utils.scss` pins to **z 50000**:

```scss
[data-state="open"] { z-index: var(--z-index-context) !important; }  // 50000
```

The layer hosting the focused window lifts to **50001 !important** (`wm/skin`) and carries that window's own `dialog__wrapper` — `background: transparent`, `inset: 0`. So an invisible full-area overlay sits *above* the confirm: the dialog is painted (you can see it) but every click lands on the wrapper instead of the button, and the awaited promise never resolves.

This affects **every** `Wm.confirm`/`Wm.alert` raised from inside a window, not just role changes.

## Fix

Lift the WM modal to `--z-index-modal` (100000) instead of 30000, with `!important` to out-cascade the global open-state lift. One-line change in the block already dedicated to this problem.

## Verification (live on drumee.in, Folder Settings → Permissions Matrix)

| | Before | After |
|---|---|---|
| `elementFromPoint` over Confirm | `window__wrapper-modal` | the Confirm button |
| Click Confirm | no request, dialog stays open | dialog closes |
| Role in UI | unchanged ("Chat") | updates to "Admin" |
| Hub `permission` row | 7 | **31** (persisted) |

Verified by injecting the rule in the live page, then confirming the DB write in the hub database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)