### PR TITLE
fix(folder-grid): column count follows the window width instead of a fixed 5/6

### DIFF
--- a/src/drumee/builtins/window/folder/skin/index.scss
+++ b/src/drumee/builtins/window/folder/skin/index.scss
@@ -2192,10 +2192,13 @@
     // Force grid content to stay at the top so empty space sits below
     // instead of stretching items vertically. 3-tier order:
     // workspace → folder → file.
-    // Fixed 5-column tracks (not auto-fill): the product spec is 5 tiles
-    // per row at normal window size, 6 when maximized/fullscreen (see the
-    // ≥701px @container block below). Rows are unbounded — overflow wraps
-    // down and scrolls vertically. The compact (≤700px) container rules
+    // Auto-fill tracks, not a fixed count. The original spec's "5 tiles per
+    // row, 6 maximized" was written for a laptop-sized window; on a wide
+    // monitor those 5–6 `1fr` tracks ballooned to ~250px around 120px tiles
+    // and the grid read as mostly empty space (reported 2026-07-29). A
+    // 120px-min track keeps the same ~5 columns in a ~700px window and
+    // simply adds columns as the window grows; tiles stretch at most a few
+    // px into the leftover fraction. The compact (≤700px) container rules
     // later in this file still win via source order.
     .workspace-section,
     .folder-section,
@@ -2203,7 +2206,7 @@
       align-content: start;
       align-items: start;
       justify-items: start;
-      grid-template-columns: repeat(5, minmax(0, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(var(--grid-cell-w), 1fr));
       gap: var(--grid-gap);
     }
 
@@ -2220,24 +2223,10 @@
     }
   }
 
-  // ── Full size → 6 tiles per row ─────────────────────────────────
-  // "Full" = browser fullscreen (⤢ button, native :fullscreen), the
-  // window-zoom menu action (data-zoomed, stamped in folder/index.js
-  // toggleZoom), or the headless workspace pane (data-headless, stamped
-  // in buildContent). Scoped ≥701px so the compact (≤700px) container
-  // rules always win in a narrow window regardless of state — these
-  // selectors otherwise out-rank them on specificity.
-  @container window-folder-w (min-width: 701px) {
-    &:fullscreen,
-    &[data-zoomed="1"],
-    &[data-headless="1"] {
-      .window__icons-scroll .workspace-section,
-      .window__icons-scroll .folder-section,
-      .window__icons-scroll .file-section {
-        grid-template-columns: repeat(6, minmax(0, 1fr));
-      }
-    }
-  }
+  // Fullscreen / zoomed / headless no longer force a 6-column grid: the
+  // auto-fill tracks above already scale the column count with the window,
+  // which is exactly what a maximized window needs — six `1fr` tracks on a
+  // wide monitor were the main source of the empty-space complaint.
 
   .window__content-main {
     flex: 1 1 auto;


### PR DESCRIPTION
Reported: on a large monitor the folder window showed 6 sparse columns (~250px tracks around 120px tiles) — most of the row was dead space.

**Cause**: the >700px container rules pinned `repeat(5, minmax(0,1fr))` (6 when maximized/headless) regardless of how wide the window actually is.

**Fix**: `repeat(auto-fill, minmax(var(--grid-cell-w), 1fr))` — ~5 columns at ~700px as before, more as the window grows. The fixed 6-column maximized override is removed (auto-fill covers it). Compact ≤700px and phone ≤480px rules untouched.

**Verified on stage** at a 2328px viewport: files pane 1460px renders **10 columns of ~124px**, normal and zoomed, folders still grouped before files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)