### PR TITLE
feat(billing): sell extra Team seats — volume-tiered add-on + Manage seats flow

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -2610,5 +2610,10 @@
   "MIGRATE_GDRIVE_SUMMARY_SKIPPED": "{0} skipped.",
   "MIGRATE_GDRIVE_MORE_ITEMS": "+{0} more",
   "GDRIVE_SHORTCUT_SKIPPED": "Google Drive shortcut — not copied",
-  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry"
+  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry",
+  "MANAGE_SEATS": "Manage seats",
+  "ADDITIONAL_SEATS": "Additional members",
+  "SEAT_TIER_BASE": "$3.00 per member — $2.90 from 10",
+  "SEAT_TIER_BULK": "$2.90 per member",
+  "SEATS_LINE": "{0} extra members"
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -2188,5 +2188,10 @@
   "MIGRATE_GDRIVE_SUMMARY_SKIPPED": "{0} skipped.",
   "MIGRATE_GDRIVE_MORE_ITEMS": "+{0} more",
   "GDRIVE_SHORTCUT_SKIPPED": "Google Drive shortcut — not copied",
-  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry"
+  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry",
+  "MANAGE_SEATS": "Manage seats",
+  "ADDITIONAL_SEATS": "Additional members",
+  "SEAT_TIER_BASE": "$3.00 per member — $2.90 from 10",
+  "SEAT_TIER_BULK": "$2.90 per member",
+  "SEATS_LINE": "{0} extra members"
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -2184,5 +2184,10 @@
   "MIGRATE_GDRIVE_SUMMARY_SKIPPED": "{0} skipped.",
   "MIGRATE_GDRIVE_MORE_ITEMS": "+{0} more",
   "GDRIVE_SHORTCUT_SKIPPED": "Google Drive shortcut — not copied",
-  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry"
+  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry",
+  "MANAGE_SEATS": "Manage seats",
+  "ADDITIONAL_SEATS": "Additional members",
+  "SEAT_TIER_BASE": "$3.00 per member — $2.90 from 10",
+  "SEAT_TIER_BULK": "$2.90 per member",
+  "SEATS_LINE": "{0} extra members"
 }

--- a/locale/km.json
+++ b/locale/km.json
@@ -2183,5 +2183,10 @@
   "MIGRATE_GDRIVE_SUMMARY_SKIPPED": "{0} skipped.",
   "MIGRATE_GDRIVE_MORE_ITEMS": "+{0} more",
   "GDRIVE_SHORTCUT_SKIPPED": "Google Drive shortcut — not copied",
-  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry"
+  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry",
+  "MANAGE_SEATS": "Manage seats",
+  "ADDITIONAL_SEATS": "Additional members",
+  "SEAT_TIER_BASE": "$3.00 per member — $2.90 from 10",
+  "SEAT_TIER_BULK": "$2.90 per member",
+  "SEATS_LINE": "{0} extra members"
 }

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -2183,5 +2183,10 @@
   "MIGRATE_GDRIVE_SUMMARY_SKIPPED": "{0} skipped.",
   "MIGRATE_GDRIVE_MORE_ITEMS": "+{0} more",
   "GDRIVE_SHORTCUT_SKIPPED": "Google Drive shortcut — not copied",
-  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry"
+  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry",
+  "MANAGE_SEATS": "Manage seats",
+  "ADDITIONAL_SEATS": "Additional members",
+  "SEAT_TIER_BASE": "$3.00 per member — $2.90 from 10",
+  "SEAT_TIER_BULK": "$2.90 per member",
+  "SEATS_LINE": "{0} extra members"
 }

--- a/locale/zh.json
+++ b/locale/zh.json
@@ -2183,5 +2183,10 @@
   "MIGRATE_GDRIVE_SUMMARY_SKIPPED": "{0} skipped.",
   "MIGRATE_GDRIVE_MORE_ITEMS": "+{0} more",
   "GDRIVE_SHORTCUT_SKIPPED": "Google Drive shortcut — not copied",
-  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry"
+  "MAIL_SALES_SUBJECT": "Drumee {0} plan enquiry",
+  "MANAGE_SEATS": "Manage seats",
+  "ADDITIONAL_SEATS": "Additional members",
+  "SEAT_TIER_BASE": "$3.00 per member — $2.90 from 10",
+  "SEAT_TIER_BULK": "$2.90 per member",
+  "SEATS_LINE": "{0} extra members"
 }

