### PR TITLE
fix(desk): sidebar 'Upgrade plan' is org-owner only

### DIFF
--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -1904,8 +1904,17 @@ class desk_module extends LetcBox {
       // Every billing entry point (sidebar "Upgrade plan", Settings "Manage
       // subscription" card, admin-console upsell, desk storage card) → the
       // full-page billing screen in settings-main-slot (NOT a popup).
-      case "upgrade-plan":
+      case "upgrade-plan": {
+        // Defense in depth behind the sidebar gating: billing is owner-managed
+        // inside an organization — ignore stray triggers (deep links, stale
+        // UI) from members/workspace admins who cannot change the org plan.
+        const quota = (Visitor.quota && Visitor.quota()) || {};
+        const canUpgrade =
+          ~~quota.domain_id <= 1 ||
+          !!(Visitor.domainCan && Visitor.domainCan(_K.permission.owner));
+        if (!canUpgrade) return;
         return this.openBillingPage();
+      }
 
       // Display mode (light/dark/system) moved to Settings → Appearance.
       // See builtins/widget/settings/main + utils router/theme.js.

--- a/src/drumee/modules/desk/skeleton/sidebar.js
+++ b/src/drumee/modules/desk/skeleton/sidebar.js
@@ -101,24 +101,35 @@ const createFooter = (ui, username) => {
   const fig = getSidebarFig(ui);
   // Real plan badge under the username (design: "Pro Plan"): read the live
   // entitlement instead of the old hardcoded PRO_PLAN label.
-  const plan = (((Visitor.quota && Visitor.quota()) || {}).plan || "free").toString();
+  const quota = (Visitor.quota && Visitor.quota()) || {};
+  const plan = (quota.plan || "free").toString();
   const planBadge = (LOCALE.PLAN_BADGE || "{0} Plan").format(
     plan.charAt(0).toUpperCase() + plan.slice(1),
   );
+  // Billing is owner-managed: inside an organization (domain_id > 1) only the
+  // org OWNER can change the plan — a member/workspace-admin clicking through
+  // to the plans page could at best bootstrap a stray second org. Personal
+  // users (domain 1) always see it: they upgrade themselves.
+  const canUpgrade =
+    ~~quota.domain_id <= 1 ||
+    !!(Visitor.domainCan && Visitor.domainCan(_K.permission.owner));
 
   return Skeletons.Box.Y({
     className: cls(fig, "footer"),
     kids: [
-      // Design: a dedicated "Upgrade plan" entry above Settings.
-      createNavItem(
-        ui,
-        "billing",
-        LOCALE.UPGRADE_PLAN_MENU || "Upgrade plan",
-        "upgrade-plan",
-        "",
-        null,
-        "sidebar-upgrade",
-      ),
+      // Design: a dedicated "Upgrade plan" entry above Settings (org owners
+      // and personal accounts only — see canUpgrade above).
+      canUpgrade
+        ? createNavItem(
+            ui,
+            "billing",
+            LOCALE.UPGRADE_PLAN_MENU || "Upgrade plan",
+            "upgrade-plan",
+            "",
+            null,
+            "sidebar-upgrade",
+          )
+        : null,
       createNavItem(
         ui,
         "sidebar_settings",


### PR DESCRIPTION
Billing is owner-managed inside an organization — a member or workspace admin cannot change the org plan, and clicking through to the plans page could at worst bootstrap a stray second org via the TEAM checkout (`payment.checkout` resolves the org by `owner_id`; a non-owner falls into the bootstrap branch).

- Sidebar **Upgrade plan** entry renders only for: org **owners** (`Visitor.domainCan(_K.permission.owner)`) and **personal** (domain-1) accounts, who upgrade themselves.
- The `upgrade-plan` service handler gets the same guard (defense in depth against deep links / stale UI).

Companion: drumee/admin-dash-ui#8 gates the admin console's four upgrade CTAs (storage card, manage-storage header, admin/audit upsells) on the same rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)