### PR TITLE
fix(api): public-api language fallback defaults to English, not French

### DIFF
--- a/src/drumee/api.js
+++ b/src/drumee/api.js
@@ -20,7 +20,9 @@ const intEnv = function () {
   let domain = "drumee.com";
   let endpointName = "main";
   let endpointPath = "/-/";
-  let language = 'fr'
+  // Default English (product decision 2026-07-21) — matches the server-side
+  // default; the real value comes from <html lang> two lines down.
+  let language = 'en'
   let d = {};
   try {
     d = document.getElementById('drumee-api').dataset;


### PR DESCRIPTION
Companion to drumee/server-team#103 (anonymous pages default to English): the public-api bootstrap in `src/drumee/api.js` fell back to `'fr'` when the served page carries no `<html lang>`. Default English everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)