### PR TITLE
feat(desk): right-click menu mirrors topbar — Create workspace, + New, Invite

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1477,6 +1477,7 @@
   "NEW_FILE": "New file",
   "NEW_WORKSPACE": "New Workspace",
   "CREATE_NEW_WORKSPACE": "Create new workspace",
+  "CREATE_WORKSPACE": "Create workspace",
   "CREATE_NEW_WORKSPACE_HINT": "Specify a name for your new organization unit.",
   "WORKSPACE_NAME_PLACEHOLDER": "e.g. Q4 Strategy",
   "INTERNAL_WORKSPACE": "Internal Workspace",

--- a/locale/es.json
+++ b/locale/es.json
@@ -393,6 +393,7 @@
   "STORAGE_GB": "Almacenamiento (GB)",
   "NO_USERS": "No se encontraron usuarios",
   "CREATE_NEW_WORKSPACE": "Crear nuevo espacio de trabajo",
+  "CREATE_WORKSPACE": "Crear espacio de trabajo",
   "CREATE_NEW_WORKSPACE_HINT": "Especifica un nombre para tu nueva unidad organizativa.",
   "WORKSPACE_NAME_PLACEHOLDER": "ej. Estrategia Q4",
   "INTERNAL_WORKSPACE": "Espacio de trabajo interno",

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -1202,6 +1202,7 @@
   "NEW_FILE": "Nouveau fichier",
   "NEW_WORKSPACE": "Nouvel espace de travail",
   "CREATE_NEW_WORKSPACE": "Créer un nouvel espace de travail",
+  "CREATE_WORKSPACE": "Créer un espace de travail",
   "CREATE_NEW_WORKSPACE_HINT": "Spécifiez un nom pour votre nouvelle unité organisationnelle.",
   "WORKSPACE_NAME_PLACEHOLDER": "ex. Stratégie Q4",
   "INTERNAL_WORKSPACE": "Espace de travail interne",

--- a/locale/km.json
+++ b/locale/km.json
@@ -1202,6 +1202,7 @@
   "NEW_FILE": "ឯកសារថ្មី",
   "NEW_WORKSPACE": "កន្លែងធ្វើការថ្មី",
   "CREATE_NEW_WORKSPACE": "បង្កើតកន្លែងធ្វើការថ្មី",
+  "CREATE_WORKSPACE": "បង្កើតកន្លែងធ្វើការ",
   "CREATE_NEW_WORKSPACE_HINT": "បញ្ជាក់ឈ្មោះសម្រាប់ឯកតាអង្គការថ្មីរបស់អ្នក។",
   "WORKSPACE_NAME_PLACEHOLDER": "ឧ. យុទ្ធសាស្ត្រ Q4",
   "INTERNAL_WORKSPACE": "កន្លែងធ្វើការផ្ទៃក្នុង",

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -1202,6 +1202,7 @@
   "NEW_FILE": "Новый файл",
   "NEW_WORKSPACE": "Новое рабочее пространство",
   "CREATE_NEW_WORKSPACE": "Создать новое рабочее пространство",
+  "CREATE_WORKSPACE": "Создать рабочее пространство",
   "CREATE_NEW_WORKSPACE_HINT": "Укажите название для вашей новой организационной единицы.",
   "WORKSPACE_NAME_PLACEHOLDER": "напр. Стратегия Q4",
   "INTERNAL_WORKSPACE": "Внутреннее рабочее пространство",

--- a/locale/zh.json
+++ b/locale/zh.json
@@ -1202,6 +1202,7 @@
   "NEW_FILE": "新文件",
   "NEW_WORKSPACE": "新工作区",
   "CREATE_NEW_WORKSPACE": "创建新工作区",
+  "CREATE_WORKSPACE": "创建工作区",
   "CREATE_NEW_WORKSPACE_HINT": "为您的新组织单位指定名称。",
   "WORKSPACE_NAME_PLACEHOLDER": "例如 Q4 战略",
   "INTERNAL_WORKSPACE": "内部工作区",

