### PR TITLE
fix(billing): read the disk allowance under either key

### DIFF
--- a/src/drumee/builtins/widget/settings/account/skeleton/billing.js
+++ b/src/drumee/builtins/widget/settings/account/skeleton/billing.js
@@ -43,8 +43,12 @@ function filter(ui) {
  */
 function header(ui) {
   const fig = `${ui.fig.family}-storage__header`;
-  const { storage } = Visitor.quota();
-  const use_rate = (100 * Visitor.diskUsed()) / storage;
+  // See settings/account/skeleton/storage.js: the allowance arrives as `disk`
+  // from the get_quota FUNCTION and only as `storage` from the procedure, so
+  // read whichever this deployment sends.
+  const q = Visitor.quota() || {};
+  const storage = q.storage != null ? q.storage : q.disk;
+  const use_rate = storage ? (100 * Visitor.diskUsed()) / storage : 0;
   return Skeletons.Box.Y({
     className: `${fig}-content`,
     kids: [

--- a/src/drumee/builtins/widget/settings/account/skeleton/storage.js
+++ b/src/drumee/builtins/widget/settings/account/skeleton/storage.js
@@ -43,8 +43,14 @@ function filter(ui) {
  */
 function header(ui) {
   const fig = `${ui.fig.family}-storage__header`;
-  const { storage } = Visitor.quota();
-  const use_rate = 100 * Visitor.diskUsed() / storage;
+  // `storage` is the alias; `disk` is the key the quota row is actually stored
+  // under. desk.get_env is fed by the get_quota FUNCTION, which returned only
+  // the latter — so this read undefined, the total rendered "0 B" and the bar
+  // got width:NaN%. The server now emits both, but production trails the
+  // schema, so take whichever is present rather than depending on the rollout.
+  const q = Visitor.quota() || {};
+  const storage = q.storage != null ? q.storage : q.disk;
+  const use_rate = storage ? 100 * Visitor.diskUsed() / storage : 0;
   return Skeletons.Box.Y({
     className: `${fig}-content`,
     kids: [

--- a/src/drumee/builtins/window/account/data/index.js
+++ b/src/drumee/builtins/window/account/data/index.js
@@ -182,7 +182,10 @@ class __account_data extends DrumeeMFS {
     let { quota, usage } = data;
     if (quota) Visitor.set({ quota });
     if (usage) Visitor.set({ disk_usage: usage });
-    let max = Visitor.quota("storage");
+    // `storage` is an alias the get_quota PROCEDURE adds; the FUNCTION that
+    // feeds desk.get_env sends the underlying `disk`. Fall back so this works
+    // against a deployment whose schema has not caught up.
+    let max = Visitor.quota("storage") || Visitor.quota("disk");
     let details = [];
     let du = Visitor.diskUsage();
     for (let k in du) {


### PR DESCRIPTION
Settings → Account → Storage showed **"You used 16.04 GB / 0 B"** with a dead usage bar. The used figure was correct; the total and the bar were not.

Three places destructure or request `storage` from `Visitor.quota()`, but `desk.get_env` is fed by the `get_quota` **function**, which sends the allowance as `disk` (only the procedure of that name aliases it). So they read `undefined` → total `0 B`, `width: NaN%`.

- `settings/account/skeleton/storage.js`
- `settings/account/skeleton/billing.js`
- `window/account/data/index.js`

drumee/schemas#92 makes the function emit both keys, but deployments trail the schema — production does not have it yet — so these read whichever is present rather than depending on the rollout, and a missing allowance renders 0% instead of NaN.

Verified on stage after the schema fix: the panel reads `16.04 GB / 100 GB` and the bar sits at `width: 16.04%`.

Note: the storage COUNTING itself was never broken. Uploading six files totalling 13,632,512 bytes moved `Visitor.diskUsed()` by exactly 13,632,512 — the reported "upload files, storage stays the same" is this panel showing a total of zero, not the accounting failing.

Paired with drumee/ui-core `fix/quota-storage-key` (`diskFree()` returned NaN for the same reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)