### PR TITLE
fix(activity): folder-chat meeting rows read "started/ended a meeting in <folder>"

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -487,6 +487,8 @@
   "TASK_ASSIGNED_ACTION": "assigned you to ",
   "TASK_MENTION_ACTION": "mentioned you in ",
   "TASK_COMMENT_REPLY_ACTION": "replied to your comment in ",
+  "STARTED_MEETING_ACTION": "started a meeting in ",
+  "ENDED_MEETING_ACTION": "ended a meeting in ",
   "DECLINED_YOUR_INVITATION": "declined your contact invitation",
   "CREATE_SHARED_FOLDER": "Create an external folder",
   "NOTES": "Notes:",

--- a/src/drumee/builtins/panel/activity/widget/item/skeleton/index.js
+++ b/src/drumee/builtins/panel/activity/widget/item/skeleton/index.js
@@ -166,6 +166,22 @@ function getActivityMeta(ui, data) {
       };
 
     case 'teamchat':
+      // A folder-chat rollup whose latest unread meeting event is a start/end
+      // (notification_center_next surfaces it as meeting_action, giving meetings
+      // priority over plain chat). Render "<actor> started/ended a meeting in
+      // <folder>" — actor name + avatar come from the same author fields. No count
+      // suffix here (a meeting event is a single fact, not a message tally).
+      if (data.meeting_action === 'start' || data.meeting_action === 'end') {
+        return {
+          before: data.meeting_action === 'start'
+            ? (LOCALE.STARTED_MEETING_ACTION || 'started a meeting in ')
+            : (LOCALE.ENDED_MEETING_ACTION || 'ended a meeting in '),
+          label: name,
+          after: '',
+          colorClass: 'mention',
+          badge: 'mention',
+        };
+      }
       return {
         before: 'posted in ',
         label: name,


### PR DESCRIPTION
Hotfix off preview. Batch 3 of the notification program (pairs with schemas + server `hotfix/noti-teamchat-actor`).

The team-chat rollup now carries `meeting_action` (`start`|`end`) from `notification_center_next`, with meetings taking priority over plain chat. In `getActivityMeta`, a folder-chat row with `meeting_action` start/end renders **"<user> started/ended a meeting in <folder>"** (no count suffix — a meeting is a single fact); plain folder chat still reads **"posted in <folder> (N)"**. The actor name + avatar come from the `author_*` fields the SP now provides (this is what fixes "Someone posted…" + the wrong/viewer-own avatar).

New `STARTED_MEETING_ACTION` / `ENDED_MEETING_ACTION` locale keys (en.json) with in-code English fallbacks — same pattern as the existing `TASK_*_ACTION` keys (other langs get English via the fallback; i18n follow-up is non-blocking).

Depends on the schemas + server PRs. No prod deploy — bundled with the held notification work (Lexis notif #312, task-assignee #325, etc.).