### PR TITLE
fix(websocket): stop the reconnect loop from leaking sockets

### DIFF
--- a/src/drumee/builtins/webrtc/room/index.js
+++ b/src/drumee/builtins/webrtc/room/index.js
@@ -137,7 +137,6 @@ class __webrtc_room extends __interact {
       case "nop":
         this.stateMessage(s);
         break;
-        break;
       default:
         this.stateMessage(s);
     }

--- a/src/drumee/builtins/webrtc/room/index.js
+++ b/src/drumee/builtins/webrtc/room/index.js
@@ -24,6 +24,9 @@ class __webrtc_room extends __interact {
       // no user permission). NOT for a blocked mic or camera — that is
       // `mediaDenied`, which mediaErrorMessage() replaces with the real cause.
       permissionDenied: LOCALE.WEAK_PRIVILEGE,
+      // The join request never reached the server, or never came back. Nothing
+      // is wrong with the user's rights, so do not blame their privilege.
+      unreachable: LOCALE.CONNECTION_LOST,
       mediaDenied: LOCALE.DEVICES_PERMISSION_DENIED.format(
         `${LOCALE.MICROPHONE.toLowerCase()} / ${LOCALE.CAMERA.toLowerCase()}`,
       ),
@@ -740,7 +743,17 @@ class __webrtc_room extends __interact {
     };
 
     let c = await this.postService(SERVICE.conference.join, opt);
-    if (!c || !c.user || !c.user.permission) {
+    /**
+     * A request that never completed resolves undefined: doRequest routes
+     * network failures through onServerComplain without throwing. That is a
+     * dead connection, not a rights problem, and reporting it as a weak
+     * privilege sent users hunting for permissions they had all along.
+     */
+    if (!c) {
+      this.stateMachine("unreachable");
+      return null;
+    }
+    if (!c.user || !c.user.permission) {
       this.stateMachine("permissionDenied");
       return null;
     }

--- a/src/drumee/builtins/window/meeting/index.js
+++ b/src/drumee/builtins/window/meeting/index.js
@@ -150,7 +150,15 @@ class __window_meeting extends __room {
     try {
       room = await this.join();
       if (!room || !room.user) {
-        this.stateMachine("permissionDenied");
+        /**
+         * join() has already reported the accurate reason: "unreachable" when
+         * the request never came back, "permissionDenied" when the server
+         * genuinely refused. Overwriting it here is what told users their
+         * privilege was insufficient every time the connection dropped.
+         */
+        if (this.state !== "unreachable") {
+          this.stateMachine("permissionDenied");
+        }
         return;
       }
       // sendRoomInfo doesn't forward the host record to non-host clients;

--- a/src/drumee/router/websocket/index.js
+++ b/src/drumee/router/websocket/index.js
@@ -226,7 +226,7 @@ class __router_websocket extends LetcBox {
   _bind(client) {
     this.resetSocket(client);
     this._reconnect_count++;
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       if (!client) {
         reject({ error: "got undefined socket" });
         this.warn("ERROR:166 - got undefined socket");
@@ -315,7 +315,7 @@ class __router_websocket extends LetcBox {
    * @returns
    */
   connect(force = 0) {
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const { endpoint, main_domain } = bootstrap();
       if (!endpoint || !main_domain) {
         return resolve(0);
@@ -370,14 +370,19 @@ class __router_websocket extends LetcBox {
    */
   restart(force = 0) {
     if (force) this._reconnect_count = 0;
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       if (!force && this.isOk()) return resolve();
-      let o = await this.connect(force)
-      this.debug("AAAA:318", o)
-      if (o) {
-        return resolve()
-      }
-      return reject()
+      /**
+       * An async executor swallows a rejection from connect() and leaves this
+       * promise pending for good, so settle it explicitly instead.
+       */
+      this.connect(force).then((o) => {
+        this.debug("AAAA:318", o)
+        if (o) {
+          return resolve()
+        }
+        return reject()
+      }).catch(reject)
     })
   }
 

--- a/src/drumee/router/websocket/index.js
+++ b/src/drumee/router/websocket/index.js
@@ -18,6 +18,8 @@ const W3CWebSocket = require("websocket").w3cwebsocket;
 const WEBSOCKET_ERROR = "websocket:error";
 const WEBSOCKET_MESSAGE = "websocket:message";
 const RECONNECT_INTERVAL = 5000;
+/** How long a pending handshake blocks a new one before it is retried anyway */
+const CONNECT_TIMEOUT = 60000;
 
 window.W3CWebSocket = W3CWebSocket;
 let TIMESTAMP = new Date().getTime();
@@ -70,6 +72,7 @@ class __router_websocket extends LetcBox {
     RADIO_NETWORK.trigger(_e.websocketReady, this);
     this.reconnectTimer = RECONNECT_INTERVAL;
     this._reconnect_count = 0;
+    this._connecting = 0;
     this.keepAlive();
     window.addEventListener("online", this.onLinkUp);
     window.addEventListener("offline", this.onLinkDown);
@@ -157,14 +160,46 @@ class __router_websocket extends LetcBox {
   resetSocket(client) {
     this.socketBound = 0;
     if (this.socket) {
-      if (this.socket.readyState === this.socket.OPEN) {
-        this.socket.close();
+      const previous = this.socket;
+      /**
+       * Detach before closing. onerror and onclose were left attached, so a
+       * socket we had already abandoned still queued its own reconnect.
+       */
+      previous.onopen = null;
+      previous.onclose = null;
+      previous.onerror = null;
+      previous.onmessage = null;
+      /**
+       * A socket still CONNECTING used to be dropped without close(): it went
+       * on to complete its handshake and stayed open until the tab was closed.
+       */
+      if (
+        previous.readyState === previous.CONNECTING ||
+        previous.readyState === previous.OPEN
+      ) {
+        try {
+          previous.close();
+        } catch (e) {
+          this.warn("Failed to close the previous socket", e);
+        }
       }
-      this.socket.onopen = null;
-      this.socket.onclose = null;
       this.socket = null;
     }
     if (client) this.socket = client;
+  }
+
+  /**
+   * Sole owner of this.timer. Cancels whatever is already queued so a single
+   * dropped socket can never schedule more than one reconnect.
+   */
+  scheduleReconnect(delay) {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.restart().catch((e) => {
+        this.warn("Reconnection attempt failed", e);
+      });
+    }, delay == null ? Visitor.timeout(this.reconnectTimer) : delay);
   }
 
   /**
@@ -250,12 +285,13 @@ class __router_websocket extends LetcBox {
         this.warn("Websocket encounted error", e);
         this.trigger(_e.error, "connect_error");
         this.socketBound = 0;
+        /**
+         * A failed connection always fires close right after error, and onclose
+         * is what schedules the reconnect. Scheduling here too meant every
+         * single drop opened two sockets.
+         */
         if (client.readyState !== client.OPEN) {
           this.reconnectTimer = parseInt(this.reconnectTimer * 3);
-          this.timer = setTimeout(
-            this.connect.bind(this),
-            Visitor.timeout(this.reconnectTimer)
-          );
         }
       };
 
@@ -268,10 +304,7 @@ class __router_websocket extends LetcBox {
         this.warn("WebSocket CLOSE !", e);
         RADIO_NETWORK.trigger(_e.offline, this);
         this.reconnectTimer = Visitor.timeout(RECONNECT_INTERVAL);
-        this.timer = setTimeout(
-          this.restart.bind(this),
-          Visitor.timeout(this.reconnectTimer)
-        );
+        this.scheduleReconnect();
       };
     });
   }
@@ -281,7 +314,7 @@ class __router_websocket extends LetcBox {
    * @param {*} reconnecting
    * @returns
    */
-  connect() {
+  connect(force = 0) {
     return new Promise(async (resolve, reject) => {
       const { endpoint, main_domain } = bootstrap();
       if (!endpoint || !main_domain) {
@@ -291,20 +324,41 @@ class __router_websocket extends LetcBox {
         this.warn("Too many reconnections failed. Giving up");
         return resolve(0);
       }
-      if (this.timer) {
+      /**
+       * authn is asynchronous. Without this guard every queued attempt issued
+       * its own request and each one opened its own socket. The deadline keeps
+       * a stalled request from blocking reconnects for good.
+       */
+      if (
+        !force &&
+        this._connecting &&
+        new Date().getTime() - this._connecting < CONNECT_TIMEOUT
+      ) {
         this.warn("Already connection pending> Skipped");
+        return resolve(0);
+      }
+      if (this.timer) {
+        clearTimeout(this.timer);
         this.timer = null;
       }
+      this._connecting = new Date().getTime();
       this.postService(SERVICE.bootstrap.authn).then((r) => {
+        this._connecting = 0;
         if (r.otp_key) {
           Visitor.set({ otp_key: r.otp_key });
         }
         let url = this.url(r);
         this._bind(new W3CWebSocket(url, _a.service)).then(() => { resolve(1) }).catch(() => { resolve(0) });
       }).catch((e) => {
+        this._connecting = 0;
         this.warn("ERROR:292 - failed to connect websocket", e)
-        let url = this.url({});
-        this._bind(new W3CWebSocket(url, _a.service)).then(() => { resolve(1) }).catch(() => { resolve(0) });
+        /**
+         * Opening a socket without the otak we just failed to obtain only
+         * yields a connection the server has to reject, which closes and asks
+         * for yet another one. Wait and retry the handshake instead.
+         */
+        this.scheduleReconnect();
+        resolve(0);
       })
     })
   }
@@ -318,7 +372,7 @@ class __router_websocket extends LetcBox {
     if (force) this._reconnect_count = 0;
     return new Promise(async (resolve, reject) => {
       if (!force && this.isOk()) return resolve();
-      let o = await this.connect()
+      let o = await this.connect(force)
       this.debug("AAAA:318", o)
       if (o) {
         return resolve()


### PR DESCRIPTION
Hotfix for Theo (`tastoshi`), reported on prod 2026-07-27: "insufficient privilege" when answering a call, then `ERR_CONNECTION_RESET` on app.drumee.com — even in a fresh Chrome incognito window, while Safari worked fine.

## It was never a permissions problem

- **Zero `DENIED` events** for his uid all day; every `conference.*` call was `GRANTED`
- No fail2ban, no `return 444`, no rate limit, no IP ban
- Safari worked **from the same IP** four minutes later

## Root cause: the websocket reconnect loop leaked sockets

nginx access log for his IP: **352 handshakes in ~1h, 297 of them tokenless** (`GET /-/websocket/?` with no `otak`), **33 closing at the same instant**, then Chrome went silent. Recurring — the same mobile IP range topped the tokenless count on Jul 18/20/21/26/27, while every other user sits at 2–11/day.

Four defects in `router/websocket/index.js` compounding:

1. `connect()`'s guard logged `"Already connection pending> Skipped"` but had no `return` and no `clearTimeout` — it did not skip.
2. `resetSocket()` only closed `readyState === OPEN`. Sockets still `CONNECTING` were dropped **without** `close()`, so they completed their handshake and stayed open until the tab died. It also never detached `onerror`/`onmessage`, so abandoned sockets kept queueing reconnects.
3. `onerror` **and** `onclose` each scheduled a reconnect → two sockets per drop.
4. On `authn` failure it opened a socket anyway, using `url({})` — no token. Once the pool was saturated `authn` started failing, and each failure opened another doomed socket. That is the death spiral.

Chrome's network service is shared across profiles, which is why a brand-new incognito window was also dead while Safari (separate pool) was unaffected.

## The fix

- `resetSocket` detaches every handler, then closes `CONNECTING` as well as `OPEN`
- new `scheduleReconnect()` is the sole owner of `this.timer` and cancels whatever is queued
- `onclose` alone drives reconnection — the spec fires `close` after every `error`
- `connect(force)` serialises the async `authn` window via a timestamp guard with a 60s expiry so it can never deadlock; `force` bypasses it so sign-in and network-up still reconnect immediately
- a failed `authn` retries the handshake instead of opening a tokenless socket

**Reconnect timing is deliberately unchanged.** I rejected exponential backoff — it would have slowed normal recovery from 5s to minutes for every user, to fix a bug in one path.

After this there is exactly **one** `new W3CWebSocket(...)` call site in the whole codebase; there were two.

## Also: the misleading message

`postService` resolves `undefined` when a request never completes (`doRequest` routes network failures through `onServerComplain` without throwing). `join()` mapped that to `permissionDenied` → `LOCALE.WEAK_PRIVILEGE`, so a dead connection told users their rights were insufficient. It now reports `unreachable` → `LOCALE.CONNECTION_LOST` (an existing key, already present in all 6 locales — no new strings).

`window/meeting/index.js` re-set `permissionDenied` right after calling `join()`, which would have overridden the fix, so that caller is corrected too.

## Verification

No test runner exists in this repo, so I built a harness that loads the **real** class in Node (intercepting `require("websocket")`, stubbing only injected globals) and asserts 9 invariants. Run against the **pre-fix baseline** to prove the tests actually detect the bug:

| | original | this PR |
|---|---|---|
| CONNECTING socket closed when replaced | ❌ `closed=0` | ✅ |
| failed authn opens no socket | ❌ opens 1 tokenless | ✅ |
| failed authn schedules a retry | ❌ none | ✅ |
| concurrent `connect()` → 1 authn | ❌ **3 authn** | ✅ |
| connect-time failure → 1 reconnect | ❌ **spawned=2** | ✅ |
| | **5 violated** | **all 9 hold** |

Also: real webpack compile passes, ESLint clean under CI's config, and CD deployed green to drumee.in.

## Second commit — pre-existing lint

The lint job only checks *changed* files, so touching these surfaced 4 pre-existing errors (verified identical at preview HEAD). The substantive one: `restart()` used an `async` promise executor, which **swallows** a rejection from `connect()` and leaves the promise pending forever. It now chains explicitly and always settles.

## Notes for the reviewer

- The **Guard preview source** check will fail: it requires PRs into `preview` to come from `test`. This is a hotfix branched off `preview`, per the hotfix flow — merging `test` would drag in 22+ unrelated commits. Needs an admin merge, as with previous hotfixes.
- Deploy **preview only** for now.
- Not included, needs its own ticket: `modules/dmz/meeting/index.js` has a separate `join()` with the same transport-failure→`WEAK_PRIVILEGE` bug in the public-guest meeting flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)