### PR TITLE
fix(build): stop sass emitting a BOM that voids the :root font vars

### DIFF
--- a/src/drumee/skin/vars/box-shadow.scss
+++ b/src/drumee/skin/vars/box-shadow.scss
@@ -14,10 +14,10 @@
   /*****************************Topbar*****************/
   --drumee-shadow-topbar: 0 2px 2px 1px rgba(63, 79, 117, 0.13), 0 6px 16px 0 rgba(86, 65, 113, 0.08), 0 2px 14px 0 rgba(194, 185, 203, 0.0);
   --shadow-topbar: --drumee-shadow-topbar:
-    /*****************************Account - préférence- language*****************/
+    /*****************************Account - preference- language*****************/
     --drumee-shadow-accountlist: 0 0px 5px 0px rgba(63, 79, 117, 0.13), 7px -6px 10px 0 rgba(86, 65, 113, 0.08), 0 2px 13px 0 rgba(194, 185, 203, 0.0);
 
-  /*****************************Account - préférence- language*****************/
+  /*****************************Account - preference- language*****************/
   --drumee-shadow-popup: 0 0 7px 0 rgba(0, 0, 0, 0.14), 0 0 6px 0 #f8fafc, 0 3px 5px 0 rgba(0, 0, 0, 0.2);
 
   /*****************************popup*****************/

--- a/webpack/module.js
+++ b/webpack/module.js
@@ -23,6 +23,10 @@ module.exports = function (basedir) {
             sassOptions: {
               sourceMap: true,
               sourceMapEmbed: true,
+              // Sass prepends a BOM to compressed output containing non-ASCII;
+              // style-loader injects it glued to the first selector, which kills
+              // the :root{--font-*} block. Never emit @charset/BOM.
+              charset: false,
               includePaths: [
                 resolve(basedir, drumee_path, 'skin'),
                 resolve(basedir, 'node_modules')


### PR DESCRIPTION
Carries drumee/ui-team#391 from test to preview: sass `charset: false` + de-accented comments, so the compressed CSS bundle no longer starts with a BOM that kills the `:root{--font-*}` block (Times-serif fallback seen on the preview endpoint since Jul 27).