### PR TITLE
fix(list): patch ui-core to drop stale responses on refetch (subfolder delay + wrong parent)

### DIFF
--- a/patches/@drumee+ui-core+1.1.47.patch
+++ b/patches/@drumee+ui-core+1.1.47.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/@drumee/ui-core/letc/widgets/list/index.js b/node_modules/@drumee/ui-core/letc/widgets/list/index.js
+index 46969b0..838406c 100644
+--- a/node_modules/@drumee/ui-core/letc/widgets/list/index.js
++++ b/node_modules/@drumee/ui-core/letc/widgets/list/index.js
+@@ -149,6 +149,9 @@ class __list extends LetcBox {
+    */
+   start(reset = 0) {
+     this._curPage = 1;
++    // Invalidate any in-flight request issued before this (re)start — see the
++    // stale-response guard in fetch().
++    this._reqGen = (this._reqGen || 0) + 1;
+     this._waiting = false; // wait util data received
+     this._scrollY = 0;
+     this._lastScrollTop = 0;
+@@ -436,9 +439,24 @@ class __list extends LetcBox {
+     } else {
+       this.checkSpinner();
+     }
++    // Stale-response guard. restart()/start() resets the collection and
++    // refetches, but an in-flight request from the PREVIOUS api (e.g. the
++    // folder the user just navigated away from) is never cancelled — when it
++    // lands it would renderData() the old folder's rows into the new folder's
++    // list ("wrong subfolder shown"), and its _eod() would set
++    // _end_of_data = true, blocking every later fetch so the correct rows
++    // only appear seconds later, or not at all. Tie each request to the
++    // generation that issued it and drop anything from an older one.
++    const gen = this._reqGen;
+     this.fetchService(service, opt)
+-      .then(this.handleResponse.bind(this))
+-      .catch(this.onServerComplain.bind(this));
++      .then((data) => {
++        if (gen !== this._reqGen || this.isDestroyed()) return;
++        this.handleResponse(data);
++      })
++      .catch((e) => {
++        if (gen !== this._reqGen || this.isDestroyed()) return;
++        this.onServerComplain(e);
++      });
+     return opt;
+   }
+ 


### PR DESCRIPTION
**Reported (production, urgent):** subfolders take 3–10s to appear; occasionally a subfolder renders inside the **wrong** parent folder.

**Root cause — one missing guard in `@drumee/ui-core`'s list widget explains both.** `loadContent()` → `l.restart()` → `start(1)` resets the collection and issues a fresh `fetch()`, but the request already in flight for the *previous* api is never cancelled or invalidated. When it resolves:

1. it runs `handleResponse` → `renderData` → `collection.cleanSet(data)` — painting the folder the user just navigated **away from** into the list that now shows a different folder → **wrong subfolder shown**;
2. if that stale page was shorter than `pagelength` it also calls `_eod()`, setting `_end_of_data = true` on the **live** list — after which `fetch()` returns early on every later call, so the correct rows only appear once something else forces another `start()` → **the 3–10s (or never) delay**.

Verified statically end-to-end: `fetch()` has no abort and no sequence check, `handleResponse`'s own `_waiting = false` is commented out, and `renderData` calls `collection.cleanSet` unconditionally.

**Fix:** tag each request with the generation that issued it (`_reqGen`, bumped in `start()`) and ignore any response whose generation no longer matches, or whose view was destroyed meanwhile. No behaviour change on the non-racing path.

Delivered via `patch-package` (repo already uses this for `@drumee/ui-essentials`) so it ships without waiting on an npm release. Upstream source-of-truth PR: drumee/ui-core#1 — once that's released, bump `@drumee/ui-core` and drop this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)