### PR TITLE
fix(tasks): task notification opens the task, in the right folder

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -486,6 +486,7 @@
   "ACCEPTED_YOUR_INVITATION": "accepted your invitation",
   "TASK_ASSIGNED_ACTION": "assigned you to ",
   "TASK_MENTION_ACTION": "mentioned you in ",
+  "TASK_COMMENT_REPLY_ACTION": "replied to your comment in ",
   "DECLINED_YOUR_INVITATION": "declined your contact invitation",
   "CREATE_SHARED_FOLDER": "Create an external folder",
   "NOTES": "Notes:",

--- a/src/drumee/builtins/panel/activity/index.js
+++ b/src/drumee/builtins/panel/activity/index.js
@@ -367,9 +367,9 @@ class __panel_activity extends LetcBox {
           || (item && item.mget && item.mget('room_id')) || 0;
         if (hub_id && typeof Wm !== 'undefined') {
           try {
-            const open = ((Wm.getItemsByKind && Wm.getItemsByKind('window_folder')) || [])
-              .find((w) => !w.isDestroyed() && w.mget(_a.hub_id) == hub_id
-                && `${w.mget(_a.nid)}` === `${folderNid}`);
+            // Same "the window already showing this exact folder" lookup the
+            // notification tab deep link uses — one definition, in window/utils.
+            const open = Wm._findFolderWindow(hub_id, folderNid);
             if (open) {
               if (open.raise) open.raise();
               if (open.showFolderTab) open.showFolderTab(_a.chat);

--- a/src/drumee/builtins/panel/activity/widget/item/skeleton/index.js
+++ b/src/drumee/builtins/panel/activity/widget/item/skeleton/index.js
@@ -47,6 +47,21 @@ function getActivityMeta(ui, data) {
     data.event === 'mention'
     || getMentionIds(data).some((id) => String(id) === String(Visitor.id));
 
+  // 0. Reply to your task comment ("{author} replied to your comment in {task}").
+  // It rides the same task_mention row (data.kind='reply' → task_kind), so it
+  // MUST be checked before the mention branch below: channel.list_notifications
+  // synthesises mention_ids for every task row, which would otherwise label a
+  // plain reply "mentioned you in" — a claim the sender never made.
+  if (data.event === 'task_mention' && data.task_kind === 'reply') {
+    return {
+      before: LOCALE.TASK_COMMENT_REPLY_ACTION || 'replied to your comment in ',
+      label: data.task_title || name,
+      after: '',
+      colorClass: 'mention',
+      badge: 'mention',
+    };
+  }
+
   // 1. Mention is special — overrides any category branch.
   if (mentioned) {
     return {

--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -3102,12 +3102,27 @@ class __window_folder extends mfsInteract {
   // uses its own nid. `isRoot` also lets the panel surface legacy (nid-less)
   // tasks at the root only. Mirrors the breadcrumb's curNid resolution.
   _taskScopeArgs() {
-    const isRoot =
-      this.mget(_a.filetype) === _a.hub && this.mget(_a.actual_home_id);
+    const nid = this.mget(_a.nid);
+    const homeId = this.mget(_a.actual_home_id);
+    const isHubWindow = this.mget(_a.filetype) === _a.hub && homeId;
+    // A workspace window KEEPS filetype 'hub' after navigating into a subfolder
+    // (only its nid/filename follow the navigation), so filetype alone reported
+    // "I am the root" while the window was showing a subfolder — scoping the
+    // task panel to the workspace root and hiding that subfolder's tasks. Treat
+    // it as the root only while it is actually showing the root node; anything
+    // else is a real subfolder and scopes to its own nid, exactly like a
+    // plain folder window already does.
+    const inSubfolder =
+      isHubWindow &&
+      nid &&
+      `${nid}` !== "0" &&
+      `${nid}` !== `${homeId}` &&
+      `${nid}` !== `${this.mget(_a.hub_id)}`;
+    const isRoot = isHubWindow && !inSubfolder;
     return {
-      scopeNid: isRoot ? this.mget(_a.actual_home_id) : this.mget(_a.nid),
+      scopeNid: isRoot ? homeId : nid,
       isRoot: isRoot ? 1 : 0,
-      destNid: this.mget(_a.actual_home_id) || this.mget(_a.nid),
+      destNid: homeId || nid,
     };
   }
 
@@ -3136,6 +3151,13 @@ class __window_folder extends mfsInteract {
     // exactly like a freshly launched window does.
     if (task_id && !mounted) this.mset("open_task_id", task_id);
     const shown = this.showFolderTab(_a.task);
+    // showFolderTab returns early when the Task tab is ALREADY the active one,
+    // so the panel would keep the scope it was mounted with — the workspace
+    // root, when the tab was first opened while this window sat at the root.
+    // Re-assert the scope of the folder the window is on NOW. setScope is a
+    // no-op when the scope is unchanged, so this costs nothing in the common
+    // case (switching tabs already re-scopes via showFolderTab).
+    if (mounted) this.scopeTasksToFolder();
     if (!task_id) return shown;
     return Promise.resolve(shown).then(() => {
       const p = this._taskPanel;

--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -3126,6 +3126,28 @@ class __window_folder extends mfsInteract {
     });
   }
 
+  // Deep link from a task mention/assignment notification on a window that is
+  // ALREADY open: show the Task tab and open that task's detail. The mount-time
+  // `open_task_id` (read in the tasks panel's initialize) only ever fires on a
+  // fresh mount, so a panel that is already mounted has to be told directly.
+  openTaskDeepLink(task_id) {
+    const mounted = this._taskPanelMounted;
+    // Not mounted yet → the panel picks the id up from the model as it mounts,
+    // exactly like a freshly launched window does.
+    if (task_id && !mounted) this.mset("open_task_id", task_id);
+    const shown = this.showFolderTab(_a.task);
+    if (!task_id) return shown;
+    return Promise.resolve(shown).then(() => {
+      const p = this._taskPanel;
+      if (p && !(p.isDestroyed && p.isDestroyed()) && _.isFunction(p.openTaskById)) {
+        p.openTaskById(task_id);
+      }
+      // Consumed: a later remount of the panel (the Meeting view resets it)
+      // must not reopen this task out of the blue.
+      if (!mounted) this.mset("open_task_id", null);
+    });
+  }
+
   // Keep folder-chat scope in sync with the navigated folder so the right-side
   // chat panel reflects the current folder's messages even on the Files tab.
   // Snapshot must run before super (which overwrites the model via

--- a/src/drumee/builtins/window/tasks/index.js
+++ b/src/drumee/builtins/window/tasks/index.js
@@ -320,6 +320,23 @@ class __tasks_panel extends LetcBox {
     }
   }
 
+  // Same deep link as above, but for a panel that is ALREADY mounted: the
+  // mount-time `open_task_id` is consumed once in onDomRefresh, so a second
+  // notification click (folder already open) has to reach the detail this way.
+  // Called by the folder window's openTaskDeepLink.
+  openTaskById(id) {
+    if (!id) return;
+    // Not rendered yet, or the list is still loading: hand it back to the
+    // mount-time path, which opens the detail as soon as the list lands.
+    if (!this.el || !this._tasks || !this._tasks.length) {
+      this._openTaskId = id;
+      return;
+    }
+    // Same guard as onDomRefresh — only open a task that really belongs to this
+    // folder's list, never an empty detail panel.
+    if (this._tasks.some((t) => t.id === id)) this._openDetail(id);
+  }
+
   // Files dragged from the home grid use Drumee's internal jQuery-UI drag, not
   // native dataTransfer — register the panel as a droppable so they attach.
   _installMediaDroppable() {

--- a/src/drumee/builtins/window/tasks/index.js
+++ b/src/drumee/builtins/window/tasks/index.js
@@ -2712,8 +2712,12 @@ class __tasks_panel extends LetcBox {
     // A reply may target a root or a child. Flatten it to a sibling under the
     // root (parent_id = root) so threads stay 1-level, mirroring the skeleton's
     // orphan fallback (a reply whose parent is gone counts as its own root).
-    // When answering a child, also notify that child's author — the backend
-    // only auto-notifies the parent_id (root) author.
+    // When answering a child, that child's author is invisible to the backend
+    // (it only sees parent_id = root), so name them via reply_to_uid — the new
+    // server notifies them as a REPLY (not a mention) and pulls them back out of
+    // mention_uids. They stay in mention_uids as well so an OLD server (deployed
+    // before this) still notifies them exactly as it did before — the two
+    // deploys are independent in either order.
     const ids = new Set((this._comments || []).map((c) => String(c.id)));
     const clicked = (this._comments || []).find(
       (c) => String(c.id) === String(clickedId),
@@ -2724,7 +2728,8 @@ class __tasks_panel extends LetcBox {
     const mentions = Array.isArray(draft.mention_uids)
       ? draft.mention_uids.slice()
       : [];
-    if (repliesToChild && clicked.author_uid) mentions.push(clicked.author_uid);
+    const replyToUid = repliesToChild ? clicked.author_uid : null;
+    if (replyToUid) mentions.push(replyToUid);
     const taskId = this._detailId;
     try {
       await this.postService({
@@ -2734,6 +2739,7 @@ class __tasks_panel extends LetcBox {
         parent_id: rootId,
         body,
         mention_uids: [...new Set(mentions)],
+        ...(replyToUid ? { reply_to_uid: replyToUid } : {}),
       });
       this._replyingTo = null;
       this._replyDraft = null;

--- a/src/drumee/builtins/window/tasks/index.js
+++ b/src/drumee/builtins/window/tasks/index.js
@@ -310,13 +310,14 @@ class __tasks_panel extends LetcBox {
     ]);
     this._render();
     // Deep-link: a mention/assignment notification asked to open a specific
-    // task. Only open the detail if the task is actually in this folder's list —
-    // otherwise (legacy nid-less notification, or a task moved elsewhere) stay
-    // on the task list instead of showing an empty detail panel.
+    // task. Routed through openTaskById so this path also recovers when the
+    // task is missing from the load that just finished (it can be newer than
+    // the rows this panel was serving) instead of silently staying on the
+    // board. It still refuses to open a task belonging to another folder.
     if (this._openTaskId) {
       const id = this._openTaskId;
       this._openTaskId = null;
-      if (this._tasks.some((t) => t.id === id)) this._openDetail(id);
+      this.openTaskById(id);
     }
   }
 
@@ -324,13 +325,25 @@ class __tasks_panel extends LetcBox {
   // mount-time `open_task_id` is consumed once in onDomRefresh, so a second
   // notification click (folder already open) has to reach the detail this way.
   // Called by the folder window's openTaskDeepLink.
-  openTaskById(id) {
+  async openTaskById(id) {
     if (!id) return;
-    // Not rendered yet, or the list is still loading: hand it back to the
-    // mount-time path, which opens the detail as soon as the list lands.
-    if (!this.el || !this._tasks || !this._tasks.length) {
+    // Not rendered yet: hand it back to the mount-time path, which opens the
+    // detail as soon as the first load lands.
+    if (!this.el) {
       this._openTaskId = id;
       return;
+    }
+    // The board routinely PREDATES the task the notification points at: the
+    // panel caches its rows, and reopening the Task tab calls setScope, which
+    // skips the refetch when the scope has not changed. So a task created after
+    // this panel last loaded is simply absent — it only appeared after a full
+    // page reload, and the deep link below then found nothing to open. Refresh
+    // once before concluding the task is not in this folder.
+    if (!Array.isArray(this._tasks) || !this._tasks.some((t) => t.id === id)) {
+      await this._loadTasks();
+      // The window can be closed while the refetch is in flight.
+      if (!this.el || (this.isDestroyed && this.isDestroyed())) return;
+      this._render();
     }
     // Same guard as onDomRefresh — only open a task that really belongs to this
     // folder's list, never an empty detail panel.

--- a/src/drumee/builtins/window/utils.js
+++ b/src/drumee/builtins/window/utils.js
@@ -1105,9 +1105,40 @@ class __window_mfs extends DrumeeMFS {
       ...node,
     });
 
+    // Deep link from a notification that targets a specific TAB of the folder
+    // (task mention/assignment → Task, team chat → Chat). The generic
+    // "already rendered → open-node" shortcut below cannot carry a tab: it only
+    // re-focuses the node — or, when the match is the folder's CELL in an open
+    // parent window, opens a second window on Files — silently dropping
+    // activeTab/open_task_id. That is why these notifications only landed
+    // correctly while the folder was closed. So when a tab was asked for, reuse
+    // the folder's own window and switch it there; if no such window is open,
+    // fall through to the normal launch path, which already carries activeTab
+    // and open_task_id through `opt`.
+    const wantTab = data.activeTab;
+
     /** Direct open from the Wm if if possible */
     let found = this._findMediaByNid(nid);
-    if (found) {
+    if (wantTab && !highlight) {
+      // The folder's own window — matched on hub+nid, or the already-rendered
+      // node itself when that node IS a tab-capable window (a grid cell is not).
+      // The second form guarantees we can never open a duplicate window for a
+      // folder that is demonstrably already on screen.
+      const win =
+        this._findFolderWindow(hub_id, nid) ||
+        (found && _.isFunction(found.showFolderTab) ? found : null);
+      if (win) {
+        if (win.raise) win.raise();
+        // A task deep link carries the task to open; openTaskDeepLink switches
+        // to the Task tab itself. Anything else just switches tab.
+        if (data.open_task_id && _.isFunction(win.openTaskDeepLink)) {
+          win.openTaskDeepLink(data.open_task_id);
+        } else if (_.isFunction(win.showFolderTab)) {
+          win.showFolderTab(wantTab);
+        }
+        return win;
+      }
+    } else if (found) {
       // Already rendered in an open window: a reveal just scrolls/flashes/
       // highlights in place; a normal open triggers the node's open action.
       if (highlight) {
@@ -1266,6 +1297,32 @@ class __window_mfs extends DrumeeMFS {
       Wm.getItemsByAttr(_a.nid, key)[0] ||
       (key !== "" && !isNaN(num) ? Wm.getItemsByAttr(_a.nid, num)[0] : undefined)
     );
+  }
+
+  /**
+   * The open `window_folder` showing exactly this folder (same hub, same nid),
+   * or null. Lets a notification deep link reuse the window the user already
+   * has open — raising it and switching its tab — instead of stacking a second
+   * window on the same folder. Shared by the tab deep link in openFileLocation
+   * and the activity panel's meeting-row handler.
+   */
+  _findFolderWindow(hub_id, nid) {
+    if (typeof Wm === "undefined" || !_.isFunction(Wm.getItemsByKind)) return null;
+    try {
+      const open = Wm.getItemsByKind("window_folder") || [];
+      return (
+        open.find(
+          (w) =>
+            w &&
+            !(w.isDestroyed && w.isDestroyed()) &&
+            w.mget(_a.hub_id) == hub_id &&
+            `${w.mget(_a.nid)}` === `${nid}`,
+        ) || null
+      );
+    } catch (e) {
+      if (this.warn) this.warn("[_findFolderWindow] lookup failed", e);
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
Hotfix off `preview`. Verified on drumee.in (test) by Duy. UI-only — pairs with drumee/server-team#112 but neither blocks the other.

## Issues

**1. The notification could not reach the task when its folder was already on screen.** `openFileLocation` short-circuits on "this nid is already rendered" and calls `open-node`, which cannot carry a tab: it re-focused the folder, or — when the match was the folder's *cell* in an open parent window — opened a second window on the Files tab, dropping `activeTab` and `open_task_id`. When a tab is requested we now reuse the window already showing that exact folder and switch it there; with no such window we fall through to the unchanged launch path. Callers passing no `activeTab` (files, search, gdrive, reveal-with-highlight) keep the old branch. The window lookup is shared with the activity panel's meeting row, which had it inline.

**2. The task board showed the WRONG folder's tasks.** A workspace window keeps `filetype: 'hub'` after navigating into a subfolder — only its nid and title follow. `_taskScopeArgs` decided root-ness from `filetype` alone, scoping the panel to `actual_home_id`; the board listed the root's tasks and the subfolder's were nowhere, so a deep link could never find its task. Captured live: `nid=<subfolder>`, title `"Task"`, `filetype:"hub"` reported `scope:<root>`, `isRoot:1`. Root-ness now follows what the window is currently showing. **Pre-existing bug** — opening the Task tab after navigating into a subfolder always showed the root's tasks. Old vs new logic run over all 54 combinations of `filetype` x `actual_home_id` x `nid`: exactly one differs — the broken case. `destNid` is identical everywhere, so upload/attachment targets are untouched.

**3. A newly assigned task stayed invisible until reload.** The panel caches its rows and `setScope` skips the refetch when scope is unchanged, so the board could predate the notification's task. `openTaskById` now refreshes once before concluding the task is not here; the mount-time deep link routes through the same method. Both keep the guard that a task from another folder never opens an empty detail.

**4. A reply read "mentioned you in".** Now "replied to your comment in", keyed off `task_kind` from the server, checked before the mention branch (`channel.list_notifications` synthesises `mention_ids` for every task row).

**5. Replying to a reply still said "mentioned you".** Threads are flattened to one level, so answering a child comment had pushed that author into `mention_uids` (the only way the server saw them). They now go in the new optional `reply_to_uid` so the server notifies them as a reply. They stay in `mention_uids` too, so a server without the parameter behaves exactly as before — the deploys are order-independent.

## Notes

- `TASK_COMMENT_REPLY_ACTION` is added to `locale/en.json` only, matching its siblings `TASK_ASSIGNED_ACTION` / `TASK_MENTION_ACTION` (also en-only); there is an in-code English fallback. Worth translating all three together.
- Behaviour outside the notification flow changes in exactly one place: opening the Task tab in a subfolder of a workspace window now lists that subfolder's tasks instead of the root's.
