### PR TITLE
fix(settings): make "Download all" actually deliver a usable archive

### DIFF
--- a/src/drumee/builtins/widget/settings/export-data/index.js
+++ b/src/drumee/builtins/widget/settings/export-data/index.js
@@ -16,6 +16,25 @@ class settings_export_data extends LetcBox {
 
   onDomRefresh() {
     this.feed(require("./skeleton").default(this));
+    this._loadSizes();
+  }
+
+  /**
+   * Real byte sizes per category, so the dialog states what the download will
+   * actually contain instead of the fixed placeholders it used to print. Fire
+   * and forget: the dialog is usable while this is in flight (each row shows a
+   * dash), and a failure just leaves the dashes rather than blocking the export.
+   */
+  _loadSizes() {
+    this.fetchService(SERVICE.drumate.backup_size, { hub_id: Visitor.id })
+      .then((data) => {
+        if (!data || this.isDestroyed()) return;
+        this._sizes = data;
+        this.feed(require("./skeleton").default(this));
+      })
+      .catch((e) => {
+        this.warn("export-data: backup_size failed", e);
+      });
   }
 
   toggleSelection(key) {
@@ -38,23 +57,38 @@ class settings_export_data extends LetcBox {
         progress.suppress();
       }
       this._isDownloading = data.zipid;
+      this._pendingBackup = false;
       let { svc, keysel } = bootstrap();
       let hub_id = this.mget(_a.hub_id);
       let nid = this.mget(_a.nid) || 0;
       let url = `${svc}media.zip?hub_id=${hub_id}&nid=${nid}&id=${data.zipid}&keysel=${keysel}&zipname=${data.zipname}`;
+      // The `download` attribute OVERRIDES the server's
+      // Content-Disposition filename, and data.zipname arrives without a
+      // suffix ("Snake1-__drumee.in"). The browser therefore saved an
+      // extension-less file that the OS could not open — the archive was
+      // there, but to the user "the download didn't work". Re-attach .zip.
+      const zipname = data.zipname || "backup";
       let a = document.createElement("a");
       a.href = url;
-      a.download = data.zipname || "backup.zip";
+      a.download = /\.zip$/i.test(zipname) ? zipname : `${zipname}.zip`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
-      if (this._zipsize > MAX_BLOB_SIZE) {
-        Wm.alert(LOCALE.DOWNLOAD_LONG_TIME.format(data.zipname, filesize(this._zipsize)));
+      // Warn on a big archive. The size has to come off the completion event:
+      // drumate.backup answers {zipid, status:'queued'} before anything is
+      // compressed, so the old `this._zipsize = data.size` was always 0 and
+      // this warning never fired once — not even for the 585 MB archive this
+      // was reproduced with, leaving the user staring at a screen that looked
+      // like nothing had happened.
+      const zipsize = data.size || data.zipsize || this._zipsize || 0;
+      if (zipsize > MAX_BLOB_SIZE) {
+        Wm.alert(LOCALE.DOWNLOAD_LONG_TIME.format(a.download, filesize(zipsize)));
       }
       return;
     }
 
     if (data.exit > 0) {
+      this._pendingBackup = false;
       if (progress && !progress.isDestroyed()) {
         progress.feed(
           Skeletons.Note({
@@ -132,6 +166,11 @@ class settings_export_data extends LetcBox {
   }
 
   downloadAll() {
+    // One archive at a time. Every click spawns a server-side compression of
+    // the entire account (585 MB in testing); with no feedback for the minute
+    // or two that takes, an impatient second click used to start a second one.
+    if (this._pendingBackup) return;
+    this._pendingBackup = true;
     this.postService(SERVICE.drumate.backup, {
       hub_id: Visitor.id,
       flags: ["files", "chat", "workspace", "activity"],
@@ -152,7 +191,11 @@ class settings_export_data extends LetcBox {
         });
       })
       .catch((e) => {
+        this._pendingBackup = false;
         this.warn("downloadAll: backup failed", e);
+        if (Wm && Wm.alert) {
+          Wm.alert(LOCALE.SOMETHING_WENT_WRONG || "Something went wrong. Please try again.");
+        }
       });
   }
 }

--- a/src/drumee/builtins/widget/settings/export-data/skeleton/index.js
+++ b/src/drumee/builtins/widget/settings/export-data/skeleton/index.js
@@ -1,3 +1,5 @@
+const { filesize } = require("@drumee/ui-essentials");
+
 function exportItem(ui, { key, title, size }) {
   const pfx = ui.fig.family;
   const checked = ui._selected.has(key);
@@ -47,26 +49,36 @@ function footerButton(ui, opt) {
 export default function export_data_skeleton(ui) {
   const pfx = ui.fig.family;
 
+  // Real per-category bytes from drumate.backup_size, counted off the same
+  // rows the archiver walks. These were hardcoded — every account saw
+  // "240 MB / 12 MB / 88 MB / 2 MB" no matter what it held, which is why the
+  // 342 MB shown here didn't match the 585 MB that came down. Until the
+  // figures arrive (or if the call fails) show a dash: a placeholder number
+  // is worse than admitting we don't know yet.
+  const sizes = ui._sizes || {};
+  const shown = (key) =>
+    sizes[key] == null ? "—" : filesize(sizes[key]);
+
   const items = [
     {
       key: "files",
       title: LOCALE.DELETE_ACCOUNT_EXPORT_FILES || "Files & Uploads",
-      size: "240 MB",
+      size: shown("files"),
     },
     {
       key: "chat",
       title: LOCALE.DELETE_ACCOUNT_EXPORT_CHAT || "Chat history",
-      size: "12 MB",
+      size: shown("chat"),
     },
     {
       key: "workspace",
       title: LOCALE.DELETE_ACCOUNT_EXPORT_WORKSPACE || "Workspace data",
-      size: "88 MB",
+      size: shown("workspace"),
     },
     {
       key: "activity",
       title: LOCALE.DELETE_ACCOUNT_EXPORT_ACTIVITY || "Activity log",
-      size: "2 MB",
+      size: shown("activity"),
     },
   ];
 


### PR DESCRIPTION
Reproduced end to end on stage against a real **585 MB** export. Four faults; the first one is the reported symptom.

### 1. The saved file had no extension — this is why "download doesn't work"

The anchor's `download` attribute **overrides** the server's `Content-Disposition`, and the zipname arrives without a suffix (`Snake1-__drumee.in`). The browser wrote an extension-less file the OS wouldn't open.

The archive itself was fine the whole time — verified: `200`, `application/zip`, `585,622,338` bytes, `Content-Disposition: attachment; filename="Snake1-__drumee.in.zip"`. The server sent the right name; the client threw it away. Suffix re-attached.

### 2. The size warning could never fire

`this._zipsize = data.size` reads the `drumate.backup` response — which is `{zipid, status:'queued'}`, sent *before* anything is compressed. Always 0, so `DOWNLOAD_LONG_TIME` never showed once, not even for 585 MB. Now taken off the completion event.

### 3. Every click started another full-account compression

Compression takes a minute or two with no feedback, so an impatient second click doubled the server work. One archive at a time now, released when delivered or failed; a failed request also says so instead of only logging.

### 4. The category sizes were hardcoded

`240 MB / 12 MB / 88 MB / 2 MB` for **every account**. Real figures for the account tested: **1.58 GB** files, **235 MB** workspace — against the **342 MB** the dialog claimed, while 585 MB came down. They now come from `drumate.backup_size`, counted off the rows the archiver actually walks. Until they arrive, or if the call fails, each row shows a dash — a placeholder number is worse than admitting we don't know yet.

**Depends on server-team PR #120** (`drumate.backup_size`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)