### PR TITLE
fix(butler): hide the title in notice dialogs, show only the message

### DIFF
--- a/src/drumee/router/butler/skin/index.scss
+++ b/src/drumee/router/butler/skin/index.scss
@@ -146,17 +146,13 @@
     width: auto;
     min-height: 0;
 
+    // The title carries the raw `type` the caller passed — Butler.say() sends
+    // "info", wip() sends "warn" — so it rendered that word as a heading.
+    // Hidden rather than dropped from the skeleton so the node stays available
+    // to the non-notice dialogs' markup; display:none also keeps it out of the
+    // flex flow, so the 12px gap above does not double up.
     .router-butler__title {
-      width: 100%;
-      text-align: left;
-      font-family: var(--font-bold);
-      margin: 0;
-      @include drumee.typo(
-        $size: 16px,
-        $line: 22px,
-        $weight: 600,
-        $color: var(--normal-fg)
-      );
+      display: none;
     }
 
     .router-butler__message {


### PR DESCRIPTION
The title node renders the raw `type` the caller passed, and the two entry points pass a CSS modifier rather than a heading — Butler.say() sends "info", wip() sends "warn". So every toast displayed the literal word "info" above its message.

Hidden in the .notice scope rather than removed from the skeleton, so the node stays in message.js/confirm.js untouched. display:none also keeps it out of the flex flow, so the container's 12px gap does not leave a space where the title was.

Non-notice dialogs (main/login, quota, alert) use __main without the .notice modifier and keep their headings via the base &__title rule. Verified against the compiled CSS: notice title computes to display none, notice message to block, plain title to block.