### PR TITLE
fix(activity): single-file upload notification shows the file name

### DIFF
--- a/src/drumee/builtins/panel/activity/widget/item/skeleton/index.js
+++ b/src/drumee/builtins/panel/activity/widget/item/skeleton/index.js
@@ -235,9 +235,16 @@ function getActivityMeta(ui, data) {
       {
         const itemFiletype = data.item_filetype || data.uploaded_filetype || ui.mget('item_filetype');
         const createdFolder = itemFiletype ? itemFiletype === _a.folder : ui.isFolder();
+        // A single-file upload shows the file's OWN name (item_filename, carried
+        // by the server rollup); a multi-file rollup keeps the destination
+        // folder/workspace name with "and N more". `name` (getItemName) is the
+        // folder/workspace; item_filename is absent on raw feed rows (which
+        // already resolve `name` to the file), so this only refines the rollup.
+        const single = cnt <= 1;
+        const label = (!createdFolder && single && data.item_filename) ? data.item_filename : name;
         return {
           before: createdFolder ? 'created folder ' : 'uploaded file ',
-          label: name,
+          label,
           after: cnt > 1 ? ` and ${cnt - 1} more` : '',
           colorClass: 'mention',
           badge: 'mention',


### PR DESCRIPTION
Pairs with schemas PR #79 and server PR #115 (`hotfix/upload-noti-filename`).

A single-file upload rollup (`cnt ≤ 1`) now labels with the uploaded file's own name (`item_filename`, carried by the server) instead of its destination folder; multi-file rollups keep the folder/workspace name with 'and N more'.

Safe/no-regression: raw feed rows carry no `item_filename` and already resolve the file via `getItemName`, so they're unchanged; created-folder rows are unchanged; when the server/SP haven't shipped `item_filename` yet, the label falls back to the existing name.