### PR TITLE
fix(reward): capture the CTA click on route, and take it out of the URL

### DIFF
--- a/src/drumee/libs/campaign.js
+++ b/src/drumee/libs/campaign.js
@@ -41,20 +41,33 @@ const MAX_LEN = 64;
  *
  * @returns {Object} the markers now in force, `{}` when none were ever seen
  */
-function captureUtm() {
-  // Guarded like the other libs/ globals (see libs/billing): a lib must not
-  // assume bootstrap has run, and this one promises never to throw. The typeof
-  // test has to stay in front of the optional chain — `Visitor?.x` still throws
-  // a ReferenceError when Visitor was never declared at all.
+/**
+ * The markers on THIS navigation's URL, and nothing else.
+ *
+ * Kept separate from captureUtm's stored fallback: "what campaign has this
+ * browser ever seen" and "did this particular arrival come from a campaign
+ * link" are different questions, and only the URL can answer the second.
+ *
+ * Guarded like the other libs/ globals (see libs/billing): a lib must not
+ * assume bootstrap has run, and this one promises never to throw. The typeof
+ * test has to stay in front of the optional chain — `Visitor?.x` still throws
+ * a ReferenceError when Visitor was never declared at all.
+ */
+function readUrlMarkers() {
   const args = (typeof Visitor !== "undefined" && Visitor?.parseModuleArgs?.()) || {};
   let search = null;
   try { search = new URLSearchParams(location.search); } catch (e) { /* no URL API */ }
 
-  let utm = {};
+  const utm = {};
   for (const k of PARAMS) {
     const v = args[k] || search?.get(k) || "";
     if (v) utm[k] = String(v).trim().slice(0, MAX_LEN);
   }
+  return utm;
+}
+
+function captureUtm() {
+  let utm = readUrlMarkers();
 
   try {
     if (Object.keys(utm).length) {
@@ -70,4 +83,102 @@ function captureUtm() {
   return utm;
 }
 
-module.exports = { captureUtm };
+/**
+ * Session-scoped proof that THIS visit arrived on a campaign link.
+ *
+ * Separate from the localStorage marker above, and deliberately so. That one is
+ * attribution — which campaign this browser last saw, kept indefinitely. This
+ * one answers a narrower question the reward gate needs: did the user actually
+ * follow the CTA on the way in? Being on the recipient list is an invitation;
+ * clicking is the entitlement.
+ *
+ * sessionStorage is the right shelf for it. It survives the FULL PAGE RELOAD
+ * that signing in triggers — the same reason welcome/index.js relays
+ * drumee_secure_share_return and drumee_hubDeepLink through it — but it dies
+ * with the tab, so it cannot accumulate one key per user, leak to the next
+ * person to sign in, or go quietly stale the way a localStorage latch does.
+ */
+const ARRIVAL_KEY = "drumee_campaign_arrival";
+
+/**
+ * Take the campaign params back out of the URL once they have been recorded.
+ *
+ * Without this the address bar keeps them for the life of the tab, and since
+ * every boot and every route re-reads the URL, a plain reload — or a restored
+ * session, or signing in again — looks exactly like a fresh click. That is how
+ * a user who never touched the CTA ended up being handed the flow.
+ *
+ * replaceState, not assignment: it rewrites the URL WITHOUT firing hashchange,
+ * so tidying up cannot kick off another routing pass. Only the utm keys are
+ * removed; any other deep-link args on the hash are left exactly as they were.
+ */
+function stripCampaignParams() {
+  if (typeof history === "undefined" || !history.replaceState) return;
+  try {
+    const drop = (qs) =>
+      qs.split("&").filter((p) => p && !PARAMS.includes(p.split("=")[0])).join("&");
+
+    const hash = location.hash || "";
+    const qi = hash.indexOf("?");
+    let nextHash = hash;
+    if (qi >= 0) {
+      const kept = drop(hash.slice(qi + 1));
+      nextHash = kept ? `${hash.slice(0, qi)}?${kept}` : hash.slice(0, qi);
+    }
+
+    const search = location.search || "";
+    let nextSearch = search;
+    if (search.length > 1) {
+      const kept = drop(search.slice(1));
+      nextSearch = kept ? `?${kept}` : "";
+    }
+
+    if (nextHash === hash && nextSearch === search) return;
+    history.replaceState(null, "", `${location.pathname}${nextSearch}${nextHash}`);
+  } catch (e) { /* tidying the URL must never break navigation */ }
+}
+
+/**
+ * Record the campaign this visit arrived on, if any.
+ *
+ * Must run BEFORE anything can rewrite the hash — the signin plugin replaces it
+ * wholesale with "#/welcome/signin" and would erase the markers.
+ *
+ * Called from the router BOTH at boot and on every route: a click that lands in
+ * a tab where the app is already running is a same-document navigation, so only
+ * hashchange fires and initialize() never runs again. Capturing at boot alone
+ * silently missed exactly that case — the commonest one, since the recipient is
+ * usually already sitting on a Drumee page. Routing from a module is no better:
+ * it is skipped when the module is already mounted and only route() re-runs.
+ *
+ * Reads the URL DIRECTLY rather than going through captureUtm, whose stored
+ * fallback is right for attribution and wrong here: it would make every later
+ * page load look like a fresh click, and a browser still holding someone else's
+ * stored campaign would manufacture a click for whoever signed in next.
+ */
+function captureCampaignArrival() {
+  const campaign = readUrlMarkers().utm_campaign;
+  if (!campaign) return;
+  try {
+    sessionStorage.setItem(ARRIVAL_KEY, campaign);
+  } catch (e) { /* private mode — the gate simply will not open */ }
+  // Consume the URL itself, so this arrival is counted once and not re-counted
+  // on every subsequent load of the same address.
+  stripCampaignParams();
+}
+
+/**
+ * Read the arrival marker, optionally consuming it.
+ * @param {Boolean} [consume] remove it, once it has been recorded server-side
+ * @returns {String} the campaign arrived on, "" when this visit did not
+ */
+function campaignArrival(consume) {
+  let v = "";
+  try {
+    v = sessionStorage.getItem(ARRIVAL_KEY) || "";
+    if (v && consume) sessionStorage.removeItem(ARRIVAL_KEY);
+  } catch (e) { /* private mode */ }
+  return v;
+}
+
+module.exports = { captureUtm, captureCampaignArrival, campaignArrival, ARRIVAL_KEY };

--- a/src/drumee/libs/campaign.js
+++ b/src/drumee/libs/campaign.js
@@ -23,7 +23,9 @@
  */
 
 const KEY = "drumee_utm";
-const PARAMS = ["utm_source", "utm_medium", "utm_campaign"];
+// A Set: this is read as a membership test far more often than it is iterated,
+// and insertion order is preserved, so the `for ... of` below is unaffected.
+const PARAMS = new Set(["utm_source", "utm_medium", "utm_campaign"]);
 // Long enough for any real campaign name, short enough that a crafted link
 // cannot bloat localStorage.
 const MAX_LEN = 64;
@@ -116,7 +118,7 @@ function stripCampaignParams() {
   if (typeof history === "undefined" || !history.replaceState) return;
   try {
     const drop = (qs) =>
-      qs.split("&").filter((p) => p && !PARAMS.includes(p.split("=")[0])).join("&");
+      qs.split("&").filter((p) => p && !PARAMS.has(p.split("=")[0])).join("&");
 
     const hash = location.hash || "";
     const qi = hash.indexOf("?");
@@ -135,7 +137,13 @@ function stripCampaignParams() {
 
     if (nextHash === hash && nextSearch === search) return;
     history.replaceState(null, "", `${location.pathname}${nextSearch}${nextHash}`);
-  } catch (e) { /* tidying the URL must never break navigation */ }
+  } catch (e) {
+    // Recoverable, and deliberately not rethrown: this runs inside the router's
+    // boot and route, so a throw here would break navigation itself. The marker
+    // is already stored by the caller, so the only cost of failing to tidy the
+    // URL is that a later load of the same address counts as a fresh arrival.
+    console.warn("[campaign] could not strip the campaign params from the URL", e);
+  }
 }
 
 /**
@@ -177,7 +185,13 @@ function campaignArrival(consume) {
   try {
     v = sessionStorage.getItem(ARRIVAL_KEY) || "";
     if (v && consume) sessionStorage.removeItem(ARRIVAL_KEY);
-  } catch (e) { /* private mode */ }
+  } catch (e) {
+    // sessionStorage is unavailable (private mode) or the read was refused.
+    // Recovering as "no arrival" is the safe answer rather than a rethrow: the
+    // caller is a gate, and it should stay shut rather than open on a guess.
+    console.warn("[campaign] sessionStorage unreadable, treating as no arrival", e);
+    v = "";
+  }
   return v;
 }
 

--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -1,7 +1,7 @@
 require("welcome/skin");
 require("builtins/window/confirm/skin");
 const { canUpgradePlan, billingAvailable, needsAdminConsoleUpgrade } = require("libs/billing");
-const { captureUtm } = require("libs/campaign");
+const { captureUtm, campaignArrival } = require("libs/campaign");
 
 class desk_module extends LetcBox {
   constructor(...args) {
@@ -1319,6 +1319,19 @@ class desk_module extends LetcBox {
     if (!forced) {
       let state;
       try {
+        // Turn an invitation into an entitlement. Being mailed is not enough —
+        // the user has to have followed the CTA — and the click happens while
+        // they are signed OUT, so the router stashes it in sessionStorage and it
+        // rides through the login reload to here, where there is finally a uid
+        // to attribute it to. Awaited before get_state so the row is already
+        // 'clicked' when we ask; only consumed once the server has it.
+        if (campaignArrival()) {
+          await this.postService(SERVICE.reward.track, {
+            hub_id: Visitor.id,
+            status: "clicked",
+          });
+          campaignArrival(true);
+        }
         state = await this.fetchService(SERVICE.reward.get_state, { hub_id: Visitor.id });
       } catch (e) {
         // The gate is the only thing standing between a user and an overlay

--- a/src/drumee/router/index.js
+++ b/src/drumee/router/index.js
@@ -144,25 +144,11 @@ class drumee_router extends LetcBox {
     if (data) {
       Visitor.respawn(data);
     }
-    let { nid, hub_id, color } = Visitor.wallpaper() || {};
     require("./skin/themes/light");
     require("./skin/themes/dark");
     // Display mode (light/dark/system) — single source of truth. Applies the
     // stored preference and wires the OS listener when set to "system".
     require("./theme").initTheme();
-    return;
-    this._wallpaper = '';
-    if (color && color.primary) {
-      this.el.style.background = '';
-      this.el.style.backgroundColor = color.primary;
-    } else if (nid && hub_id) {
-      this._wallpaper = _a.image;
-      this.el.style.backgroundColor = 'transparent';
-      this.ensurePart('wallpaper').then((p) => {
-        p.feed({ nid, hub_id, kind: 'drumee_background' });
-      })
-    }
-
   }
 
   /**

--- a/src/drumee/router/index.js
+++ b/src/drumee/router/index.js
@@ -19,6 +19,7 @@ require("builtins/contextmenu/skin/index.scss");
 require("./skin");
 
 const { getModule, moduleName } = require('./modules');
+const { captureCampaignArrival } = require('libs/campaign');
 
 class drumee_router extends LetcBox {
   constructor(...args) {
@@ -41,6 +42,10 @@ class drumee_router extends LetcBox {
     this._origin = {};
     this._mainBarreShown = false;
     this.declareHandlers();
+    // Cold arrival on a campaign link. Recorded before ANY module resolves: the
+    // signin plugin replaces the hash wholesale with "#/welcome/signin", so the
+    // markers are gone by the time a module could look for them.
+    captureCampaignArrival();
     localStorage.main_domain = bootstrap().main_domain;
     this._buffer = [];
     this._loaded = {
@@ -381,6 +386,12 @@ class drumee_router extends LetcBox {
    * 
    */
   route() {
+    // Warm arrival: clicking the CTA in a tab that already has the app running
+    // is a same-document navigation, so only hashchange fires and initialize()
+    // never runs again. Capturing at boot alone missed that entirely — which is
+    // the usual case, since the recipient is normally already on a Drumee page.
+    // A no-op when the URL carries no campaign params.
+    captureCampaignArrival();
     let page = /^\/.*(.+)\.htm?/;
     if (page.test(location.pathname) || page.test(Host.get(_a.homepage))) {
       this.loadBootstrap();


### PR DESCRIPTION
huancr7lm10@ clicked the CTA, was bounced to #/welcome/signin, signed in, and stayed at 'emailed' — no click was ever recorded.

Cause: the arrival was captured in the router's initialize() only, which runs once per DOCUMENT. Clicking the CTA in a tab that already has the app running is a same-document navigation — same origin, same path, only the fragment differs — so the browser fires hashchange and never re-runs initialize. route() is what is bound to onhashchange and it did not capture. The signin plugin then replaced the hash wholesale and the markers were gone. That is the COMMON case, since the recipient is normally already sitting on a Drumee page; the instant redirect they described is itself the tell that the app was booted.

route() now captures too — a no-op when the URL has no campaign params.

Second half of the same defect, opposite symptom: the params were never removed from the URL, so every later load of that address looked like a fresh click. That is how a user who never touched the CTA was handed the flow yesterday. captureCampaignArrival now consumes the URL via replaceState — which rewrites without firing hashchange, so tidying up cannot trigger another routing pass. Only the utm keys go; other deep-link args are left alone.

Fixing one without the other just swaps which symptom you see.

Verified against the real module, 12/12: the warm click now captured, cold click still captured, a reload of the cleaned URL is not a new arrival, hub_id/invite args survive the strip, the query-string form works, and a URL with no campaign params is left untouched.