--- a/src/drumee/builtins/widget/settings/account/billing/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/index.js
@@ -550,30 +550,53 @@ class settings_billing extends LetcBox {
     const basePrice = planPrices[selectedPlan]?.[billingCycle] || 0;
     const period = billingCycle === "yearly" ? "year" : "month";
 
-    // FLAT since the 2026-07 pricing rebuild: the plan price IS the total, and
-    // the storage/seat figures come straight from the plan. The storage
-    // bundles (storage_*) and extra-seat (pro_seat) catalog rows that used to
-    // be added on top are retired with the B2C Pro tier, and `seats` is the
-    // plan's member CAP now, not a quantity the buyer picks — so there is
-    // nothing left to accumulate here.
-    //
-    // The zeroed bundle/extra-seat fields are kept in the returned shape on
-    // purpose: skeleton/checkout.js still reads them, and dropping the keys
-    // would render "undefined" rather than simply nothing.
-    const seats = baseSeats;
+    // Storage is flat — the plan's allowance is the whole allowance, and the
+    // retired storage_* bundles no longer add to it. SEATS are the one thing
+    // the buyer can still add: extras are billed through the team_seat add-on
+    // on top of the plan's included members.
+    const extraSeats = selectedPlan === "team"
+      ? Math.max(0, ~~checkout.extraSeats)
+      : 0;
+    const seatsPrice = extraSeats * this._seatUnitPrice(extraSeats, billingCycle);
+    const totalPrice = basePrice + seatsPrice;
+    const seats = baseSeats + extraSeats;
+
+    // bundlePrice/bundleStorage stay in the shape at zero: skeleton/checkout.js
+    // still reads them, and dropping the keys renders "undefined" rather than
+    // nothing.
     return {
       basePrice: formatCurrency(basePrice),
       bundlePrice: formatCurrency(0),
-      totalPrice: formatCurrency(basePrice),
+      seatsPrice: formatCurrency(seatsPrice),
+      totalPrice: formatCurrency(totalPrice),
       period,
       seats,
       totalStorage: `${baseStorage} GB`,
-      effectivePricePerSeat: formatCurrency(seats > 0 ? basePrice / seats : basePrice),
+      effectivePricePerSeat: formatCurrency(seats > 0 ? totalPrice / seats : totalPrice),
       selectedPlan,
       billingCycle,
-      extraSeats: 0,
+      extraSeats,
       bundleStorage: 0,
     };
+  }
+
+  /**
+   * Price of ONE extra seat at a given quantity.
+   *
+   * Volume-tiered: buying fewer than ten extra seats costs $3.00 each, ten or
+   * more $2.90 each — and the cheaper rate applies to the whole quantity, not
+   * just the seats past the tenth. Stripe holds the authoritative tiers on the
+   * team_seat price; this mirrors them so the checkout panel can show a total
+   * before the buyer is redirected. Any disagreement is settled by Stripe at
+   * payment time, which is why the amount is never sent to the server.
+   * @param {number} qty - how many extra seats
+   * @param {string} cycle - "monthly" | "yearly"
+   * @returns {number} unit price in currency units
+   */
+  _seatUnitPrice(qty, cycle) {
+    const monthly = ~~qty >= 10 ? 2.9 : 3;
+    // Yearly is 11 x monthly across this catalog (one month free).
+    return cycle === "yearly" ? monthly * 11 : monthly;
   }
 
 
@@ -733,6 +756,17 @@ class settings_billing extends LetcBox {
     this.renderContent();
   }
 
