### PR TITLE
fix(billing): 'Cancel plan' no-ops during the pre-mirror render window

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/index.js
@@ -126,8 +126,19 @@ class settings_billing extends LetcBox {
     return lines.join("\n\n");
   }
 
+  // Synchronous "does the caller currently pay" signal — mirrors the quota
+  // check the banner skeleton uses (subscriptionBanner) so the "Cancel plan"
+  // banner button is clickable the instant it's visible. Without this, the
+  // banner (now rendered from quota on the very first paint, ticket
+  // 2026-07-22) showed "Cancel plan" for the ~1 round-trip _hasPaidSub is
+  // still async-false, and clicking it during that window silently no-opped.
+  _isPaidByQuota() {
+    const plan = String(((Visitor.quota && Visitor.quota()) || {}).plan || "").toLowerCase();
+    return /^(pro|team|enterprise)$/.test(plan);
+  }
+
   async _confirmCancel() {
-    if (!this._hasPaidSub || this._isCanceling) return;
+    if ((!this._hasPaidSub && !this._isPaidByQuota()) || this._isCanceling) return;
     const ok = await Wm.confirm({
       title: LOCALE.CANCEL_SUBSCRIPTION || "Cancel subscription",
       message: this._cancelConsequences(),
@@ -671,10 +682,15 @@ class settings_billing extends LetcBox {
     // Team→Pro switch (confirmed in the select-plan popup): flag the checkout
     // so the Stripe webhook cancels the org's Team subscription (at period
     // end) once THIS personal payment completes. Only meaningful for a
-    // personal purchase by a paying Team owner — never set otherwise.
-    if (entity_type === "user" && this._switchFromTeam && this._isPaidTeam()) {
+    // personal Pro purchase by a still-paying Team owner — never set
+    // otherwise. Single-use: cleared right after so a leftover flag can't
+    // attach to an unrelated later checkout in the same widget session (e.g.
+    // the user backs out to the plan picker and buys a plain Pro seat add-on
+    // afterwards).
+    if (entity_type === "user" && plan === "pro" && this._switchFromTeam && this._isPaidTeam()) {
       payload.supersede = "org";
     }
+    this._switchFromTeam = false;
     // TEAM bootstrap: the payer is still on the default domain — the org
     // name + subdomain were collected in the checkout form; validate the
     // ident server-side BEFORE the Stripe redirect (product decision: prompt

--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/index.js
@@ -85,7 +85,9 @@ function subscriptionBanner(ui) {
   // render the banner from the very first paint and let the renew date fill
   // in once the mirror lands (ticket 2026-07-22).
   const quotaPlan = String(((Visitor.quota && Visitor.quota()) || {}).plan || "").toLowerCase();
-  const paidByQuota = /^(pro|team|enterprise)$/.test(quotaPlan);
+  // Shared with the "Cancel plan" click guard (_isPaidByQuota) so the button
+  // is never rendered clickable without also being armed.
+  const paidByQuota = ui._isPaidByQuota ? ui._isPaidByQuota() : /^(pro|team|enterprise)$/.test(quotaPlan);
   if (!ui._hasPaidSub && !paidByQuota) return null;
   const fig = `${ui.fig.family}__sub-banner`;
   const when = ui._periodEnd ? Dayjs(ui._periodEnd * 1000).format("MMM D, YYYY") : "";


### PR DESCRIPTION
Follow-up code review on #343 (Team→Pro switch), caught while re-testing the case thoroughly.

**Bug:** the subscription banner now renders (correctly) from the synchronous quota plan on the very first paint — including the `Cancel plan` button — before `_hasPaidSub`'s async round-trip (`_loadSubscription()`) lands. `_confirmCancel()`'s guard only checked `_hasPaidSub`, so a click in that ~1-request window was a **silent no-op**: the button was visible and looked clickable but did nothing.

**Fix:** `_isPaidByQuota()` — the same quota check the banner skeleton uses — ORed into the guard, so the button is armed the instant it's rendered. Skeleton now calls the shared method instead of duplicating the regex.

**Also hardened** (found during the same review): the Team→Pro `supersede` flag is now scoped to `plan === 'pro'` explicitly (defense in depth) and cleared right after building the checkout payload — single-use, so a leftover `_switchFromTeam=true` can't attach to an unrelated later checkout in the same widget session. Not a live bug today (the existing `_isPaidTeam()` check at submit time already protected it), but worth closing off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)