### PR TITLE
fix(tutorial): Back from step 2 resumes step 1 on its last sub-badge

### DIFF
--- a/src/drumee/modules/desk/tutorial/index.js
+++ b/src/drumee/modules/desk/tutorial/index.js
@@ -58,9 +58,14 @@ class tutorial_main extends LetcBox {
   _prevStep() {
     if (this._stepIndex <= 0) return;
     this._stepIndex--;
+    // The workspace step (index 0) has internal sub-badges; when re-entered via
+    // Back it must land on its LAST badge (where it left off), not the first.
+    const widget = this._stepIndex === 0
+      ? { ...this._widgets[0], enter_at_last: true }
+      : this._widgets[this._stepIndex];
     this.ensurePart('spotlight').then((s) => s.clear && s.clear());
     this.ensurePart(_a.content).then((p) => {
-      p.feed(this._widgets[this._stepIndex])
+      p.feed(widget)
     })
   }
 

--- a/src/drumee/modules/desk/tutorial/workspace/index.js
+++ b/src/drumee/modules/desk/tutorial/workspace/index.js
@@ -26,6 +26,8 @@ class __tutorial_workspace extends LetcBox {
   }
 
   onDomRefresh() {
+    // When re-entered via Back from step 2, resume on the last sub-badge.
+    if (this.mget('enter_at_last')) this._stepIndex = BADGES.length - 1;
     this.feed(require('./skeleton')(this));
     this._showBadge();
   }


### PR DESCRIPTION
Going Back from the Folder step (2) re-fed a fresh workspace widget that always inits at sub-badge 0, dropping the user on the first workspace badge instead of the last one where step 1 had left off.

Pass an enter_at_last flag on the workspace descriptor when re-entering it via Back, and have the workspace step start at BADGES.length - 1 when that flag is set.