### PR TITLE
Secure share: drop the Task tab from shared-link views

### DIFF
--- a/src/drumee/builtins/window/skeleton/toolkit/index.js
+++ b/src/drumee/builtins/window/skeleton/toolkit/index.js
@@ -24,6 +24,23 @@ function _dmzShareWithoutChat() {
   return !!(r && typeof r.isDmz === "function" && r.isDmz() && r._dmzShareCanChat === false);
 }
 
+// True in a DMZ share view: the sharebox itself, OR a NESTED window/folder opened
+// from a share (dmz/wm getWindowPreset pins the share token onto every window it
+// launches, at every nesting level, so the token is the reliable marker one or more
+// layers deep). Same expression the chatPanel/fileThreadPanel posting gates below
+// already use — deliberately NOT uiRouter.isDmz(), which reads bootstrap().area: the
+// env served on the share host carries no top-level `area` (only hub.area), so that
+// test is always false and would silently never fire. A normal desk folder window
+// has no share token, so desk/team/sharebox windows are unaffected — the Meeting tab
+// is already gated on this very signal (`meeting: !ui.mget(_a.token)`).
+function _inDmzShare(ui) {
+  if (!ui || !ui.fig) return false;
+  if (ui.fig.family === "dmz-sharebox") return true;
+  // Defensive: a throw here would take down the whole tab bar render.
+  return ui.fig.family === "window-folder" &&
+         typeof ui.mget === "function" && !!ui.mget(_a.token);
+}
+
 export function breadcrumbs(ui, opt) {
   return Skeletons.Wrapper.X({
     debug: __filename,
@@ -96,6 +113,33 @@ export function tabBar(ui, opt = {}) {
     chat_tab = "";
   }
 
+  let task_tab = folderTab({
+    ico: "app-task",
+    label: LOCALE.TASK || "Tasks",
+    service: "tab-task",
+    state: 0,
+    tab: _a.task,
+  });
+  let task_label = Skeletons.Button.Label({
+    className: `${cnRoot}-item ${ui.fig.family}__tab-bar-item`,
+    label: LOCALE.TASK,
+    ico: "list",
+    service: "tab-task",
+    state: 0,
+    dataset: { tab: _a.task },
+    uiHandler: [ui],
+  });
+
+  // A shared link carries files (and optionally a conversation) — never a task
+  // board, and the DMZ mounts no task panel: dmzSplitBody only ever builds the
+  // files + conversation panels while the skin hides BOTH for data-view="task",
+  // so the tab opened a blank body. Drop it in every share view, at every folder
+  // depth. Desk/team/sharebox windows keep it (_inDmzShare is false there).
+  if (_inDmzShare(ui)) {
+    task_label = "";
+    task_tab = "";
+  }
+
   const kids = useEmojiTabs
     ? [
         folderTab({
@@ -106,13 +150,7 @@ export function tabBar(ui, opt = {}) {
           tab: "files",
         }),
         chat_tab,
-        folderTab({
-          ico: "app-task",
-          label: LOCALE.TASK || "Tasks",
-          service: "tab-task",
-          state: 0,
-          tab: _a.task,
-        }),
+        task_tab,
       ]
     : [
         Skeletons.Button.Label({
@@ -125,15 +163,7 @@ export function tabBar(ui, opt = {}) {
           uiHandler: [ui],
         }),
         chat_label,
-        Skeletons.Button.Label({
-          className: `${cnRoot}-item ${ui.fig.family}__tab-bar-item`,
-          label: LOCALE.TASK,
-          ico: "list",
-          service: "tab-task",
-          state: 0,
-          dataset: { tab: _a.task },
-          uiHandler: [ui],
-        }),
+        task_label,
       ];
 
   if (opt.meeting) {


### PR DESCRIPTION
Reported on prod: a shared link shows a **Task** tab that has nothing behind it.

## The bug

It is not just cosmetic. In the DMZ, `dmzSplitBody` only ever mounts `[filesPanel, chatPanel]` — **no task panel is ever mounted** — while `modules/dmz/sharebox/skin/index.scss` hides the files panel *and* the chat panel for `data-view="task"`. So clicking Task in a share hid everything and mounted nothing: a **fully blank body**, escapable only by clicking Files.

## Fix (UI only — one file, no schema, no server)

`builtins/window/skeleton/toolkit/index.js`: hide the Task tab in every share view, at every folder depth.

The two task-tab descriptors move into `task_tab` / `task_label` **byte-identical** and blank out exactly like the existing `chat_tab` (the framework's `validChild = (e) => e && e.kind` drops falsy kids), behind a new local predicate:

```js
ui.fig.family === "dmz-sharebox" || (ui.fig.family === "window-folder" && !!ui.mget(_a.token))
```

This is the same expression the `chatPanel` / `fileThreadPanel` posting gates in this file already use. It is reliable one or more layers deep because `modules/dmz/wm/index.js::getWindowPreset` pins the share token onto **every** window it launches at every nesting level.

**Deliberately NOT `uiRouter.isDmz()`.** That reads `bootstrap().area`, and `intEnv()` in `src/drumee/api.js` builds its env with no `area` key — `yp.get_env` on the share host returns `area` only under `hub` (`'public'` on prod). So `isDmz()` is always false in production and a gate built on it would silently never fire. Worth knowing for future work in this area, and see the reviewer note below.

## Verification

- Verified on the test endpoint (drumee.in) by the reporter: no Task tab at the share root or in nested subfolders; Chat still appears when the link grants chat and stays absent when it does not; the desk folder window is unchanged.
- Deploy confirmed at bytecode level in the deployed bundle, not just on a green CI run.
- All **5** `tabBar` call sites enumerated — only the two DMZ ones match the predicate; desk folder, desk sharebox, desk team and the tutorial folder all keep their Task tab.
- 14-case harness over every call site plus degenerate inputs (`ui` null, no `fig`, no `mget`, falsy tokens), asserting no desk/team/sharebox surface loses its Task tab. **Negative-controlled**: removing the token check drops it to 9/14 and trips the invariant.
- No positional/`nth-child`/fixed-count tab CSS, and a 2-item tab bar is already a shipped state (the chat tab blanks the same way). A single "Files" tab for a no-chat share is the intended result.
- `showFolderTab` uses jQuery `.find()` (a no-op on an absent element) and guards `_taskFilterBtn`, so nothing throws. The only programmatic task-tab entry points — `linkFilesToTask`, `openTaskDeepLink`, and the `activeTab` deep link — are desk-only features. This change removes an entry point and cannot create one.

## Reviewer notes

- `check-source` fails by design here: the head is a hotfix branch, not `test`. The same change is already on `test` as `d13ae6d9`, patch-content identical.
- The `tab-task` case in the DMZ sharebox's `onUiEvent` is left in place. It is now unreachable there, but keeping it is the minimal change and it still works if the tab is ever re-enabled.
- **Pre-existing bug found, deliberately not fixed here:** `_dmzShareWithoutChat()` is built on the same `isDmz()` and is therefore dead code in production. Its job is hiding the Chat tab in nested subfolders of a share with no chat grant; at the share root the `opt.chat === false` argument masks it. Likely live symptom: a no-chat share shows a Chat tab one folder deep. The fix is a one-line swap to the predicate added here, but it is a separate bug and is being tracked separately.