### PR TITLE
feat(address-book): render contact avatars with the shared UserProfil…

### DIFF
--- a/src/drumee/builtins/widget/address-book/skeleton/contact-list.js
+++ b/src/drumee/builtins/widget/address-book/skeleton/contact-list.js
@@ -1,4 +1,7 @@
 const { actionBtn, iconBtn } = require("./action-buttons");
+// Same helper UserProfile uses for its auto_color, so the initials chip we
+// draw for account-less contacts picks the identical color.
+const { colorFromName } = require("@drumee/ui-essentials");
 
 module.exports = function (ui, contacts) {
   const fig = ui.fig.family;
@@ -31,9 +34,67 @@ module.exports = function (ui, contacts) {
     return value && value !== name ? value : "";
   };
 
-  const initials = (c) => {
-    const name = fullName(c).trim();
-    return (name[0] || "?").toUpperCase();
+  // Drumee uid the avatar picture is fetched with (Visitor.avatar). Contacts
+  // carry it in `entity` (my_contact_show_next), invitations in `drumate_id`.
+  // `entity` holds a raw email for contacts with no drumee account, so filter
+  // those out; null means "no picture to fetch" (see `avatar` below).
+  const avatarId = (c) => {
+    const uid = c.drumate_id || c.uid || c.entity || c.entity_id || "";
+    if (typeof uid !== "string" || !uid || looksLikeEmail(uid)) return null;
+    return uid;
+  };
+
+  // Same rule UserProfile.initiales() applies, so both branches below agree.
+  const initialsOf = (fn, ln, name) => {
+    const first = (fn || name || "?")[0] || "?";
+    return (first + (ln ? ln[0] : "")).toUpperCase();
+  };
+
+  // Same render path as widget-chatcontactItem (bigchat inbox): the shared
+  // UserProfile widget, which loads the real picture and tracks the live
+  // online dot — so a drumate looks identical in both lists.
+  //
+  // Contacts with no drumee account get the initials chip drawn here instead
+  // of an id-less UserProfile: Visitor.avatar() falls back to the *current*
+  // user's id, so a widget without an id would show our own face on every
+  // address-only contact. Same shape/colors either way.
+  const avatar = (c, name) => {
+    const uid = avatarId(c);
+    const fn = (c.firstname || "").trim();
+    const ln = (c.lastname || "").trim();
+    let inner;
+    if (uid) {
+      const opt = {
+        className: `${fig}__avatar`,
+        id: uid,
+        // UserProfile initials read firstname[0], so never hand it a blank.
+        firstname: fn || name,
+        fullname: name,
+        online: c.online,
+        live_status: 1,
+        auto_color: 1,
+      };
+      // Only pass a real lastname: an empty one makes the widget repeat the
+      // first letter ("JJ") instead of falling back to a single initial.
+      if (ln) opt.lastname = ln;
+      inner = Skeletons.UserProfile(opt);
+    } else {
+      const text = initialsOf(fn, ln, name);
+      inner = Skeletons.Box.Y({
+        className: `${fig}__avatar`,
+        styleOpt: { background: colorFromName(text || "??") },
+        kids: [
+          Skeletons.Note({
+            className: `${fig}__avatar-text`,
+            content: text,
+          }),
+        ],
+      });
+    }
+    return Skeletons.Box.X({
+      className: `${fig}__avatar-wrapper`,
+      kids: [inner],
+    });
   };
 
   // Best email for invite accept/refuse (mirrors contact-detail's pickEmail).
@@ -136,16 +197,7 @@ module.exports = function (ui, contacts) {
       uiHandler: [ui],
       contactKey: key,
       kids: [
-        Skeletons.Box.Y({
-          className: `${fig}__avatar`,
-          styleOpt: { background: c.color || "#e4e3ff" },
-          kids: [
-            Skeletons.Note({
-              className: `${fig}__avatar-text`,
-              content: initials(c),
-            }),
-          ],
-        }),
+        avatar(c, name),
         Skeletons.Box.Y({
           className: `${fig}__contact-text`,
           kids: [

--- a/src/drumee/builtins/widget/address-book/skin/index.scss
+++ b/src/drumee/builtins/widget/address-book/skin/index.scss
@@ -216,22 +216,87 @@
     }
   }
 
-  &__avatar {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    align-items: center;
-    justify-content: center;
+  // Mirrors widget-chatcontactItem__avatar-wrapper: relative host that never
+  // shrinks, and transparent to clicks so the whole row keeps firing
+  // `select-contact` even though the avatar may be a widget of its own. It
+  // also owns the avatar size, so both branches of contact-list's `avatar()`
+  // — the UserProfile widget and the plain initials chip — fill the same box
+  // and only one rule has to change per breakpoint.
+  &__avatar-wrapper {
+    position: relative;
     flex-shrink: 0;
     pointer-events: none;
+    width: 32px;
+    height: 32px;
+    // Never clip here: the online badge is a `:before` anchored to the
+    // avatar's bottom-right corner and overhangs the box.
+    overflow: visible;
   }
 
-  &__avatar-text {
+  // The widget variant carries `.user-profile__ui` too; restating the compound
+  // selector is how chatcontactItem__profile beats the widget's own 40px/50%
+  // defaults. Rounded square keeps the base's 48/12 ratio at this size (32/8).
+  // Rounding is clipped on the inner `.user-profile__main` (and on the chip's
+  // own background), NOT here — the root carries the online `:before`, so
+  // `overflow: hidden` at this level would cut the badge off.
+  &__avatar,
+  &__avatar.user-profile__ui {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    border: none;
+    border-radius: 8px;
+    overflow: visible;
+    align-items: center;
+    justify-content: center;
+  }
+
+  // The chip branch has no inner box to clip against, so it rounds itself.
+  &__avatar:not(.user-profile__ui) {
+    overflow: hidden;
+  }
+
+  &__avatar.user-profile__ui {
+    .user-profile__main,
+    & > .user-profile__main {
+      border-radius: 8px !important;
+      overflow: hidden;
+
+      img {
+        border-radius: 8px;
+      }
+    }
+
+    // Online dot: the widget default sits at a hardcoded left/top meant for
+    // 40px, so re-anchor it bottom-right like the chat inbox does. Kept inside
+    // the box (0/0, not negative) so it survives any clipping ancestor.
+    &[data-online="1"]:before,
+    &[data-online="2"]:before {
+      background-color: #847eff;
+      border-radius: 50%;
+      box-shadow: 0 0 0 2px var(--normal-bg);
+      content: " ";
+      height: 8px;
+      width: 8px;
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      left: auto;
+      top: auto;
+      z-index: 9;
+    }
+  }
+
+  // Initials: `__avatar-text` is the chip we draw, `.user-profile__initiales`
+  // the one the widget draws. Same type scale on both.
+  &__avatar-text,
+  &__avatar .user-profile__initiales .note-content {
     @include drumee.typo(
       $size: 12px,
       $weight: 600,
       $line: 16px,
-      $color: var(--primary-purple-100, #0b0a21)
+      $color: var(--ewhite, #fff)
     );
     text-transform: uppercase;
   }
@@ -1389,12 +1454,29 @@
       padding: 12px 14px;
     }
 
-    &__avatar {
+    &__avatar-wrapper {
       width: 44px;
       height: 44px;
     }
 
-    &__avatar-text {
+    &__avatar,
+    &__avatar.user-profile__ui {
+      border-radius: 11px;
+    }
+
+    &__avatar.user-profile__ui {
+      .user-profile__main,
+      & > .user-profile__main {
+        border-radius: 11px !important;
+
+        img {
+          border-radius: 11px;
+        }
+      }
+    }
+
+    &__avatar-text,
+    &__avatar .user-profile__initiales .note-content {
       font-size: 16px;
       line-height: 20px;
     }


### PR DESCRIPTION
…e widget

Contact rows drew their own initials chip, so a contact with a drumee account showed a letter in the address book while the bigchat inbox showed their actual photo. Route the list avatar through the same UserProfile widget widget-chatcontactItem uses: real picture, live online dot, matching rounded-square shape at 32px (44px on the wide sidebar breakpoint).

Contacts with no drumee account keep a locally drawn chip rather than an id-less UserProfile: Visitor.avatar() falls back to the *current* user's id, so a widget without an id would paint our own face on every address-only contact. Both branches share the shape and use colorFromName, so they are indistinguishable.

The uid the picture is fetched with is not the row key — keyOf() returns the contact row id, while my_contact_show_next returns the drumee uid in `entity` (invite_get in `drumate_id`), and `entity` holds a raw email for non-drumee contacts, which avatarId() filters out.

Initials also gain a second letter when a lastname exists ("JD" vs "J"). A blank lastname is omitted rather than passed empty — UserProfile repeats the first letter ("JJ") otherwise.