--- a/src/drumee/builtins/contextmenu/skeleton/classes.js
+++ b/src/drumee/builtins/contextmenu/skeleton/classes.js
@@ -5,10 +5,13 @@
 // ==================================================================== *
 
 const __classname = function(_ui_, trigger, k){
-  const cn = { 
+  const cn = {
     account: 'account',
+    addNew: 'add-new',
     background: 'desk-background',
     copy: 'copy',
+    createWorkspace: 'create-workspace blue',
+    inviteMember: 'invite-member',
     download:'download',
     fullscreen: 'fullscreen',
     exitFullScreen: 'exit-fullscreen',

--- a/src/drumee/builtins/contextmenu/skeleton/icons.js
+++ b/src/drumee/builtins/contextmenu/skeleton/icons.js
@@ -2,8 +2,10 @@
 const __icon = function (_ui_) {
   const a = {
     account: "desktop_account--white",
+    addNew: "topbar-add",
     background: "desktop_picture",
     copy: "desktop_copy",
+    createWorkspace: "addmenu-folder",
     delete: "ctxmenu-delete",
     duplicate: "file-copy",
     designationLink: "ctxmenu-designation-link",
@@ -19,6 +21,7 @@ const __icon = function (_ui_) {
     import: "server-import",
     importHidden: "server-import",
     info: "ctxmenu-info",
+    inviteMember: "topbar-invite",
     link: "editbox_link",
     lock: "protected-lock",
     makeACopy: "ctxmenu-copy",

--- a/src/drumee/builtins/contextmenu/skeleton/items.js
+++ b/src/drumee/builtins/contextmenu/skeleton/items.js
@@ -48,13 +48,26 @@ const __button = function (ui, trigger, k) {
         Skeletons.Note({ content: '›', className: `${pfx}__chevron` }),
         Skeletons.Box.Y({
           className: `${pfx}__submenu`,
+          // Same icons as the topbar Add-new menu (addmenu-* sprites carry
+          // their own colors). Interaction props live on the Box.X row;
+          // kids are inert (active: 0) so clicks resolve to the row.
           kids: [
-            button({ content: LOCALE.WORKSPACE, service: 'new-workspace', className: `${pfx} submenu-item`, uiHandler: [ui] }),
-            button({ content: LOCALE.NOTE, service: 'new-note', className: `${pfx} submenu-item`, uiHandler: [ui] }),
-            button({ content: LOCALE.DOCUMENT, service: 'new-document', name: 'document.docx', className: `${pfx} submenu-item`, uiHandler: [ui] }),
-            button({ content: LOCALE.SPREADSHEET, service: 'new-spreadsheet', name: 'spreadsheet.xlsx', className: `${pfx} submenu-item`, uiHandler: [ui] }),
-            button({ content: LOCALE.PRESENTATION, service: 'new-presentation', name: 'presentation.pptx', className: `${pfx} submenu-item`, uiHandler: [ui] }),
-          ],
+            { ico: 'addmenu-folder', label: LOCALE.WORKSPACE, service: 'new-workspace' },
+            { ico: 'addmenu-note', label: LOCALE.NOTE, service: 'new-note' },
+            { ico: 'addmenu-document', label: LOCALE.DOCUMENT, service: 'new-document', name: 'document.docx' },
+            { ico: 'addmenu-spreadsheet', label: LOCALE.SPREADSHEET, service: 'new-spreadsheet', name: 'spreadsheet.xlsx' },
+            { ico: 'addmenu-presentation', label: LOCALE.PRESENTATION, service: 'new-presentation', name: 'presentation.pptx' },
+          ].map((it) => Skeletons.Box.X({
+            className: `${pfx} submenu-item`,
+            service: it.service,
+            name: it.name,
+            uiHandler: [ui],
+            kidsOpt: { active: 0 },
+            kids: [
+              Skeletons.Image.Svg({ ico: it.ico, className: `${pfx}__icon` }),
+              Skeletons.Note({ content: it.label, className: `${pfx}__label` }),
+            ],
+          })),
         }),
       ],
     }),

--- a/src/drumee/builtins/contextmenu/skeleton/items.js
+++ b/src/drumee/builtins/contextmenu/skeleton/items.js
@@ -36,6 +36,29 @@ const __button = function (ui, trigger, k) {
 
     account: button({ content: LOCALE.MY_ACCOUNT, service: _a.account }),
 
+    // "+ New" parent: hover-expand submenu (same pattern as `organize`).
+    // Mirrors the topbar's "Add new" menu item-for-item so the desk
+    // background right-click offers the same creation flows. Services are
+    // Desk flows — Wm.onUiEvent delegates them up (wm/index.js).
+    addNew: Skeletons.Box.X({
+      content: LOCALE.ADD_NEW,
+      service: 'add-new',
+      kids: [
+        Skeletons.Note({ content: LOCALE.ADD_NEW, className: `${pfx}__label` }),
+        Skeletons.Note({ content: '›', className: `${pfx}__chevron` }),
+        Skeletons.Box.Y({
+          className: `${pfx}__submenu`,
+          kids: [
+            button({ content: LOCALE.WORKSPACE, service: 'new-workspace', className: `${pfx} submenu-item`, uiHandler: [ui] }),
+            button({ content: LOCALE.NOTE, service: 'new-note', className: `${pfx} submenu-item`, uiHandler: [ui] }),
+            button({ content: LOCALE.DOCUMENT, service: 'new-document', name: 'document.docx', className: `${pfx} submenu-item`, uiHandler: [ui] }),
+            button({ content: LOCALE.SPREADSHEET, service: 'new-spreadsheet', name: 'spreadsheet.xlsx', className: `${pfx} submenu-item`, uiHandler: [ui] }),
+            button({ content: LOCALE.PRESENTATION, service: 'new-presentation', name: 'presentation.pptx', className: `${pfx} submenu-item`, uiHandler: [ui] }),
+          ],
+        }),
+      ],
+    }),
+
     background: button({ content: LOCALE.SET_AS_BACKGROUND, service: 'set-as-background' }),
 
     // "Chat Threads" parent: hover-expand submenu (same pattern as `organize`).
@@ -60,6 +83,10 @@ const __button = function (ui, trigger, k) {
     }),
 
     copy: button({ content: LOCALE.COPY, service: _e.copy }),
+
+    // Opens the create-workspace modal (media_form: internal / external /
+    // personal type options) — the same flow as the topbar +New → Workspace.
+    createWorkspace: button({ content: LOCALE.CREATE_WORKSPACE, service: 'new-workspace' }),
 
     delete: button({ content: LOCALE.DELETE, service: _e.delete }),
 
@@ -94,6 +121,10 @@ const __button = function (ui, trigger, k) {
     importHidden: button({ content: LOCALE.IMPORT_FROM_SERVER, service: _a.none, type: _a.import, dataset: { state: _a.disable } }),
 
     info: button({ content: LOCALE.GET_INFO, service: _e.settings, type: _a.info }),
+
+    // Desk-background variant of the topbar Invite button: opens the
+    // invite-members popup (Desk._openInvitePopup via wm delegation).
+    inviteMember: button({ content: LOCALE.INVITE, service: 'invite-member' }),
 
     link: button({ content: LOCALE.SHARE_LINK, service: _a.link }),
 
@@ -240,10 +271,10 @@ const __button = function (ui, trigger, k) {
 
     }
 
-    // organize / seeChatThreads: already a Box.X submenu; its first kid is the
+    // organize / seeChatThreads / addNew: already a Box.X submenu; its first kid is the
     // __label Note. Just prepend the icon when one is mapped.
 
-    if (k === 'organize' || k === 'seeChatThreads') {
+    if (k === 'organize' || k === 'seeChatThreads' || k === 'addNew') {
 
       r.className = cls;
 

--- a/src/drumee/builtins/contextmenu/skin/index.scss
+++ b/src/drumee/builtins/contextmenu/skin/index.scss
@@ -86,6 +86,13 @@
       left: calc(100% - 8px);
       min-width: 220px;
       min-height: 84px;
+      // The submenu's className derives from the shared item pfx, so it ALSO
+      // carries `{group}__contextmenu-item` — and per-group ITEM rules like
+      // `.window__contextmenu-item { height: 36px }` clamp the PANEL itself.
+      // Rows then overflow the painted background (visible page-bg stripes
+      // between items once the list is taller than ~2 rows). Force content
+      // sizing; this selector out-specifies the group rule.
+      height: auto;
       // Same edge-to-edge treatment as the root menu: vertical padding only,
       // submenu items carry their own horizontal inset (8px 16px below).
       padding: 8px 0;

--- a/src/drumee/builtins/contextmenu/skin/index.scss
+++ b/src/drumee/builtins/contextmenu/skin/index.scss
@@ -70,6 +70,17 @@
       height: 16px;
       flex-shrink: 0;
       fill: currentColor;
+
+      // The window-group rule (.window__contextmenu-item svg → 20×20 +
+      // margin-right) leaks into these icons, so each sprite rendered at a
+      // different visual size inside the 16px box. Normalize: the inner svg
+      // fills the box exactly (this selector out-specifies the group rule).
+      svg {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        display: block;
+      }
     }
 
     &__label {

--- a/src/drumee/modules/desk/wm/index.js
+++ b/src/drumee/modules/desk/wm/index.js
@@ -29,12 +29,14 @@ class __window_manager extends push {
     if (Visitor.canServerImpExp()) {
       exportMenu = [_a.separator, _a.import];
     }
+    // Desk-background right-click mirrors the topbar actions: Create
+    // workspace (media_form modal), + New (same submenu as the topbar
+    // Add-new menu) and Invite (invite-members popup).
     this.contextmenuItems = [
-      _a.newFolder,
-      _a.paste,
-      _a.upload,
+      _a.createWorkspace,
+      _a.addNew,
       _a.separator,
-      _a.preferences,
+      _a.inviteMember,
     ];
     this._handelKbdEvents = this._handelKbdEvents.bind(this);
     RADIO_KBD.on(_e.keyup, this._handelKbdEvents);
@@ -1792,6 +1794,18 @@ class __window_manager extends push {
           area: _a.personal,
           filename: LOCALE.NEW_FOLDER,
         });
+
+      // Desk-background context menu (+ New submenu / Invite): these are
+      // Desk-owned flows — same handlers the topbar buttons hit — so
+      // delegate up instead of duplicating them here.
+      case "new-note":
+      case "new-document":
+      case "new-spreadsheet":
+      case "new-presentation":
+      case "invite-member":
+        return window.Desk
+          ? Desk.onUiEvent(cmd, { ...args, service })
+          : null;
 
       case _a.helpdesk:
         return this.launch(


### PR DESCRIPTION
Replaces the desk-background right-click menu (New folder / Paste / Upload / Preferences) with the three topbar flows, per ticket:

1. **Create workspace** — opens the `media_form` modal with its three workspace-type options (internal / external / personal), same as topbar **+ New → Workspace**.
2. **+ New** — hover submenu mirroring the topbar Add-new menu item-for-item: Workspace, Note, Document, Spreadsheet, Presentation (same services, same `name` template payloads).
3. **Invite** — opens the invite-members popup (same `invite-member` service as the topbar button).

Wm delegates the Desk-owned services (`new-note`, `new-document`, `new-spreadsheet`, `new-presentation`, `invite-member`) up to `Desk.onUiEvent` instead of duplicating the handlers. New `CREATE_WORKSPACE` locale key added to all six languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)