### PR TITLE
fix(reward-flow): drop stale coach advice once the invite is sent

### DIFF
--- a/src/drumee/builtins/widget/reward-flow/guide.js
+++ b/src/drumee/builtins/widget/reward-flow/guide.js
@@ -113,8 +113,13 @@ function tooltipFor(sub) {
 }
 
 /** Perm-phase instruction — one uniform line (no separate heading), specific to
- *  the branch: internal (permission_restricted) vs external (secure_share). */
+ *  the branch: internal (permission_restricted) vs external (secure_share).
+ *  Once a confirmation (window_info) sits on top — e.g. "The invitation was sent
+ *  successfully" after inviting a member to an internal workspace — the branch
+ *  advice is stale: the invite has already been sent and the panel behind is
+ *  unreachable, so the only thing left to do is close the notice. */
 function permText() {
+  if (firstVisible(SEL.windowInfo)) return tooltipFor("perm");
   if (firstVisible(SEL.permShare)) {
     return LOCALE.REWARD_FLOW_GUIDE_PERM_EXTERNAL
       || "Open to share externally with your clients. Close to continue";


### PR DESCRIPTION
At sub-step 4 the coach text was chosen purely by branch (internal permission_restricted vs external secure_share). When the internal panel popped its window_info confirmation ("The invitation was sent successfully"), the coach kept reading "Add team members or Close to continue" — but the invite is already sent and the panel behind the notice is unreachable, so the only thing left to do is close it.

Return the plain REWARD_FLOW_GUIDE_PERM line ("Close to continue") whenever the confirmation is on screen. The spotlight already retargets window_info in _targetEl(), and _position()'s dedup signature includes the target rect, so the coach repaints on its own.

No new locale strings: REWARD_FLOW_GUIDE_PERM already exists in all six locale files.