### PR TITLE
fix(sidebar): final toggle/open-only split per product spec

### DIFF
--- a/src/drumee/builtins/panel/trash/skeleton/topbar.js
+++ b/src/drumee/builtins/panel/trash/skeleton/topbar.js
@@ -14,7 +14,7 @@ module.exports = function (ui) {
       Skeletons.Image.Svg({
         ico: 'cross',
         className: `${pfx}__header-icon`,
-        service: "close-trash",
+        service: "toggle-trash",
         uiHandler: [Desk]
       }),
     ],

--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -2151,16 +2151,18 @@ class desk_module extends LetcBox {
 
       case "toggle-inbox":
       case "toggle-chat":
-        // Sidebar re-click on the active item keeps the layout open
-        // (openOnly) — closing goes through the panel's own close paths.
-        return this.togglePanel("chat_p2p", "chat-panel", true);
+        return this.togglePanel("chat_p2p", "chat-panel");
 
       case "toggle-contacts":
         RADIO_BROADCAST.trigger("breadcrumb:context", {
           filename: LOCALE.CONTACTS,
         });
-        return this.togglePanel("address_book", "chat-panel", true);
+        return this.togglePanel("address_book", "chat-panel");
 
+      // Product spec 2026-07-30 — sidebar click behaviour:
+      //   toggle    : notification bell, inbox/chat, contacts, trash
+      //   open-only : settings, billing (openBillingPage), admin console,
+      //               home (loadHome), user menu (fires toggle-settings)
       case "toggle-settings":
         RADIO_BROADCAST.trigger("breadcrumb:context", {
           filename: LOCALE.SETTINGS,
@@ -2199,11 +2201,6 @@ class desk_module extends LetcBox {
         RADIO_BROADCAST.trigger("breadcrumb:context", {
           filename: LOCALE.TRASH,
         });
-        return this.togglePanel("panel_trash", "trash-panel", true);
-
-      // The trash topbar X — the one caller that still needs the close
-      // half of the old toggle (the sidebar item above is open-only now).
-      case "close-trash":
         return this.togglePanel("panel_trash", "trash-panel");
 
       // Every billing entry point (sidebar "Upgrade plan", Settings "Manage


### PR DESCRIPTION
Product spec 2026-07-30 for sidebar click behaviour:

| behaviour | items |
|---|---|
| **toggle** | notification bell, inbox/chat, contacts, trash |
| **open-only** | settings, billing & subscription, admin console, home, user menu |

PR #418 had made every layout item open-only — this restores the toggle half for inbox/contacts/trash and reverts the trash-✕ service split (with toggle back, the ✕ closes through `toggle-trash` as before).

Verified on stage: trash/contacts open→re-click closes; admin console stays open on re-click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)