### PR TITLE
fix(billing): a plan change no longer appears to undo itself

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/index.js
@@ -502,11 +502,27 @@ class settings_billing extends LetcBox {
    */
   fetchPlanData() {
     try {
-      // Get current plan from Visitor.quota()
-      // Structure: {plan: 'free', organization: 0, seat: 0, storage: 20000000000}
+      // Quota carries the entitlement figures (seats, storage, cycle).
       let { total_seat, plan = "free", billing_cycle = "monthly", storage } = Visitor.quota() || {}
-      // Get plan name from quota.plan (primary source)
-      const planName = (plan || "free").toLowerCase();
+      // ...but NOT the authoritative plan name. Visitor.quota() is a client
+      // cache refreshed only when the payment.plan_updated WS event lands and
+      // calls Visitor.respawn. The subscription mirror, by contrast, is read
+      // straight from the server by _loadSubscription.
+      //
+      // Reading the plan from the cache made a plan change appear to undo
+      // itself: the confirm flipped the cards optimistically, _awaitPlanSync
+      // then polled the MIRROR until it showed the new plan — and handed over
+      // to this method, which read the stale CACHE and put the old plan back.
+      // Server said business, the page said team. Prefer the mirror whenever
+      // there is a live subscription row; quota stays the source for everyone
+      // else (a free account has no mirror row at all).
+      const mirrored = String((this._subscription || {}).plan || "");
+      const planName = (mirrored || plan || "free").toLowerCase();
+      if (mirrored) {
+        const p = String((this._subscription || {}).period || "");
+        if (/^year/.test(p)) billing_cycle = "yearly";
+        else if (/^month/.test(p)) billing_cycle = "monthly";
+      }
       // Get period from plan_detail if available, default to monthly
 
       // Normalise quota.plan onto a card key. Legacy hand-granted rows carry


### PR DESCRIPTION
Changing plan flipped the cards, then put the old plan back a few seconds later. The server was right the whole time — mirror and quota both said `business` — but the page went back to saying `team`.

## Cause

`fetchPlanData` read the plan name from `Visitor.quota()`, which is a **client cache** refreshed only when the `payment.plan_updated` WS event lands and calls `Visitor.respawn`. The subscription mirror is read straight from the server by `_loadSubscription`.

So the sequence defeated itself:

1. Confirm flips the cards optimistically ✓
2. `_awaitPlanSync` polls the **mirror** until it shows the new plan ✓
3. …then hands over to `fetchPlanData`, which reads the stale **cache** and reverts everything the poll had just confirmed ✗

## Fix

Plan name and billing cycle now come from the mirror whenever there is a live subscription row. Quota remains the source for accounts that have none (a free account has no mirror row at all) and still supplies the entitlement figures — it is a cache of the entitlement, never the authority on which plan is held.

## Verified on stage

| Check | Before | After |
|---|---|---|
| Server on business, open the page | painted **team** | paints **business** |
| Switch business → team, at 3s / 12s / 22s | reverted at ~9s | holds at all three |
| Server after the switch | — | mirror `team/month $29`, quota `team 100 GB`, proration `invoice.paid` processed |

## Note on the payment step

There is deliberately **no checkout page** when changing plan. A live subscriber cannot be sent to checkout — that creates a *second* Stripe subscription and bills them twice, which is why `payment.checkout` refuses them. The switch is a price swap on the existing subscription: Stripe charges the prorated difference to the card on file immediately (verified earlier: +$63.76 upgrading, −$63.75 credited downgrading).

The confirm dialog says the difference is charged now but does not show the exact amount. Stripe can preview it (upcoming-invoice API) — worth adding if the amount should be visible before confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)