### PR TITLE
fix(folder): files flash as one vertical column while the grid partitions

### DIFF
--- a/src/drumee/builtins/window/folder/skin/index.scss
+++ b/src/drumee/builtins/window/folder/skin/index.scss
@@ -2143,6 +2143,23 @@
     justify-content: flex-start;
     justify-items: flex-start;
     padding: 24px;
+
+    // Structural guard against the "files stack in one vertical column for a
+    // couple of seconds, then snap into the grid" flash. Items stream into
+    // the smart-container as RAW direct children and only look right once
+    // _doPartition moves them into the workspace/folder/file sections. The
+    // JS hide (visibility:hidden at buildContent) only fires when
+    // .smart-container already exists at setup time — on a fresh window the
+    // list may still be mounting, so early items painted unpartitioned.
+    // Hide raw direct children by STRUCTURE instead of timing: no attribute
+    // (fresh container) or data-partitioning="1" → not painted; once
+    // partitioned they live inside the sections so this selector no longer
+    // matches. The partition give-up path sets data-partitioning="0" on the
+    // raw container, which re-shows them — files are never lost if
+    // partitioning can't complete.
+    &:not([data-partitioning="0"]) > [data-filetype] {
+      visibility: hidden;
+    }
   }
 
   .window__icons-scroll {


### PR DESCRIPTION
## Problem (QA report, intermittent)

Opening a folder window sometimes shows every file stacked in **one vertical column for ~2s**, then it snaps into the normal grid.

## Root cause

The folder window renders one flat smart list and then **partitions** its DOM into workspace/folder/file sections (`_doPartition`). Until that pass runs, items are raw direct children of a column-flex container — i.e. exactly the vertical stack in the report.

There IS a JS guard (`visibility: hidden` + `data-partitioning=1` in `buildContent`), but it only applies **when `.smart-container` already exists at setup time**. On a fresh window the smart list may still be mounting, so nothing hides the container and early items paint unpartitioned until EOD/observer triggers the partition — hence intermittent, duration ≈ data fetch time.

## Fix

Structural CSS guard, immune to JS timing:

```scss
.window-folder .window__icons-list .smart-container:not([data-partitioning="0"]) > [data-filetype] {
  visibility: hidden;
}
```

- Fresh container (no attribute yet) → raw children don't paint
- Partition success → children move into sections (selector no longer matches) + `data-partitioning=0`
- Partition give-up path → sets `data-partitioning=0` on the raw container → children re-shown, so files can never be stranded invisible
- Scoped to `.window-folder` — non-partitioned surfaces (share/dmz windows, media lists) untouched
- Bonus: an uploaded file appended as a raw child mid-session stays unpainted for the one frame before the rAF re-partition moves it — removing that flash too

## Verification

Live on drumee.in dev endpoint with CDP network throttling (widens the race window): folder opens straight into sections; no vertical column paints at any point during load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)