### PR TITLE
fix(desk): topbar actions come back when a workspace opens from the console

### DIFF
--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -59,6 +59,18 @@ class desk_module extends LetcBox {
     // open the full-page billing screen without a direct module reference.
     this._openBillingPage = () => this.openBillingPage();
     RADIO_BROADCAST.on("desk:open-billing-page", this._openBillingPage);
+    // The topbar action cluster (Add new / Upload / Search / Invite) is
+    // hidden while the admin console or Settings page is up (state 0, set in
+    // _showPanel) and restored by loadHome/togglePanel — but OPENING A
+    // WORKSPACE from one of those pages goes through the window manager and
+    // touched neither, leaving the topbar dead over a file view (reported
+    // 2026-07-29: "top bar của workspace bị freeze"). The wm broadcasts
+    // workspace:focus whenever a hub window opens or takes focus — restore
+    // the cluster on it.
+    this._restoreTopbarActions = () => {
+      this.ensurePart("action-cluster").then((p) => p && p.setState(1));
+    };
+    RADIO_BROADCAST.on("workspace:focus", this._restoreTopbarActions);
     setTimeout(this.lazyClasses, 5000);
 
     // Chrome-style folder tabs in the desk topbar. One tab per open


### PR DESCRIPTION
Opening a workspace **from the admin console / Settings page** left the topbar action cluster in its hidden/disabled state (the wm path never reset it) — reported as 'top bar của workspace bị freeze'. The desk now restores it on the wm's `workspace:focus` broadcast. Verified on stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)