### PR TITLE
feat(meeting): responsive resize — auto-collapse the panel, fold chat…

### DIFF
--- a/src/drumee/builtins/webrtc/skeleton/topbar.js
+++ b/src/drumee/builtins/webrtc/skeleton/topbar.js
@@ -231,6 +231,47 @@ module.exports = function (_ui_) {
     }),
   };
 
+  // Overflow menu for the controls the narrow layout drops. Chat and
+  // Participants are hidden from the bar below the data-narrow breakpoint (see
+  // meeting-shell.scss) and reachable here instead; this trigger is itself
+  // hidden until then, so the wide bar is unchanged. Items dispatch the SAME
+  // services as the real buttons (_a.chat / show-people), so the room wiring in
+  // window/meeting/index.js needs no new cases.
+  const moreItem = (ico, label, service) =>
+    Skeletons.Button.Label({
+      className: `${pfx}__more-item`,
+      ico,
+      label,
+      labelClass: `${pfx}__more-item-label`,
+      service,
+      uiHandler: [_ui_],
+    });
+
+  // P2P connect calls have no chat / people controls at all, so the overflow
+  // menu would be empty — omit the whole trigger rather than ship a dead button.
+  const moreBtn = isP2P
+    ? null
+    : {
+        kind: KIND.menu.topic,
+        className: `${pfx}__more-menu`,
+        flow: _a.y,
+        opening: _e.click,
+        persistence: _a.once,
+        offsetY: 8,
+        trigger: Skeletons.Button.Svg({
+          ico: "more",
+          className: `${pfx}__ctrl-btn more`,
+          attrOpt: { "data-tip": LOCALE.MORE || "More" },
+        }),
+        items: Skeletons.Box.Y({
+          className: `${pfx}__more-items`,
+          kids: [
+            moreItem("meet-chat-dots", LOCALE.CHAT, _a.chat),
+            moreItem("meet-users", LOCALE.PARTICIPANTS, "show-people"),
+          ],
+        }),
+      };
+
   const divider = Skeletons.Note({ className: `${pfx}__in-topbar-divider` });
 
   // Camera pill: toggle + device caret + video-input picker (twin of the mic
@@ -339,6 +380,8 @@ module.exports = function (_ui_) {
           reactionsBtn,
           isP2P ? null : chatWrap,
           isP2P ? null : peopleBtn,
+          // Stands in for chat + people once those are hidden (data-narrow).
+          moreBtn,
           fullscreenBtn,
           divider,
           cameraPill,

--- a/src/drumee/builtins/webrtc/skin/meeting-shell.scss
+++ b/src/drumee/builtins/webrtc/skin/meeting-shell.scss
@@ -13,6 +13,34 @@
 @use "builtins/webrtc/skin/remote" as *;
 @use "mixins/drumee";
 
+// Chat + Participants fold into the "more" overflow menu.
+//
+// The "more" trigger must appear if and ONLY if those two are hidden, so the
+// hide and the show live in one block rather than two rules kept in step by
+// hand. Two different breakpoints include this — window width (data-narrow)
+// and stage width (@container meeting-stage, which shrinks when the 420px chat
+// panel opens) — and neither can drift from the other.
+//
+// !important on every declaration, for the same reason the host-label hide
+// further down needs it: ui-styles/container.css ships
+// `.drumee-widget[data-flow=y] { display: flex }` (and the -box/-flow=x twin) at
+// specificity 0,2,0. The chat wrap is a Box.X and the "more" trigger is a
+// menu.topic carrying `flow: y`, so BOTH match it. Without !important the
+// @container call site — which can only reach 0,2,0, since @container adds no
+// specificity — merely ties with the framework rule and is decided by stylesheet
+// order. Do not "clean these up".
+@mixin meeting-overflow-fold($pfx) {
+  .#{$pfx}__in-topbar-chat-wrap,
+  .#{$pfx}__ctrl-btn.people,
+  .#{$pfx}__in-topbar-divider {
+    display: none !important;
+  }
+
+  .#{$pfx}__more-menu {
+    display: flex !important;
+  }
+}
+
 @mixin meeting-shell($chat: true, $pfx: "window-meeting") {
   @include webrtc-ui;
   @include webrtc-topbar;
@@ -430,7 +458,12 @@
   // responsive(); the window can be small on a large viewport so @media can't
   // catch it). Google-Meet-style graceful shrink. ──────────────────────────
   @if $chat {
-  &__ui[data-narrow="1"] &__chat-panel {
+  // data-panel-overlay is set below CHAT_AUTO_CLOSE_W (950px) in
+  // window/meeting/index.js responsive() — a strict superset of data-narrow
+  // (640px). The panel auto-collapses at that same width, so this styles the
+  // case where the user opens it BY HAND on a small window: full-bleed overlay
+  // rather than a 420px column that would leave the stage a sliver.
+  &__ui[data-panel-overlay="1"] &__chat-panel {
     // Side panel becomes a full-width overlay instead of a fixed 340px column
     // that crushes the video stage.
     position: absolute;
@@ -450,14 +483,12 @@
   }
   }
 
-  // Narrow window: drop the secondary reactions/fullscreen buttons so the
-  // primary controls (hand, chat, people, camera, mic, screen, leave) fit.
+  // Narrow window: fold chat + people into the "more" overflow menu so the
+  // primary controls (hand, reactions, fullscreen, camera, mic, screen, leave)
+  // still fit. Reactions and fullscreen stay in the bar; only the two controls
+  // the overflow menu can stand in for are dropped.
   &__ui[data-narrow="1"] {
-    .#{$pfx}__reactions-menu,
-    .#{$pfx}__resize-menu,
-    .#{$pfx}__in-topbar-divider {
-      display: none;
-    }
+    @include meeting-overflow-fold($pfx);
   }
 
   &__ui[data-compact="1"] {
@@ -698,16 +729,17 @@
     }
   }
 
