### PR TITLE
fix(desk): hide the topbar actions outright on admin console / settings

### DIFF
--- a/src/drumee/modules/desk/skin/topbar.scss
+++ b/src/drumee/modules/desk/skin/topbar.scss
@@ -30,8 +30,13 @@
 
   &__actions-cluster {
     &[data-state="0"] {
-      opacity: 0.45;
-      pointer-events: none;
+      // Hidden outright, not dimmed (2026-07-29): the admin console and
+      // Settings pages set state 0 on this cluster, and a greyed-out,
+      // dead Add new / Search / Invite row read as broken UI. None of
+      // those actions mean anything on those pages, so remove them.
+      // !important — Box children are forced display:flex inline by the
+      // framework.
+      display: none !important;
     }
   }
 


### PR DESCRIPTION
The Add new / Upload / Search / Invite cluster was dimmed (opacity .45, inert) on the admin console and Settings pages — a dead grey row that read as broken. It is now hidden entirely on those pages (state 0 → display:none), and restored on Home.

Verified on stage: admin console topbar shows only the breadcrumb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)