### PR TITLE
fix(auth): stop an accidental Back from landing on the spent Google consent page

### DIFF
--- a/src/drumee/drumee.js
+++ b/src/drumee/drumee.js
@@ -27,9 +27,23 @@ class Drumee extends Marionette.Application {
   }
 
   /**
-   * 
+   *
    */
   onStart() {
+    // Arriving from an OAuth provider leaves that provider's SPENT consent
+    // page as the history entry directly behind the app — Google answers a
+    // navigation back to it with "400 malformed, should not be retried".
+    // Push one buffer entry (same URL) so the first Back lands on the app
+    // again instead of that dead page. One entry only — a second Back still
+    // leaves, deliberately; this just absorbs the accidental one (trackpad
+    // swipe while editing a document, reported 2026-07-29). The CSS
+    // overscroll-behavior guard blocks the gesture itself; this covers the
+    // browser Back button and any UA that ignores overscroll-behavior.
+    try {
+      if (/accounts\.google\.com|appleid\.apple\.com/.test(document.referrer || "")) {
+        history.pushState(history.state, "", location.href);
+      }
+    } catch (e) { /* history API unavailable — nothing to guard */ }
     xhRequest(`yp.get_env`).then((r) => {
       if (!r || r.__status != 200 || r.response?.error) {
         return this.failover(r.response);

--- a/src/drumee/skin/index.scss
+++ b/src/drumee/skin/index.scss
@@ -14,6 +14,19 @@ body {
   visibility: visible;
 }
 
+html,
+body {
+  // Kill the two-finger horizontal-swipe "Back" gesture. The desk is a
+  // single-page app whose hash rarely changes, so the history entry BEHIND it
+  // is whatever the user arrived from — after a Google sign-in that is
+  // Google's spent OAuth consent page, which answers "400 malformed, should
+  // not be retried" when navigated back to. One accidental trackpad swipe
+  // while editing a document threw users onto that page (reported
+  // 2026-07-29). Deliberate Back via the browser button still works, and
+  // drumee.js pushes one buffer entry after an OAuth arrival for that case.
+  overscroll-behavior-x: none;
+}
+
 
 #--router {
   .wrapper.gateway {


### PR DESCRIPTION
**Reported**: editing a doc → suddenly on `accounts.google.com/signin/oauth/consent` showing *400 malformed, should not be retried*.

**Root cause**: that URL is Google's consent-resume page — the app has no code that links to it (verified across ui-team/loby/marketplace). It is simply the **history entry behind the desk** after a Google sign-in, and the desk's hash rarely changes — so one accidental two-finger swipe (very easy while editing in the EurOffice iframe) walked Back out of the SPA onto a page Google refuses to serve twice.

**Fix, two layers**
1. `overscroll-behavior-x: none` on html/body — the swipe gesture no longer triggers Back (browser Back button unaffected). Verified live on stage (computed style).
2. `drumee.js`: one buffer history entry when `document.referrer` is accounts.google.com / appleid.apple.com — the first Back after an OAuth arrival stays in the app; a second, deliberate Back still leaves.

**Not the cause**: the office version-history work — that branch isn't on `test`; stage runs without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)