-  // Stage column squeezed: drop the secondary buttons first, then collapse the
-  // leave button to icon-only. NB: `meeting-stage` is the stage column ALONE
-  // (the 420px chat panel is a flex sibling outside it), so this width is the
-  // space left AFTER the panel — keep the threshold low enough that simply
-  // opening the panel doesn't hide reactions on a normal-width window.
+  // Stage column squeezed: same fold, measured on the stage instead of the
+  // window. NB: `meeting-stage` is the stage column ALONE (the 420px chat panel
+  // is a flex sibling outside it), so this width is the space left AFTER the
+  // panel — a wide window with the panel open lands here.
+  //
+  // The &__ui nesting is load-bearing, not cosmetic: it supplies the specificity
+  // the mixin's single-class selectors need to beat the base rule (see the
+  // mixin's own note).
   @container meeting-stage (max-width: 480px) {
-    &__reactions-menu,
-    &__resize-menu,
-    &__in-topbar-divider {
-      display: none;
+    &__ui {
+      @include meeting-overflow-fold($pfx);
     }
   }
 
@@ -876,12 +908,14 @@
     animation: window-meeting-party-toast 4s ease-out forwards;
   }
 
-  // Narrow layout turns the chat/people panel into a full-width overlay at
+  // Overlay layout turns the chat/people panel into a full-width overlay at
   // z:140 — far below this layer, so a toast would float over the conversation.
   // Suppress while it is open (wide layout keeps the panel in its own column,
