### PR TITLE
Secure share: restore chat hiding in nested subfolders of a no-chat share

### DIFF
--- a/src/drumee/builtins/window/skeleton/toolkit/index.js
+++ b/src/drumee/builtins/window/skeleton/toolkit/index.js
@@ -15,13 +15,25 @@ const AREA_LABELS = {
 // folder depth: nested subfolders open as plain desk folder windows that lose the
 // share's caps, so per-window gating doesn't reach them — but the recipient's
 // whole session is one share with fixed caps, so this session-global is correct
-// at any depth. Gated on uiRouter.isDmz() (the boot area), so it can NEVER be true
-// in a normal desk session → desk folders are completely unaffected. The flag is
-// published by the DMZ sharebox on loadDeskContent(); `=== false` means we only
-// hide when chat is explicitly not granted (unknown/undefined → show, safe default).
-function _dmzShareWithoutChat() {
+// at any depth. The flag is published by the DMZ sharebox on loadDeskContent();
+// `=== false` means we only hide when chat is explicitly not granted
+// (unknown/undefined → show, safe default).
+// ⚠️ The uiRouter.isDmz() this used to gate on is ALWAYS FALSE in production —
+// it tests bootstrap().area, and intEnv() (src/drumee/api.js) builds the env with
+// no `area` key at all (yp.get_env exposes area only under `hub`). So this helper
+// never returned true on prod: the chat tab AND the conversation panel both stayed
+// mounted inside nested subfolders of a share that grants no chat, which is exactly
+// the "chat visible before permission" exposure the callers exist to prevent. It was
+// masked at the share root, where the sharebox passes opt.chat === false explicitly.
+// Now gated on the structural predicate instead (same one the posting gates use).
+// `_dmzShareCanChat` is published from exactly ONE place — dmz/sharebox/index.js
+// loadDeskContent(), as `!!this.mget('can_chat')` — so `=== false` can only mean the
+// sharebox declared this share has no chat grant. Unset/undefined (boot race, or any
+// desk session) → false → chat SHOWN, i.e. the pre-existing safe default.
+function _dmzShareWithoutChat(ui) {
+  if (!_inDmzShare(ui)) return false;
   const r = (typeof window !== "undefined") && window.uiRouter;
-  return !!(r && typeof r.isDmz === "function" && r.isDmz() && r._dmzShareCanChat === false);
+  return !!(r && r._dmzShareCanChat === false);
 }
 
 // True in a DMZ share view: the sharebox itself, OR a NESTED window/folder opened
@@ -108,7 +120,7 @@ export function tabBar(ui, opt = {}) {
   // chat tab is unchanged. _dmzShareWithoutChat() additionally hides it inside nested
   // recipient subfolders (which lose opt.chat). Personal-area folders keep the chat
   // tab — the folder team chat is identical across all areas.
-  if (opt.chat === false || _dmzShareWithoutChat()) {
+  if (opt.chat === false || _dmzShareWithoutChat(ui)) {
     chat_label = "";
     chat_tab = "";
   }
@@ -1168,7 +1180,7 @@ export function folderFilesView(ui) {
       : filesContainer(ui);
   // Recipient subfolder of a no-chat share → files only (no conversation panel).
   // Personal-area folders keep the chat panel — folder chat is identical across areas.
-  if (_dmzShareWithoutChat()) return [files];
+  if (_dmzShareWithoutChat(ui)) return [files];
   // [files, splitter, rail, chat, file-thread panel] — the resize gutter sits
   // BETWEEN files and chat so grid auto-placement lays it out as the middle
   // column in the Files view (files | gutter | chat); rail + panel flank the


### PR DESCRIPTION
A recipient of a share that grants **no chat** still got the Chat tab **and a mounted conversation panel** once they navigated into a subfolder. That is the "chat visible before permission" exposure those call sites exist to prevent — the panel loads the chat widget and subscribes to the channel.

## Cause

`_dmzShareWithoutChat()` gated on `uiRouter.isDmz()`, which tests `bootstrap().area`. But `intEnv()` in `src/drumee/api.js` builds the env with **no `area` key at all** — `yp.get_env` on the share host exposes area only under `hub` (and it is `'public'` on prod). So the helper **never returned true in production** and both its callers were inert:

- `tabBar` → the Chat tab
- `folderFilesView` → the conversation panel

It was masked at the share root, where the sharebox passes `opt.chat === false` explicitly, so only nested subfolders were affected.

## Fix

Gate on the structural predicate instead — the sharebox family, or a `window/folder` carrying the pinned share token. That is the same signal the chat-posting gates in this file already use, and it is reliable at any depth because `dmz/wm getWindowPreset` pins the share token onto every window it launches (that pinning is itself security-load-bearing: it closes the view-only one-layer-deep write hole).

## Why this is safe

- `_dmzShareCanChat` has **exactly one writer** — `dmz/sharebox/index.js loadDeskContent()`, as `!!this.mget('can_chat')` — so `=== false` can only mean the sharebox declared this share has no chat grant.
- Unset or undefined (boot race, or any desk session) → `false` → **chat shown**, which is the pre-existing safe default. The change can only ever hide chat where the share genuinely lacks the grant.
- A desk window has no share token, so `_inDmzShare` is false there and desk/team/sharebox surfaces **cannot lose their chat even if a stale flag were present**.

## Verification

- 17-case harness over both call sites, including five desk-with-stale-flag cases and `flag === 1` / `flag === 0` (neither must hide), plus degenerate inputs (`ui` null, no `fig`, no `mget`, no router).
- **Two negative controls**: simulating the old always-false `isDmz()` drops it to 15/17 (the two hide-cases fail, i.e. it reproduces the bug); removing the structural guard drops it to 9/17 and trips the desk invariant, exit 1.
- The task-tab suite from #400 still passes 14/14.
- Verified on the test endpoint (drumee.in), bytecode-checked in the deployed bundle.

## Reviewer notes

- `check-source` fails by design: the head is a hotfix branch, not `test`. The same change is on `test` as `ac9fb7c4`.
- The stale sentence in the comment above the helper, which still described the `isDmz()` gating, is corrected in the same commit.
- Worth knowing for future work in this area: **any DMZ gate written on `uiRouter.isDmz()` is silently inert.**