### PR TITLE
chore(deps): @drumee/ui-core 1.1.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "webpack-manifest-plugin": "5.0.0"
   },
   "dependencies": {
-    "@drumee/ui-core": "^1.1.49",
+    "@drumee/ui-core": "^1.1.50",
     "@drumee/ui-essentials": "^1.0.2",
     "@drumee/ui-styles": "^1.0.6",
     "@drumee/ui-toolkit": "^0.0.23",


### PR DESCRIPTION
Pins the published version that carries the quota fix (drumee/ui-core#3): `quota()` normalises the `disk` key the backend actually sends to the `storage` every consumer reads, and `diskFree()` stops returning NaN.

Strictly a pin — `^1.1.49` already resolves to 1.1.50, so a fresh install picks it up either way. This makes the dependency explicit so the requirement is visible rather than implied by a caret range.

Missed #377 only because that PR merged before this commit was pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)