+  /**
+   * "Manage seats" on the current Team card: same checkout, opened on the plan
+   * they already have, with the seat stepper primed at one extra. Starting at
+   * zero would show a checkout that charges the plan again for nothing, which
+   * reads like a mistake.
+   */
+  _manageSeats() {
+    this.state.checkout.extraSeats = Math.max(1, ~~this.state.checkout.extraSeats);
+    this._enterCheckoutFor("team");
+  }
+
   async _proceedToCheckout() {
     // The SERVER decides the price (Stripe price_id from yp.plan); the client
     // only declares WHAT to buy. plan 'team' => org (per-seat) checkout.
@@ -752,6 +786,11 @@ class settings_billing extends LetcBox {
     // returns 403 PERMISSION_DENIED. Send the caller's own hub so the owner
     // check resolves correctly (verified: missing hub_id -> 403, present -> 200).
     const payload = { hub_id: Visitor.id, entity_type, plan, period };
+    // Extra members ride along as the team_seat add-on line. Only the COUNT
+    // goes over the wire — Stripe owns the tiered price, so the client never
+    // sends an amount it could disagree with.
+    const extraSeats = plan === "team" ? Math.max(0, ~~checkout.extraSeats) : 0;
+    if (extraSeats > 0) payload.extra_seats = extraSeats;
     // TEAM bootstrap: the payer is still on the default domain — the org
     // name + subdomain were collected in the checkout form; validate the
     // ident server-side BEFORE the Stripe redirect (product decision: prompt
@@ -1142,6 +1181,23 @@ class settings_billing extends LetcBox {
     switch (service) {
       case "select-plan":
         return this.handleSelectPlan(cmd);
+
+      case "manage-seats":
+        // From the current-plan pill: buy members beyond the included ten.
+        this._manageSeats();
+        return false;
+
+      case "seats-inc":
+      case "seats-dec": {
+        const step = service === "seats-inc" ? 1 : -1;
+        // Floor at 1, not 0: this checkout exists to add seats, and letting it
+        // reach zero leaves a panel that charges the plan again for nothing.
+        this.state.checkout.extraSeats =
+          Math.max(1, (~~this.state.checkout.extraSeats) + step);
+        this._updateRightPanelContent();
+        this.renderContent();
+        return false;
+      }
 
       case "select-plan-button": {
         const planValue = this._getValueFromCmd(cmd, args);

--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/checkout.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/checkout.js
@@ -49,7 +49,7 @@ function checkout(ui) {
   const summary = ui.calculateCheckoutSummary();
 
   const isFreePlan = ui.state?.checkout?.selectedPlan === "free";
-  let { seats, selectedPlan, storage, billingCycle } = summary
+  let { seats, selectedPlan, storage, billingCycle, extraSeats } = summary
   let min, max;
   if (seats > 1) {
     min = 5;
@@ -125,6 +125,50 @@ function checkout(ui) {
       }),
 
       ...(orgSection ? [orgSection] : []),
+
+      // Extra members, Team only. Free has no seats to extend and Business is
+      // already unlimited, so the stepper would be meaningless on either.
+      ...(selectedPlan === "team" ? [Skeletons.Box.Y({
+        className: `${pfx}-section`,
+        kids: [
+          Skeletons.Note({
+            className: `${pfx}-section-title`,
+            content: LOCALE.ADDITIONAL_SEATS || "Additional members",
+          }),
+          Skeletons.Box.X({
+            className: `${pfx}-seats-row`,
+            kids: [
+              Skeletons.Note({
+                className: `${pfx}-seats-step`,
+                content: "−",
+                service: "seats-dec",
+                uiHandler: [ui],
+                // Nothing to remove at one — this checkout exists to add seats.
+                dataset: { disabled: extraSeats <= 1 ? 1 : 0 },
+              }),
+              Skeletons.Note({
+                className: `${pfx}-seats-count`,
+                content: String(extraSeats),
+              }),
+              Skeletons.Note({
+                className: `${pfx}-seats-step`,
+                content: "+",
+                service: "seats-inc",
+                uiHandler: [ui],
+              }),
+              Skeletons.Note({
+                className: `${pfx}-seats-hint`,
+                // States the tier the buyer is actually on, and what it takes
+                // to reach the cheaper one — the discount is invisible
+                // otherwise, since Stripe only applies it at ten.
+                content: extraSeats >= 10
+                  ? (LOCALE.SEAT_TIER_BULK || "$2.90 per member")
+                  : (LOCALE.SEAT_TIER_BASE || "$3.00 per member — $2.90 from 10"),
+              }),
+            ],
+          }),
+        ],
+      })] : []),
 
       Skeletons.Box.Y({
         className: `${pfx}-section`,

--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/plans.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/plans.js
@@ -222,8 +222,37 @@ function ctaButton(ui, fig, opt, option) {
   const locked =
     !isCurrent && !(ui._mayCheckout ? ui._mayCheckout() : canUpgradePlan());
 
+  // A Team owner can buy extra members from their own plan card — the pill
+  // that just says "Your current plan" is the only thing sitting where they'd
+  // look for it, and before this there was no route to more seats at all
+  // short of moving to Business. Team only: Free has no seats to extend and
+  // Business is already unlimited.
+  const canManageSeats =
+    isCurrent && opt === "team" &&
+    (ui._mayCheckout ? ui._mayCheckout() : canUpgradePlan());
+
   let buttonBtn;
-  if (isCurrent) {
+  if (canManageSeats) {
+    // Same pill, two labels: the state at rest, the action on hover (CSS
+    // swaps them — see &-button-main.current.manageable in the skin). Keeping
+    // one element means the card doesn't shift when the label changes.
+    buttonBtn = Skeletons.Box.X({
+      className: `${fig}-button-main current manageable`,
+      service: "manage-seats",
+      uiHandler: [ui],
+      kidsOpt: { active: 0 },
+      kids: [
+        Skeletons.Note({
+          className: `${fig}-current-label`,
+          content: LOCALE.YOUR_CURRENT_PLAN,
+        }),
+        Skeletons.Note({
+          className: `${fig}-manage-seats-label`,
+          content: LOCALE.MANAGE_SEATS || "Manage seats",
+        }),
+      ],
+    });
+  } else if (isCurrent) {
     // Flat pill (no button() helper — a single element, so there's no
     // outer/inner split to keep in sync). "-main" matches the family the
     // button() helper's outer box uses below, so both share one CSS block.

--- a/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
+++ b/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
@@ -1704,3 +1704,67 @@
     }
   }
 }
+
+// "Your current plan" on the Team card doubles as the way in to buying more
+// members: the label swaps to "Manage seats" on hover. One element with two
+// labels rather than two pills, so the card doesn't shift as the text changes.
+.settings-billing__plan-button-main.current.manageable {
+  cursor: pointer;
+
+  .settings-billing__plan-manage-seats-label {
+    display: none;
+  }
+
+  &:hover {
+    .settings-billing__plan-current-label {
+      display: none;
+    }
+
+    .settings-billing__plan-manage-seats-label {
+      display: flex;
+      justify-content: center;
+    }
+  }
+}
+
+// Seat stepper in the checkout form.
+.settings-billing__checkout {
+  &-seats-row {
+    align-items: center;
+    gap: var(--spacer-3);
+  }
+
+  &-seats-step {
+    width: 32px;
+    height: 32px;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--normal-bg-20, rgba(0, 0, 0, 0.14));
+    border-radius: var(--corner-radius-2);
+    cursor: pointer;
+    user-select: none;
+    @include drumee.typo($size: 16px, $line: 20px, $weight: 400, $color: var(--normal-fg));
+
+    &:hover {
+      background-color: var(--normal-bg-100, rgba(0, 0, 0, 0.04));
+    }
+
+    // At the floor the control stays visible but plainly inert, rather than
+    // vanishing and shifting the row.
+    &[data-disabled="1"] {
+      opacity: 0.4;
+      pointer-events: none;
+    }
+  }
+
+  &-seats-count {
+    min-width: 28px;
+    justify-content: center;
+    @include drumee.typo($size: 15px, $line: 20px, $weight: 400, $color: var(--normal-fg));
+    font-weight: 600;
+  }
+
+  &-seats-hint {
+    @include drumee.typo($size: 12px, $line: 16px, $weight: 400, $color: var(--normal-fg-10));
+  }
+}


### PR DESCRIPTION
Team is flat with ten included members, so an org that outgrew it had no route to an eleventh short of moving to Business — and nothing in the UI hinted otherwise. This adds the seat add-on back, attached to Team.

## Pricing

Volume-tiered, and the cheaper rate applies to the **whole** quantity:

| extra members | unit | total |
| :-- | :-- | :-- |
| 1 | $3.00 | $3.00 |
| 9 | $3.00 | $27.00 |
| **10** | **$2.90** | **$29.00** |
| 20 | $2.90 | $58.00 |

Verified against the live sandbox price (`billing_scheme=tiered`, `tiers_mode=volume`). Yearly is 11× monthly like the rest of the catalog.

## The flow

The current-plan pill is where an owner looks, so it doubles as the way in: **"Your current plan"** at rest, **"Manage seats"** on hover → opens the checkout on the plan they already have with the stepper primed at one. One element with two labels rather than two pills, so the card doesn't shift as the text changes.

Team only — Free has no seats to extend, Business is already unlimited — and non-owners are excluded by the same `_mayCheckout` rule that gates every other purchase.

## How the money is kept honest

- The **base plan line stays quantity 1**. Plans are flat; a seat count there would multiply the whole bill.
- Extra members are a **second recurring line** (`team_seat`), quantity = members beyond the included ten.
- Only the **count** goes over the wire. Stripe owns the tiered price, so the client can never disagree with the amount actually charged. `_seatUnitPrice` mirrors the tiers purely to total the panel before redirecting.
- The session metadata deliberately does **not** carry the seat count — the webhook reads it back from the real subscription line items, so an owner who changes the quantity in the Stripe portal still gets the right entitlement.

## Entitlement

`payment_apply_entitlement` now **adds** purchased seats to the plan's included count. It adds rather than assigns on purpose: writing the add-on quantity straight into `$.seat` would drop the included ten and leave a paying org **smaller** than one that bought nothing. `_seats` changes meaning with it — extra seats, not subscription quantity — so its default drops from 1 to 0, since leaving it at 1 would hand every org a free eleventh seat on every renewal.

## Two bugs found on the way

- **`_seatTotal` returned the base line's quantity for orgs.** That was right when the quantity *was* the seat count; now it is always 1, and since the procedure adds its argument to the included seats, every Team org would have been capped at eleven members no matter how many they bought.
- **The individual path looked plans up with a hardcoded `'eur'`.** The pricing rebuild deactivated every EUR row, so that matched nothing and silently reported zero included seats.

## Also cleaned up

The retired `seats` and `bundle` params are dropped from the checkout ACL — advertising inputs the service ignores invites callers to send values that quietly do nothing.

---

**Note for whoever merges:** `team_seat` needs a Stripe price seeded per environment before the seat line can be billed (sandbox is done: `prod_UwyifX6LCo57Dm`). A missing price is skipped with a warning rather than failing the checkout, so the buyer still gets their plan — but their seats won't be charged or granted until it's seeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