-  // clear of the bottom-left corner, so toasts stay).
+  // clear of the bottom-left corner, so toasts stay). Tracks data-panel-overlay
+  // rather than data-narrow so it covers the whole overlay range, not just
+  // below 640.
   @if $chat {
-    &__ui[data-narrow="1"] &__chat-panel[data-open="1"] ~ &__party-toasts {
+    &__ui[data-panel-overlay="1"] &__chat-panel[data-open="1"] ~ &__party-toasts {
       display: none;
     }
 
@@ -1000,6 +1034,75 @@
   }
 
   &__resize-item {
+    display: flex;
+    box-sizing: border-box;
+    align-items: center;
+    gap: 8px;
+    padding: 8px;
+    border-radius: 8px;
+    cursor: pointer;
+    color: var(--primary-purple-100, #0b0a21);
+    transition: background 0.12s ease;
+
+    svg {
+      width: 17px;
+      height: 17px;
+      flex-shrink: 0;
+      fill: currentColor;
+    }
+
+    .note-content {
+      @include drumee.typo(
+        $size: 12px,
+        $line: 17px,
+        $weight: 400,
+        $color: #0b0a21
+      );
+      white-space: nowrap;
+
+      section {
+        white-space: nowrap;
+      }
+    }
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.05);
+    }
+  }
+
+  // ── "More" overflow dropdown ───────────────────────────────────────────
+  // Hidden in the wide bar (chat + people are shown directly there); the
+  // data-narrow rule above flips it to flex at the same breakpoint that hides
+  // them, so exactly one of the two presentations is ever visible.
+  &__more-menu {
+    // !important: this is a menu.topic with `flow: y`, so it renders as
+    // .drumee-widget[data-flow="y"], which container.css gives display:flex at
+    // 0,2,0 — a plain single-class hide (0,1,0) loses and the trigger would sit
+    // in the wide bar alongside the chat + people buttons it exists to replace.
+    display: none !important;
+    position: relative;
+    flex-shrink: 0;
+
+    .menu-topic-trigger {
+      display: flex;
+      align-items: center;
+    }
+
+    .menu-topic-items {
+      background: #ffffff;
+      border-radius: 8px;
+      box-shadow: 0 1px 11px rgba(0, 0, 0, 0.13);
+      z-index: 300;
+    }
+  }
+
+  &__more-items {
+    width: 180px;
+    padding: 12px;
+    gap: 0;
+  }
+
+  &__more-item {
     display: flex;
     box-sizing: border-box;
     align-items: center;

--- a/src/drumee/builtins/widget/chat/index.js
+++ b/src/drumee/builtins/widget/chat/index.js
@@ -2113,6 +2113,11 @@ class __widget_chat extends LetcBox {
       this._newMsgCount++;
       this.__buttonScroll.el.dataset.count = this._newMsgCount;
       this.__list.append(data);
+      // Genuinely new inbound message — own posts return above via the echoId /
+      // message_id branches, so hosts can treat this as "someone else wrote".
+      // Purely additive: hosts that don't listen are unaffected. The meeting
+      // window uses it to light its unread badge while the chat pane is hidden.
+      this.trigger("message-received", data);
       // RADIO_BROADCAST.trigger('activity:notify', {type:"chat", ...data});
       return;
     }

--- a/src/drumee/builtins/window/meeting/index.js
+++ b/src/drumee/builtins/window/meeting/index.js
@@ -168,11 +168,11 @@ class __window_meeting extends __room {
     if (this._resizeObserver || !this.el || typeof ResizeObserver !== "function")
       return;
     this._resizeObserver = new ResizeObserver(() => {
-      if (this.isDestroyed && this.isDestroyed()) return;
+      if (this.isDestroyed?.()) return;
       // Same guard as _resize: while a presenter video is fullscreen the
       // browser owns geometry, and re-flowing can kick it straight back out.
       if (document.fullscreenElement) return;
-      this.responsive((this.el && this.el.dataset.mode) || "normal");
+      this.responsive(this.el?.dataset.mode || "normal");
     });
     this._resizeObserver.observe(this.el);
   }

--- a/src/drumee/builtins/window/meeting/index.js
+++ b/src/drumee/builtins/window/meeting/index.js
@@ -5,6 +5,11 @@ const __room = require("builtins/webrtc/room/jitsi");
 const PARTY_TOAST_MAX = 3;
 // Matches the window-meeting-party-toast fade-out tail.
 const PARTY_TOAST_MS = 4000;
+// Below this window width the 420px side panel and the video stage can no
+// longer share the row, so the panel auto-collapses (see _applyChatAutoClose)
+// and switches to full-bleed overlay mode when opened by hand
+// (data-panel-overlay in webrtc/skin/meeting-shell.scss).
+const CHAT_AUTO_CLOSE_W = 950;
 
 class __window_meeting extends __room {
   /**
@@ -105,8 +110,77 @@ class __window_meeting extends __room {
     if (!this.el || !this.$el) return;
     const w = this.$el.width() || this.el.offsetWidth || 0;
     if (!w) return;
-    this.el.dataset.narrow = w < 640 ? "1" : "0";
-    this.el.dataset.compact = w < 520 ? "1" : "0";
+    // The ResizeObserver, _resize, fitScreenSize, change_size and
+    // _applyWindowGeometry all funnel here, often for the same size — skip the
+    // redundant dataset writes. _applyChatAutoClose still runs every time: it
+    // is edge-triggered on its own state, and the panel does not exist yet on
+    // the first call of the mount sequence (responsive() runs once before the
+    // skeleton is fed and again straight after, at the same width), so gating
+    // it on a width CHANGE would drop the initial collapse entirely.
+    if (this._lastWidth !== w) {
+      this._lastWidth = w;
+      this.el.dataset.narrow = w < 640 ? "1" : "0";
+      this.el.dataset.compact = w < 520 ? "1" : "0";
+      // Panel switches to a full-bleed overlay at the same width it auto-closes,
+      // so a manual open below the threshold doesn't crush the stage into a
+      // sliver. Superset of data-narrow, which keeps its own job (dropping the
+      // secondary topbar controls).
+      this.el.dataset.panelOverlay = w < CHAT_AUTO_CLOSE_W ? "1" : "0";
+    }
+    this._applyChatAutoClose(w);
+  }
+
+  // Collapse the side panel when the window gets too small to hold both it and
+  // the stage, and bring it back when there's room again.
+  //
+  // Edge-triggered, NOT level-triggered: we act only on the crossing, never on
+  // every observation while small. That's what lets a manual open below the
+  // threshold survive — the topbar Chat button opens the panel as an overlay
+  // and no further resize tick slams it shut, because no new crossing occurred.
+  //
+  // `_chatAutoClosed` records that WE closed it, so widening restores it. Any
+  // user-initiated open/close clears the flag (see _setChatOpen), meaning a
+  // deliberate close while narrow stays closed on the way back up.
+  _applyChatAutoClose(w) {
+    const panel = this._chatPanelEl();
+    if (!panel) return;
+    const small = w < CHAT_AUTO_CLOSE_W;
+    const wasSmall = this._chatSmall;
+    this._chatSmall = small;
+    if (small === wasSmall) return;
+    if (small) {
+      if (panel.dataset.open === "1") {
+        this._chatAutoClosed = 1;
+        this._setChatOpen(false, { auto: 1 });
+      }
+    } else if (this._chatAutoClosed) {
+      this._chatAutoClosed = 0;
+      this._setChatOpen(true, { auto: 1 });
+    }
+  }
+
+  // Single source of truth for the size-driven layout. _resize only fires while
+  // dragging the window's own jQuery-UI handles, which misses the cases users
+  // actually hit: the browser viewport resizing (the WM clamps windows down in
+  // window/manager.js without notifying them) and embedded meetings whose host
+  // pane changes size. Observing the root element catches all of them.
+  _bindResizeObserver() {
+    if (this._resizeObserver || !this.el || typeof ResizeObserver !== "function")
+      return;
+    this._resizeObserver = new ResizeObserver(() => {
+      if (this.isDestroyed && this.isDestroyed()) return;
+      // Same guard as _resize: while a presenter video is fullscreen the
+      // browser owns geometry, and re-flowing can kick it straight back out.
+      if (document.fullscreenElement) return;
+      this.responsive((this.el && this.el.dataset.mode) || "normal");
+    });
+    this._resizeObserver.observe(this.el);
+  }
+
+  _unbindResizeObserver() {
+    if (!this._resizeObserver) return;
+    this._resizeObserver.disconnect();
+    this._resizeObserver = null;
   }
 
   /**
@@ -124,6 +198,7 @@ class __window_meeting extends __room {
   async onDomRefresh() {
     this.raise();
     this._initIdleControls();
+    this._bindResizeObserver();
     // Standalone (Wm pool) calls must float via the base window's absolute
     // positioning; embedded meetings (folder tab) stay relative/fill-parent.
     if (this.el) this.el.dataset.standalone = this.mget("standalone") ? "1" : "0";
@@ -173,6 +248,7 @@ class __window_meeting extends __room {
       this.feed(require("./skeleton")(this, room.user));
       await this.prepareConference(room);
       this.responsive();
+      this._bindChatUnread();
       this.ensurePart("commands").then((p) => {
         p.el.show();
       });
@@ -251,6 +327,7 @@ class __window_meeting extends __room {
 
   onBeforeDestroy() {
     clearTimeout(this._idleTimer);
+    this._unbindResizeObserver();
     // Cancel any pending hand-raise auto-clear timers so they can't fire after
     // teardown.
     if (this._handTimers) {
@@ -724,16 +801,64 @@ class __window_meeting extends __room {
     return this.el && this.el.querySelector(`.${this.fig.family}__chat-panel`);
   }
 
-  _setChatOpen(open) {
+  // `opts.auto` marks the call as coming from _applyChatAutoClose. Anything
+  // else is the user acting on the panel (topbar Chat/People, the close X, a
+  // tab switch), which retires any pending auto-restore — their choice outlives
+  // ours, so widening the window won't undo a deliberate close.
+  _setChatOpen(open, opts = {}) {
     const panel = this._chatPanelEl();
     if (!panel) return;
+    if (!opts.auto) this._chatAutoClosed = 0;
     panel.dataset.open = open ? "1" : "0";
-    if (open) {
-      const badge = this.el.querySelector(
-        `.${this.fig.family}__in-topbar-chat-badge`,
-      );
-      if (badge) badge.dataset.state = 0;
-    }
+    // Opening the panel only clears the pane you actually land on — a chat
+    // message shouldn't be marked seen because you opened Participants.
+    if (open) this._clearUnreadForTab(panel.dataset.tab);
+  }
+
+  // Unread-chat badge on the topbar chat button. NB: that button is hidden once
+  // the narrow layout folds chat into the "more" menu, so while narrow an
+  // unread message has no visible indicator — the "more" dot that used to
+  // mirror it was removed deliberately.
+  _setChatUnread(on) {
+    if (!this.el) return;
+    this._chatUnread = !!on;
+    const badge = this.el.querySelector(
+      `.${this.fig.family}__in-topbar-chat-badge`,
+    );
+    if (badge) badge.dataset.state = on ? "1" : "0";
+  }
+
+  // True only when the Chat pane is actually on screen — the panel must be open
+  // AND showing the chat tab. An open panel sitting on Participants does not
+  // count, otherwise messages would be marked read while never displayed.
+  _chatPaneVisible() {
+    const panel = this._chatPanelEl();
+    return (
+      !!panel && panel.dataset.open === "1" && panel.dataset.tab === "chat"
+    );
+  }
+
+  // Light the unread badge when a message lands while the chat pane is hidden.
+  // Skipped on rooms with no side panel (DMZ) — ensurePart would never resolve
+  // there, leaving a dangling part-ready listener.
+  _bindChatUnread() {
+    if (this._chatUnreadBound || !this._chatPanelEl()) return;
+    this._chatUnreadBound = 1;
+    this.ensurePart("meeting-chat-widget")
+      .then((w) => {
+        if (!w) return;
+        // listenTo (not on) so the subscription dies with the window.
+        this.listenTo(w, "message-received", () => {
+          if (!this._chatPaneVisible()) this._setChatUnread(true);
+        });
+      })
+      .catch(() => {});
+  }
+
+  // Clears only the source belonging to the pane being shown. Landing on
+  // Participants must NOT clear chat — those messages were never displayed.
+  _clearUnreadForTab(tab) {
+    if (tab !== "participants") this._setChatUnread(false);
   }
 
   // Topbar chat button: open the side panel on the Chat tab, or collapse it if

--- a/src/drumee/builtins/window/meeting/skeleton/index.js
+++ b/src/drumee/builtins/window/meeting/skeleton/index.js
@@ -155,6 +155,11 @@ function meetingSidePanel(_ui_) {
             send_icon: "raw-send-chat",
             attach_icon: "chat-link-simple",
             sys_pn: "meeting-chat-widget",
+            // partHandler is what registers the widget as an addressable part;
+            // sys_pn alone is not enough. Needed so the meeting can reach the
+            // instance via ensurePart and subscribe to "message-received" for
+            // the unread badge (see _bindChatUnread).
+            partHandler: [_ui_],
           },
         ],
       }),


### PR DESCRIPTION
…/people into "more"

The meeting window only re-ran its size-driven layout while dragging its own jQuery-UI handles, so data-narrow went stale in the cases users actually hit: the browser viewport resizing (the WM clamps windows down without notifying them) and embedded meetings whose host pane changes size. Observe the root element instead, and let every other caller funnel through responsive().

On top of that, drive the side panel and the control cluster off the measured width:

- Panel auto-collapses below 950px and restores on the way back up. Edge- triggered on the crossing, so a manual open while narrow survives later resize ticks; any user-initiated open/close retires the pending restore, so a deliberate close stays closed.
- Below the same width the panel opens as a full-bleed overlay (data-panel-overlay) rather than a 420px column that leaves the stage a sliver.
- Chat + Participants fold into a new "more" overflow menu; reactions and fullscreen keep their place in the bar. The show and the hide live in one mixin included by both the window-width and stage-width breakpoints, so the trigger appears if and only if the two controls it replaces are gone.
- Unread chat badge is now actually driven: widget_chat emits "message-received" for genuinely new inbound messages (own posts return earlier via the echoId / message_id branches), and the meeting lights the badge only when the chat pane is not on screen. Opening Participants no longer marks chat messages read.

The display rules need !important: ui-styles/container.css ships `.drumee-widget[data-flow=y] { display: flex }` at 0,2,0, which a plain single-class hide loses to, and which the @container call site can only tie with — @container contributes no specificity of its own.