### PR TITLE
fix(build): stop sass emitting a BOM that voids the :root font vars

### DIFF
--- a/src/drumee/skin/vars/box-shadow.scss
+++ b/src/drumee/skin/vars/box-shadow.scss
@@ -14,10 +14,10 @@
   /*****************************Topbar*****************/
   --drumee-shadow-topbar: 0 2px 2px 1px rgba(63, 79, 117, 0.13), 0 6px 16px 0 rgba(86, 65, 113, 0.08), 0 2px 14px 0 rgba(194, 185, 203, 0.0);
   --shadow-topbar: --drumee-shadow-topbar:
-    /*****************************Account - préférence- language*****************/
+    /*****************************Account - preference- language*****************/
     --drumee-shadow-accountlist: 0 0px 5px 0px rgba(63, 79, 117, 0.13), 7px -6px 10px 0 rgba(86, 65, 113, 0.08), 0 2px 13px 0 rgba(194, 185, 203, 0.0);
 
-  /*****************************Account - préférence- language*****************/
+  /*****************************Account - preference- language*****************/
   --drumee-shadow-popup: 0 0 7px 0 rgba(0, 0, 0, 0.14), 0 0 6px 0 #f8fafc, 0 3px 5px 0 rgba(0, 0, 0, 0.2);
 
   /*****************************popup*****************/

--- a/webpack/module.js
+++ b/webpack/module.js
@@ -23,6 +23,10 @@ module.exports = function (basedir) {
             sassOptions: {
               sourceMap: true,
               sourceMapEmbed: true,
+              // Sass prepends a BOM to compressed output containing non-ASCII;
+              // style-loader injects it glued to the first selector, which kills
+              // the :root{--font-*} block. Never emit @charset/BOM.
+              charset: false,
               includePaths: [
                 resolve(basedir, drumee_path, 'skin'),
                 resolve(basedir, 'node_modules')


### PR DESCRIPTION
Sass prepends a U+FEFF BOM to compressed output when it contains non-ASCII (here: an accented comment trapped inside a custom-property value in `box-shadow.scss`). style-loader injects that CSS with the BOM glued to the first selector, turning it into `﻿:root` — which matches nothing, so every `--font-*` variable dies and the whole app falls back to Times. This is what broke fonts on the preview endpoint after the Jul 27 dependency refresh; stage escapes only by toolchain luck (different machine-local node_modules — no committed lockfile).

- `webpack/module.js`: pass `charset: false` to sass so it never emits a BOM/@charset, regardless of which machine builds.
- `box-shadow.scss`: de-accent the two comments that sit inside a custom-property value.