### PR TITLE
fix(billing): keep active checkout plan through subscription re-syncs

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/index.js
@@ -281,11 +281,22 @@ class settings_billing extends LetcBox {
       // 'month'/'monthly' => monthly; 'year'/'yearly' => yearly. (The old
       // /^moth/ typo never matched, so checkout always pre-selected yearly.)
       billing_cycle = /^month/i.test(billing_cycle || "") ? "monthly" : (/^year/i.test(billing_cycle || "") ? "yearly" : "monthly");
-      // Update checkout state with current plan, seats, and storage
-      this.state.checkout.selectedPlan = mappedPlan;
-      this.state.checkout.billingCycle = billing_cycle;
-      this.state.checkout.seats = total_seat || 0;
-      this.state.checkout.storage = storageGB;
+      // Seed the checkout form from the CURRENT plan — but ONLY while the user
+      // isn't already in the checkout tab. fetchPlanData re-runs on every
+      // subscription re-sync (the initial load's slow ~5s round-trip, a
+      // payment.plan_updated WS event, a visibilitychange), and each run used
+      // to overwrite the checkout selection with the current plan. So a Team
+      // owner who clicked "Choose Pro" → confirm → checkout would, ~5s later,
+      // have selectedPlan silently reverted from 'pro' back to 'team': the
+      // payment form flips to their existing plan and the switch is lost
+      // (QA: "clicking checkout bounces back to subscription management"). The
+      // user's active checkout selection must win over a background re-sync.
+      if (this.state.currentTab !== TAB_CHECKOUT) {
+        this.state.checkout.selectedPlan = mappedPlan;
+        this.state.checkout.billingCycle = billing_cycle;
+        this.state.checkout.seats = total_seat || 0;
+        this.state.checkout.storage = storageGB;
+      }
       // Store plan data for reference
       this.currentPlan = {
         plan: planName,


### PR DESCRIPTION
## Problem
[Billing] Team → Pro checkout bounces back to the subscription-management view.

A Team owner clicks **Choose Pro** → confirm → the checkout form opens on Pro. ~5s later the form silently reverts to **Team** (their existing plan) and the switch is lost. QA reported it as "clicking checkout bounces back to subscription management page and gets lost".

## Root cause
`fetchPlanData()` re-seeds the checkout form (`state.checkout.selectedPlan` + `seats` / `storage` / `billingCycle`) from the **current** plan on every run. It runs not just on first paint but on:
- the initial load's slow (~5s) `_loadSubscription()` round-trip (`onDomRefresh`),
- `payment.plan_updated` WS events,
- every `visibilitychange` re-sync.

So a background re-sync fired ~5s after entering checkout and clobbered the user's `pro` selection back to `team`, while the tab stayed on checkout — the payment form flipped to the plan they already had.

## Fix
Only re-seed the checkout form while the user is **not** already on the checkout tab (`currentTab !== TAB_CHECKOUT`). The active checkout selection now wins over background re-syncs. `currentPlanName` still updates unconditionally, so the current-plan banner keeps reflecting reality.

One guard covers all three callers (initial slow load, WS event, visibilitychange).

## Verification
Reproduced live on the vudangnt dev endpoint (mocked `Visitor.quota()` → team, slowed `_loadSubscription` 5s): before the fix the late `fetchPlanData()` reverted `selectedPlan` `pro`→`team`; with the guard the selection stays `pro` and the tab stays on checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)