### PR TITLE
fix(confirm): pending Wm.confirm becomes an invisible full-screen click shield

### DIFF
--- a/src/drumee/builtins/window/confirm/index.js
+++ b/src/drumee/builtins/window/confirm/index.js
@@ -53,6 +53,7 @@ class ___window_confirm extends mfsInteract {
     const a = new Promise((resolve, reject) => {
       this.onConfirm = (cmd, args) => {
         this._done = true;
+        this._releaseModalGuards();
         try {
           resolve({ response: _e.confirm });
         } catch (e) {
@@ -62,6 +63,7 @@ class ___window_confirm extends mfsInteract {
       }
       this.onCancel = (cmd, args) => {
         this._done = true;
+        this._releaseModalGuards();
         try {
           reject({ response: _e.cancel });
         } catch (e) {
@@ -70,6 +72,7 @@ class ___window_confirm extends mfsInteract {
         if (this.mget(_a.cancel_action) == _e.close) this.goodbye();
       }
       this.onBeforeDestroy = (cmd, args) => {
+        this._releaseModalGuards();
         if (this._done) return;
         try {
           reject({ response: _e.close });
@@ -78,7 +81,46 @@ class ___window_confirm extends mfsInteract {
         }
       }
     });
+    this._armModalGuards();
     return a;
+  }
+
+  /**
+   * A pending confirm must stay answerable until resolved. Two live-verified
+   * failure modes leave it stuck instead, turning its host wrapper-modal
+   * (which only auto-closes when the confirm is DESTROYED) into an invisible
+   * full-screen shield that eats every click/hover until reload:
+   *  - Escape has no handler anywhere (both WM _kbHandler's are empty stubs),
+   *    so keyboard users can't dismiss it.
+   *  - The confirm's el joins the app-wide window focus radio: any other
+   *    window being raised (WS event, re-render, programmatic launch — e.g.
+   *    the post-deploy newVersion() confirm losing focus to the window the
+   *    user keeps working in) demotes data-state to 0 with no way back.
+   * Escape now runs the Cancel path, and a state guard re-asserts `open`
+   * until the confirm is answered — a modal keeps the top spot by design.
+   */
+  _armModalGuards() {
+    this._kbEscape = (e) => {
+      if (e.key === 'Escape' && !this._done && this.onCancel) this.onCancel();
+    };
+    document.addEventListener(_e.keyup, this._kbEscape);
+    this._stateGuard = new MutationObserver(() => {
+      if (!this._done && this.el && this.el.dataset.state !== _a.open) {
+        this.el.dataset.state = _a.open;
+      }
+    });
+    this._stateGuard.observe(this.el, { attributes: true, attributeFilter: ['data-state'] });
+  }
+
+  _releaseModalGuards() {
+    if (this._kbEscape) {
+      document.removeEventListener(_e.keyup, this._kbEscape);
+      this._kbEscape = null;
+    }
+    if (this._stateGuard) {
+      this._stateGuard.disconnect();
+      this._stateGuard = null;
+    }
   }
 
 }


### PR DESCRIPTION
## Problem (root cause of several 'UI randomly unclickable' reports)

A pending `Wm.confirm` can strand its host `wrapper-modal` open as an **invisible full-screen shield** that eats every click/hover until reload. Reproduced live twice while debugging the role-tooltip ticket.

## Mechanism

The wrapper-modal auto-closes only when the confirm is **destroyed** (wrapper behavior watches the child collection). Two paths leave the confirm alive but inert:

1. **Escape has no handler** — both `_kbHandler` stubs (`window/manager.js`, `desk/wm/index.js`) are empty. Keyboard users cannot dismiss a confirm at all.
2. **The confirm joins the app-wide window focus radio** — any other window being raised (WS event, re-render, programmatic launch) demotes it to `data-state=0` with no way back. The biggest trigger: `newVersion()` pops the *"We have updated your Drumee desktop"* confirm for **every user with an open window after every deploy**; the user keeps working, the confirm loses focus, and their session is left with the shield up.

The z-order fix in #326 (modal to z 100000) widened the blast radius of this pre-existing bug — the shield now sits above everything.

## Fix

`ask()` arms two guards, released on answer/destroy:
- **Escape runs the Cancel path** (reject + `goodbye()` → wrapper auto-closes)
- **A MutationObserver re-asserts `data-state=open`** while unanswered — a modal keeps the top spot by design

## Verification (live, drumee.in)

- Raise a confirm → force-demote its state → observer restores `open`
- Escape → confirm destroyed, wrapper closed, page fully interactive again
- Confirm/Cancel buttons unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)