### PR TITLE
feat(tutorial): replace Skip button with a Back button

### DIFF
--- a/src/drumee/modules/desk/tutorial/folder/index.js
+++ b/src/drumee/modules/desk/tutorial/folder/index.js
@@ -42,8 +42,8 @@ class __tutorial_folder extends LetcBox {
     switch (service) {
       case 'next-step':
         return this.triggerHandlers();
-      case 'skip-tour':
-        return this.triggerHandlers({ service: 'skip-tour' });
+      case 'back-step':
+        return this.triggerHandlers({ service: 'back-step' });
     }
   }
 }

--- a/src/drumee/modules/desk/tutorial/index.js
+++ b/src/drumee/modules/desk/tutorial/index.js
@@ -52,6 +52,19 @@ class tutorial_main extends LetcBox {
   }
 
   /**
+   * Step back to the previous tutorial step. No-op on the first step,
+   * where there is nothing to go back to.
+   */
+  _prevStep() {
+    if (this._stepIndex <= 0) return;
+    this._stepIndex--;
+    this.ensurePart('spotlight').then((s) => s.clear && s.clear());
+    this.ensurePart(_a.content).then((p) => {
+      p.feed(this._widgets[this._stepIndex])
+    })
+  }
+
+  /**
    * Exit the tutorial and record that the user has seen it so it doesn't
    * auto-show again on subsequent sessions via a forced URL param.
    */
@@ -71,8 +84,8 @@ class tutorial_main extends LetcBox {
       case 'next-step':
         this._nextStep()
         break;
-      case 'skip-tour':
-        this._enterWorkspace();
+      case 'back-step':
+        this._prevStep();
         break;
       case 'spotlight:focus':
         this.ensurePart('spotlight').then((s) => s.focus(args));

--- a/src/drumee/modules/desk/tutorial/meeting/index.js
+++ b/src/drumee/modules/desk/tutorial/meeting/index.js
@@ -35,8 +35,8 @@ class __tutorial_meeting extends LetcBox {
     switch (service) {
       case 'next-step':
         return this.triggerHandlers();
-      case 'skip-tour':
-        return this.triggerHandlers({ service: 'skip-tour' });
+      case 'back-step':
+        return this.triggerHandlers({ service: 'back-step' });
     }
   }
 }

--- a/src/drumee/modules/desk/tutorial/settings/index.js
+++ b/src/drumee/modules/desk/tutorial/settings/index.js
@@ -35,8 +35,8 @@ class __tutorial_settings extends LetcBox {
     switch (service) {
       case 'next-step':
         return this.triggerHandlers();
-      case 'skip-tour':
-        return this.triggerHandlers({ service: 'skip-tour' });
+      case 'back-step':
+        return this.triggerHandlers({ service: 'back-step' });
     }
   }
 }

--- a/src/drumee/modules/desk/tutorial/skeleton/toolkit/tooltip.js
+++ b/src/drumee/modules/desk/tutorial/skeleton/toolkit/tooltip.js
@@ -16,7 +16,7 @@ const { fileItem } = require("./folder")
  *   east  = connector right of card (dot at right, points to target right)
  *   west  = connector left of card (dot at left, points to target left)
  */
-export function tooltipBadge(ui, { title, desc, badge_text, style, direction = 'north' }) {
+export function tooltipBadge(ui, { title, desc, badge_text, style, direction = 'north', hide_back = false }) {
   const fig = ui.fig.family;
   const p = `${ui.fig.group}__s1`;
 
@@ -59,12 +59,17 @@ export function tooltipBadge(ui, { title, desc, badge_text, style, direction = '
       Skeletons.Box.X({
         className: `${p}-footer`,
         kids: [
-          Skeletons.Note({
-            className: `${p}-skip`,
-            content: LOCALE.SKIP_TOUR || 'Skip tour',
-            service: 'skip-tour',
-            uiHandler: [ui],
-          }),
+          // On the very first step there is nothing to go back to: render an
+          // empty spacer so `justify-content: space-between` still pushes Next
+          // to the right edge.
+          hide_back
+            ? Skeletons.Box.Y({ className: `${p}-back-spacer` })
+            : Skeletons.Note({
+              className: `${p}-back`,
+              content: `← ${LOCALE.BACK || 'Back'}`,
+              service: 'back-step',
+              uiHandler: [ui],
+            }),
           Skeletons.Note({
             className: `${p}-next`,
             content: `${LOCALE.NEXT || 'Next'} →`,

--- a/src/drumee/modules/desk/tutorial/skin/tooltip.scss
+++ b/src/drumee/modules/desk/tutorial/skin/tooltip.scss
@@ -99,7 +99,7 @@
     margin-top: 8px;
   }
 
-  &__s1-skip {
+  &__s1-back {
     font-family: var(--font-main);
     font-size: 13px;
     font-weight: 500;

--- a/src/drumee/modules/desk/tutorial/task/index.js
+++ b/src/drumee/modules/desk/tutorial/task/index.js
@@ -36,8 +36,8 @@ class __tutorial_task extends LetcBox {
     switch (service) {
       case 'next-step':
         return this.triggerHandlers();
-      case 'skip-tour':
-        return this.triggerHandlers({ service: 'skip-tour' });
+      case 'back-step':
+        return this.triggerHandlers({ service: 'back-step' });
     }
   }
 }

--- a/src/drumee/modules/desk/tutorial/workspace/index.js
+++ b/src/drumee/modules/desk/tutorial/workspace/index.js
@@ -49,7 +49,8 @@ class __tutorial_workspace extends LetcBox {
     this.triggerHandlers({
       service: 'spotlight:focus',
       target: card.el,
-      tooltip: step,
+      // Hide the Back button on the very first badge — nothing precedes it.
+      tooltip: { ...step, hide_back: this._stepIndex === 0 },
       direction: 'north',
       owner: this,
     });
@@ -67,8 +68,12 @@ class __tutorial_workspace extends LetcBox {
         }
         this._showBadge();
         break;
-      case 'skip-tour':
-        this.triggerHandlers({ service: 'skip-tour' });
+      case 'back-step':
+        // Walk back through the workspace sub-badges. Badge 0 hides Back, so
+        // this only fires on badges 1+; guard anyway.
+        if (this._stepIndex <= 0) return;
+        this._stepIndex = this._stepIndex - 1;
+        this._showBadge();
         break;
       default:
         if (super.onUiEvent) super.onUiEvent(trigger, args);

--- a/src/drumee/modules/desk/tutorial/workspace/skin/index.scss
+++ b/src/drumee/modules/desk/tutorial/workspace/skin/index.scss
@@ -156,7 +156,7 @@
     margin-top: 8px;
   }
 
-  &__s1-skip {
+  &__s1-back {
     font-family: var(--font-main);
     font-size: 13px;
     font-weight: 500;


### PR DESCRIPTION
Swap the tooltip footer's "Skip tour" link for a "← Back" link that steps the tour backward instead of exiting it.

- tooltip: back-step service + hide_back flag (empty spacer keeps Next pinned right); the very first badge hides Back.
- main controller: add _prevStep(), route back-step to it.
- workspace step: walk its internal sub-badges on back-step (was a no-op forward that dead-ended in the main controller at index 0).
- step widgets forward back-step instead of skip-tour.
- scss: rename s1-skip -> s1-back.