### PR TITLE
fix(billing): the plans row is a flex row again, so the four cards sit side by side

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/plans.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/plans.js
@@ -430,7 +430,14 @@ function billing_content(ui, cycle = "monthly") {
   return Skeletons.Box.Y({
     className: `${fig}-main`,
     kids: [
-      Skeletons.Box.G({
+      // Box.X, not Box.G. The row's SCSS is written in flex terms — `flex-wrap:
+      // wrap` on the row and `flex: 1 1 260px` on each card, narrowing to
+      // `1 1 100%` under 620px. Box.G renders `display: grid`, where none of
+      // that applies: with no grid-template the four cards fall into a single
+      // column. It only ever looked right because the container query that
+      // revealed this layout also forced `display: flex !important`; removing
+      // that query took the flex context with it.
+      Skeletons.Box.X({
         className: `${fig}-narrow`,
         kids: [
           item(ui, "free", options.free),


### PR DESCRIPTION
Regression from #385 — the four plan cards stacked into a single column instead of sitting in a row.

## Cause

The card layout is rendered with `Box.G`, which emits `display: grid`. Its SCSS is written in flex terms — `flex-wrap: wrap` on the row, `flex: 1 1 260px` on each card, narrowing to `1 1 100%` under 620px — and **none of that applies** in a grid container with no template, so the cards fell into one column.

It had only ever looked right because the container query that used to reveal this layout also forced `display: flex !important`. Removing that query when the comparison table went took the flex context with it.

`Box.X` makes the row a real flex container, so the existing SCSS behaves as written.

## Verified on stage

At a 1600px viewport, opened **through the sidebar** rather than a detached mount (the earlier check was misled by a standalone `Wm.launch` whose host container was only 48px wide):

| Container width | Rows |
|---|---|
| 1280px | **1** — four cards at 311px each |
| 960px | 2 |
| 704px | 2 |
| 500px and below | 4 — one card per row |

Same stepping as before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)