### PR TITLE
fix(tasks): send the folder scope when renaming, re-theming or deleting a column

### DIFF
--- a/src/drumee/builtins/window/tasks/index.js
+++ b/src/drumee/builtins/window/tasks/index.js
@@ -2440,6 +2440,10 @@ class __tasks_panel extends LetcBox {
       await this.postService({
         service: SERVICE.task.column_update,
         hub_id: this._hubId,
+        // Column ids are folder-scoped: the built-ins share their status keys
+        // across boards, so without nid the server would rename this column on
+        // every board in the workspace.
+        nid: this._scopeNid,
         id,
         name,
       });
@@ -2461,6 +2465,8 @@ class __tasks_panel extends LetcBox {
       await this.postService({
         service: SERVICE.task.column_update,
         hub_id: this._hubId,
+        // Folder-scoped — see _renameColumn.
+        nid: this._scopeNid,
         id,
         theme,
       });
@@ -2479,6 +2485,9 @@ class __tasks_panel extends LetcBox {
       const resp = await this.postService({
         service: SERVICE.task.column_delete,
         hub_id: this._hubId,
+        // Folder-scoped — without nid the server would delete this column from
+        // every board in the workspace (see _renameColumn).
+        nid: this._scopeNid,
         id,
       });
       const row = Array.isArray(resp) ? resp[0] : resp;


### PR DESCRIPTION
UI half of the task_column scope fix. Pairs with **drumee/schemas#74** and **drumee/server-team#107**.

## Why

`task_column` is keyed on `(id)` alone, but the built-ins are seeded **per folder scope** using their literal status keys as ids — so only the first board opened in a workspace can hold them. schemas#74 makes the key `(id, nid)`; under it, an unscoped update or delete would hit that column on **every** board.

## Change

Adds `nid: this._scopeNid` to the three remaining column call sites:

- `_renameColumn` → `task.column_update`
- `_themeColumn` → `task.column_update`
- `_deleteColumn` → `task.column_delete`

`column_create`, `column_list` and `column_reorder` already sent it. `_scopeNid` is set in `initialize` and refreshed whenever the scope changes, and this file holds a single class, so all thirteen usages resolve to the same property.

9 added lines, no logic changes. `node --check` clean.

## Deploy order

1. schemas#74 `_v2` procs (additive).
2. server#107 + this.
3. `alter_task_column_scope_pk.sql`.

Sending `nid` early is harmless — the current server ignores unknown params — so this can ship before or with the server half.

## Related

The board-rendering hotfix already on preview (`7e73dfe0`) is independent: it stops boards hiding tasks when a scope has no stored built-ins. Once this lands and scopes seed properly, that fallback simply stops triggering.