### PR TITLE
fix(tasks): board keeps built-in columns when a scope has only custom ones

### DIFF
--- a/src/drumee/builtins/window/tasks/index.js
+++ b/src/drumee/builtins/window/tasks/index.js
@@ -4538,24 +4538,18 @@ class __tasks_panel extends LetcBox {
   // `theme` the palette key driving pill tints, `custom` marks editability.
   getColumns() {
     const rows = this._customColumns || [];
-    // Before column_list resolves there are no rows yet — show the built-in
-    // defaults as non-editable placeholders so the board isn't momentarily
-    // empty. Once the server seeds + returns rows, every column is editable.
-    if (!rows.length) {
-      return COLUMNS.map((c, i) => ({
-        key: c.key,
-        name: LOCALE[c.label] || c.key,
-        theme: c.theme,
-        color: COLUMN_THEMES[c.theme] || COLUMN_THEMES.default,
-        is_done: c.key === "complete" ? 1 : 0,
-        position: i,
-        custom: 0, // placeholder — no DB row to reorder/rename/delete yet
-      }));
-    }
-    // All columns (built-in + custom) are stored rows now, so all are uniformly
-    // editable. A built-in id left at its seeded English name shows a localized
-    // title; a renamed one shows the stored name.
-    return rows.map((r) => {
+    // Has this scope been seeded? A single stored built-in row proves it has —
+    // and once seeded, a MISSING built-in means the user DELETED it, so it must
+    // stay deleted. Only when NO built-in row exists at all (column_list has
+    // not resolved yet, or the scope was never seeded) do we fall back to the
+    // defaults. Without that fallback a scope holding only custom columns
+    // renders those alone and silently hides every task whose status is a
+    // built-in key.
+    const seeded = rows.some((r) => BUILTIN_META[r.id]);
+    // Stored columns (built-in + custom) are uniformly editable. A built-in id
+    // left at its seeded English name shows a localized title; a renamed one
+    // shows the stored name.
+    const customs = rows.map((r) => {
       const bi = BUILTIN_META[r.id];
       const name = bi && r.name === bi.seed ? LOCALE[bi.label] || r.name : r.name || "";
       return {
@@ -4568,6 +4562,16 @@ class __tasks_panel extends LetcBox {
         custom: 1,
       };
     });
+    if (seeded) return customs;
+    return COLUMNS.map((c, i) => ({
+      key: c.key,
+      name: LOCALE[c.label] || c.key,
+      theme: c.theme,
+      color: COLUMN_THEMES[c.theme] || COLUMN_THEMES.default,
+      is_done: c.key === "complete" ? 1 : 0,
+      position: i,
+      custom: 0, // placeholder — no DB row to reorder/rename/delete yet
+    })).concat(customs);
   }
 
   // Completion is column-driven: a task is "done" when its column has is_done.


### PR DESCRIPTION
Hotfix off `preview`. Verified on drumee.in.

## Problem

Task boards showed **only their custom columns** — the four built-ins were missing, and every task sitting in a built-in status was invisible. On one production board that was **79 of 137 tasks** hidden.

`getColumns()` rendered the server's rows verbatim whenever any row came back, falling back to the built-in placeholders only when the list was completely empty. So a scope holding custom columns returned those alone and the built-ins never appeared.

The underlying cause is in schemas: `task_column` is keyed on `(id)` alone, but `task_column_list` seeds the built-ins **per folder scope** using their literal status keys as ids — so only the first scope opened can hold them, and every later scope's `INSERT IGNORE` silently stores nothing. Fixed separately in drumee/schemas#74, which needs server + UI work before it can be applied.

## Fix

Fall back to the built-in defaults unless the scope has **at least one stored built-in row**:

```js
const seeded = rows.some((r) => BUILTIN_META[r.id]);
```

Gating on "does any built-in exist" rather than per-key is what keeps a deliberately **deleted** built-in deleted on a seeded scope — so column delete/rename still persist. The path stops triggering entirely once scopes seed correctly.

Works against the SPs already on production; no schema change, no migration.

## Verification

The real function was extracted from source and executed against production row shapes:

| Case | Result |
|---|---|
| No rows (pre-resolve) | 4 placeholders — unchanged from before |
| **Custom columns only** | **built-ins + customs — FIXED** |
| Seeded scope | exactly the stored rows, **no duplicates** |
| Seeded, built-in deleted by user | **stays deleted** |
| Seeded, built-in renamed | preserved, editable |

Also confirmed: 13 `getColumns()` callers, **none sort by position**, so the returned order is the render order — built-ins first, then customs, matching previous behaviour.

Verified on drumee.in.

## Deploy

UI only. No DB change, no server dependency.
