### PR TITLE
fix(billing): yearly badge states the real saving (8.3%)

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/header.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/header.js
@@ -1,9 +1,22 @@
-// The yearly badge is the product-mandated figure (Figma / pricing table
-// 2026-07: two months free ≈ 16.5%), not computed from the catalog. NOTE:
-// the Stripe prices in force when this was set were 11 × monthly (one month
-// free, an 8.3% saving) — the yearly amounts must be brought to 10 × monthly
-// for this badge to state the truth. Flagged to product 2026-07-29.
-const YEARLY_SAVING = 16.5;
+/**
+ * What paying yearly actually saves, to one decimal, from the Team prices in
+ * the server catalog. Product decision 2026-07-29: the badge states the real
+ * figure — with yearly at 11 × monthly that is 8.3%, matching the checkout
+ * tab's "1 month free" — rather than the Figma 16.5%, which would have
+ * required dropping the yearly prices to 10 × monthly on both Stripe
+ * accounts. Returns 0 when it cannot be computed — the badge is then not
+ * rendered at all, which is better than a figure nobody checked.
+ * @param {Object} ui - UI instance
+ * @returns {number}
+ */
+function yearlySaving(ui) {
+  const month = Number(ui._catPrice("team", "month")) || 0;
+  const year = Number(ui._catPrice("team", "year")) || 0;
+  if (!month || !year) return 0;
+  const full = month * 12;
+  if (year >= full) return 0;
+  return Math.round(((full - year) / full) * 1000) / 10;
+}
 
 /**
  * Create tab item for header (Monthly, Yearly, Checkout)
@@ -68,7 +81,7 @@ function billing_tabs_trigger(ui) {
   // month<->year switch is a subscription update, not a new checkout.
   const kids = [
     item(ui, {content:LOCALE.MONTHLY, discountRate:0, pos:0, service:"select-plan"}),
-    item(ui, {content:LOCALE.YEARLY, discountRate:YEARLY_SAVING, pos:1, service:"select-plan"}),
+    item(ui, {content:LOCALE.YEARLY, discountRate:yearlySaving(ui), pos:1, service:"select-plan"}),
   ];
   if (!ui._checkoutTabAllowed || ui._checkoutTabAllowed()) {
     kids.push(item(ui, {content:LOCALE.CHECKOUT, discountRate:0, pos:2, service:"checkout"}));


### PR DESCRIPTION
Product decision: keep the real prices, correct the badge. Computed from the catalog (one decimal) so a price change updates it by itself; dropped entirely when the catalog can't be read. Re-agrees with the checkout tab's **"1 month free"** line, which the hardcoded 16.5% contradicted.

Verified on stage: toggle reads **Saved 8.3%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)