### PR TITLE
fix(dmz): restyle the share status popup, drop the mailto OK button, brand the revoked card

### DIFF
--- a/src/drumee/modules/dmz/index.js
+++ b/src/drumee/modules/dmz/index.js
@@ -100,15 +100,13 @@ class __dmz_router extends LetcBox {
       case _a.hide:
         return this.getItemsByKind('window_downloader')[0].el.hide();
 
-      case 'redirect-to-home':
-        let subject = LOCALE.INVALID_LINK;
-        let body = location.href
-        subject = encodeURIComponent(subject);
-        body = encodeURIComponent(body);
-        var mailToLink = `mailto:?subject=${subject}&body=${body}`;
-        window.location.href = mailToLink;
-        this.getPart('wrapper-modal').clear();
-        return
+      // 'redirect-to-home' removed 2026-07-30. Despite the name it never
+      // redirected here — it opened a mailto: composer (subject = INVALID_LINK,
+      // body = the current URL), so the "OK" button on every share status popup
+      // launched the visitor's mail client. Its only callers were the six
+      // statuses in dmz/sharebox handleInfoStatus(), which now fall through to
+      // the popup's 'close-popup' default. The identically-named service in the
+      // welcome module is a genuine redirect and is NOT affected.
     }
   }
 

--- a/src/drumee/modules/dmz/sharebox/index.js
+++ b/src/drumee/modules/dmz/sharebox/index.js
@@ -1262,11 +1262,15 @@ class __dmz_sharebox extends LetcBox {
     if (!data.is_secure && data.dmz_expiry == _a.expired) {
       status = 'TICKET_EXPIRED';
     }
+    // No case sets btnService: the popup defaults to 'close-popup'. These all used
+    // to pass 'redirect-to-home', which in the dmz module did NOT redirect — it
+    // opened a mailto: composer — so "OK" popped the visitor's mail client on
+    // every one of these screens. (The welcome module's same-named service is a
+    // real redirect and is untouched.)
     switch (status) {
       case 'INACTIVE_TICKET':
       case 'TICKET_EXPIRED':
         opt.content = LOCALE.LINK_EXPIRES
-        opt.btnService = 'redirect-to-home'
         break
 
       case "INVALID_CREDENTIAL":
@@ -1274,25 +1278,21 @@ class __dmz_sharebox extends LetcBox {
 
       case 'TICKET_REVOKED':
         opt.content = LOCALE.SECURE_SHARE_REVOKED
-        opt.btnService = 'redirect-to-home'
         break
 
       case 'WRONG_TICKET':
       case 'TICKET_INVALID':
         opt.content = LOCALE.INVALID_LINK
-        opt.btnService = 'redirect-to-home'
         break
 
       case 'EMAIL_EXIST':
         opt.content = LOCALE.EMAIL_EXIST_SIGN_CONTINUE
-        opt.btnService = 'redirect-to-home'
         break
 
       // Logged in as an account that is not on the share's allow-list — this link
       // is restricted to a specific email; the recipient must sign in as that one.
       case 'EMAIL_MISMATCH':
         opt.content = LOCALE.SECURE_SHARE_EMAIL_BLOCKED
-        opt.btnService = 'redirect-to-home'
         break
 
       default:

--- a/src/drumee/modules/dmz/sharebox/index.js
+++ b/src/drumee/modules/dmz/sharebox/index.js
@@ -1278,6 +1278,8 @@ class __dmz_sharebox extends LetcBox {
 
       case 'TICKET_REVOKED':
         opt.content = LOCALE.SECURE_SHARE_REVOKED
+        // Brand lockup on the revoked card only (Duy 2026-07-30).
+        opt.logo = 1
         break
 
       case 'WRONG_TICKET':

--- a/src/drumee/modules/dmz/skeleton/popup-message.js
+++ b/src/drumee/modules/dmz/skeleton/popup-message.js
@@ -37,6 +37,18 @@ function __skl_dmz_popup_message (_ui_, opt) {
     className : `${popupFig}__container u-jc-center u-ai-center`,
     debug     : __filename, 
     kids: [
+      // Brand lockup, opt-in via opt.logo — set ONLY by the revoked status, so
+      // every other status keeps the card exactly as it is. raw-logo-drumee-full
+      // is the mark AND the "drumee" wordmark in ONE sprite (viewBox 160x40), so
+      // the name needs no text node and no new asset. Its paths carry the
+      // #433CC5 brand purple themselves, and the symbol is
+      // preserveAspectRatio="xMidYMid meet" so it scales to the card without
+      // ever distorting. A null kid is dropped by ui-core's validChild.
+      opt.logo ? Skeletons.Image.Svg({
+        ico       : 'raw-logo-drumee-full',
+        className : `${popupFig}__logo`
+      }) : null,
+
       Skeletons.Note({
         className : `${popupFig}__message`,
         content

--- a/src/drumee/modules/dmz/skeleton/popup-message.js
+++ b/src/drumee/modules/dmz/skeleton/popup-message.js
@@ -3,6 +3,22 @@
 //   FILE : /src/drumee/modules/dmz/skeleton/popup-message.js
 //   TYPE : Skeleton
 // ==================================================================== *
+//
+//   Status card for the share landing page (link revoked / expired /
+//   invalid / email already registered / email not allowed / error).
+//   Rendered by Dmz.say() into the dmz-router wrapper-modal.
+//
+//   The card is restyled in popup.scss to match the other secure-share
+//   popups (sharebox request-sent / request-access / signup-required);
+//   the STRUCTURE here is deliberately unchanged so the restyle cannot
+//   regress the markup.
+//
+//   The default btnService is 'close-popup' (__dmz_router.onUiEvent clears
+//   the wrapper). Callers no longer pass 'redirect-to-home': in THIS module
+//   that case never redirected — it opened a mailto: composer — so the "OK"
+//   button popped the visitor's mail client. Dropped 2026-07-30.
+//
+// ==================================================================== *
 
 function __skl_dmz_popup_message (_ui_, opt) {
 
@@ -11,13 +27,19 @@ function __skl_dmz_popup_message (_ui_, opt) {
   let btnService = opt.btnService || 'close-popup';
   let btnLabel = opt.btnLabel || LOCALE.OK
 
+  // Two of these locale strings carry a trailing space (LINK_EXPIRES,
+  // EMAIL_EXIST_SIGN_CONTINUE). A trailing space is not collapsed when the
+  // text fits on one centered line, so it shifts the sentence off-centre by
+  // half a space. Trim strings only — a caller may pass a skeleton node.
+  const content = _.isString(opt.content) ? opt.content.trim() : opt.content;
+
   const a = Skeletons.Box.Y({
     className : `${popupFig}__container u-jc-center u-ai-center`,
     debug     : __filename, 
     kids: [
       Skeletons.Note({
         className : `${popupFig}__message`,
-        content   : opt.content
+        content
       }),
 
       Skeletons.Box.X({

--- a/src/drumee/modules/dmz/skin/popup.scss
+++ b/src/drumee/modules/dmz/skin/popup.scss
@@ -15,58 +15,103 @@
         top: 0;
         width: 100vw;
         height: 100vh;
-        background-color: rgba(0, 0, 0, 0.14)
+        background-color: rgba(0, 0, 0, 0.14);
+        align-items: center;
+        justify-content: center;
       }
     }
   }
 
+  // Status card (link revoked / expired / invalid / email already registered /
+  // email not allowed / error), fed by Dmz.say().
+  //
+  // Matches the other secure-share popups — sharebox request-sent /
+  // request-access / signup-required. Those live under .dmz-sharebox, which is
+  // where the --sb-* design tokens are declared; this card is in the sibling
+  // dmz-router subtree and cannot see them, so the values are mirrored below
+  // under popup-local names. SOURCE OF TRUTH =
+  // modules/dmz/sharebox/skin/index.scss (--sb-white / --sb-text / --sb-cta /
+  // --sb-card-shadow / --sb-font-body); keep them in step. Local names, not the
+  // --sb-* ones, so this can never shadow a token inside the sharebox subtree.
+  //
+  // Light-only on purpose: the whole share landing page hardcodes its light
+  // surfaces the same way, so a visitor with the dark theme must not get a dark
+  // popup on a light page.
   &-popup {
     &__container {
-      min-height: 380px;
-      width: 600px;
-      border-radius: var(--border-radius); //4px;
-      margin: auto;
-      background-color: var(--default-bg);
-      box-shadow: var(--shadow-popup); //0 5px 8px 1px rgba(63,79,117,0.13), 0 6px 16px 0 rgba(86,65,113,0.08), 0 2px 14px 0 rgba(194,185,203,0);
-    }
+      --dmz-popup-surface: #ffffff;
+      --dmz-popup-text: #0b0a21;
+      --dmz-popup-cta: #433cc5;
+      --dmz-popup-shadow: 0 1px 11px 0 rgba(0, 0, 0, 0.13);
+      --dmz-popup-font: "Geist", system-ui, -apple-system, "Segoe UI", sans-serif;
 
-    &__footer {
-      height: 100%;
-      max-height: 120px;
-      padding: 5px;
-      width: 100%;
+      background-color: var(--dmz-popup-surface);
+      border-radius: 12px;
+      box-shadow: var(--dmz-popup-shadow);
+      gap: 24px;
+      margin: auto;
+      max-width: calc(100vw - 64px);
+      padding: 40px 48px;
+      width: 480px;
     }
 
     &__message {
-      @include drumee.typo($color: var(--default-text-color), $size: 18px, $line: 28px); //$line: 24px$size: 20px,
-      align-items: center;
-      height: 100%;
-      justify-content: center;
+      // typo() emits size/line/colour only — it never sets font-weight, and for
+      // $weight: 600 it sets no font-family either. Both are declared after it
+      // (a 400/500/700 branch would otherwise overwrite the family).
+      @include drumee.typo($color: var(--dmz-popup-text), $size: 18px, $line: 26px);
+      font-family: var(--dmz-popup-font);
+      font-weight: 600;
+      margin: 0;
+      text-align: center;
       width: 100%;
-      max-width: 343px;
-      margin-left: auto;
-      margin-right: auto;
-      max-height: 160px; //120px;
+      // Even line lengths and no lone trailing word. `balance` wins where it is
+      // supported; `pretty` covers the engines that only have that one. Both are
+      // ignored safely by older engines, which fall back to normal wrapping.
+      text-wrap: pretty;
+      text-wrap: balance;
+
+      // Note renders its text into an inner wrapper (`inner note-content`),
+      // which has to carry the centring too — same guard window-confirm uses.
+      .note-content,
+      .inner,
+      p {
+        margin: 0;
+        text-align: center;
+        width: 100%;
+      }
+    }
+
+    &__footer {
+      width: 100%;
     }
 
     &__button {
-      @include drumee.typo($color: var(--default-text-reverse), $size: 18px, $line: 21px, $weight: 300);
+      background-color: var(--dmz-popup-cta);
+      border-radius: 4px;
+      cursor: pointer;
+      min-width: 120px;
+      padding: 12px 24px;
+      text-align: center;
+      white-space: nowrap;
+      @include drumee.typo($color: #ffffff, $size: 14px, $line: 20px);
+      font-family: var(--dmz-popup-font);
+      font-weight: 600;
+      transition: filter 120ms ease;
 
-      &.go {
-        @include drumee.typo($color: var(--btn-rollback-text), $size: 16px, $line: 21px);
-        border: 1px solid var(--btn-rollback-border); //var(--white-f6);
-        //  box-shadow: 0 4px 6px 1px rgba(63,79,117,0.13), 0 0 11px 0 rgba(86,65,113,0.08), 0 0 10px 0 rgba(194,185,203,0);
-        color: var(--btn-rollback-text); //var(--egrey-89);
-        cursor: pointer;
-        height: 32px; //36px;
-        width: 90px; //160px;
-        border-radius: var(--border-radius);
-
-        &:hover {
-          border: 2px solid var(--btn-rollback-border-hover);
-          color: var(--btn-rollback-text-hover);
-        }
+      &:hover {
+        filter: brightness(1.08);
       }
+    }
+  }
+}
+
+@media (max-width: 650px) {
+  .dmz-router-popup {
+    &__container {
+      max-width: calc(100vw - 32px);
+      padding: 32px 24px;
+      width: calc(100vw - 32px);
     }
   }
 }

--- a/src/drumee/modules/dmz/skin/popup.scss
+++ b/src/drumee/modules/dmz/skin/popup.scss
@@ -55,6 +55,24 @@
       width: 480px;
     }
 
+    // Brand lockup (mark + "drumee" wordmark), rendered only when the caller
+    // sets opt.logo — today just the revoked card. The sprite is 160x40 with
+    // preserveAspectRatio="xMidYMid meet", so this 4:1 box shows it whole and
+    // undistorted, and it stays well inside the card's 384px content width.
+    // Its paths already carry #433CC5; the fill below only takes effect if the
+    // icon is ever re-exported as currentColor.
+    &__logo {
+      flex-shrink: 0;
+      height: 32px;
+      width: 128px;
+
+      svg {
+        fill: var(--dmz-popup-cta);
+        height: 100%;
+        width: 100%;
+      }
+    }
+
     &__message {
       // typo() emits size/line/colour only — it never sets font-weight, and for
       // $weight: 600 it sets no font-family either. Both are declared after it


### PR DESCRIPTION
Recipient-side hotfix on the share landing page. **UI only — no server, no schema, no locale, and nothing in the auth / session / gate / grant surface.** All four files are under `src/drumee/modules/dmz/`.

Reported by Duy from prod (`share.app.drumee.com/-/#/dmz/share/<token>`, anonymous, revoked link): the status popup was a 600×380 white box with a small outlined OK, nothing like the rest of Drumee. The three source files were byte-identical on `preview`, so it looked the same on every endpoint.

### 1. The card now matches the secure-share popups
White card, radius 12, `0 1px 11px rgba(0,0,0,.13)`, `padding 40px 48px`, `width 480 / max-width calc(100vw - 64px)`, message 18/26 centered, filled `#433cc5` CTA, plus a `max-width: 650px` block. Values mirror `sharebox` `request-sent` / `request-access` / `signup-required`.

Those popups live under `.dmz-sharebox`, where the `--sb-*` tokens are declared. This card is in the sibling **dmz-router** subtree and cannot see them, so the five values are mirrored under popup-local `--dmz-popup-*` names — deliberately *not* `--sb-*`, which could shadow the sharebox's own tokens (including the `[data-area="restricted"]` accent). Light-only on purpose: the whole landing page hardcodes light surfaces, so a dark-theme visitor must not get a dark popup on a light page.

### 2. Perfect centering, no orphan word
Duy's requirement was that no single word drops onto its own line. Three parts: `text-align: center` mirrored onto the Note's inner `note-content` wrapper (a Note renders its text into a child div, so styling the parent alone is not enough); `text-wrap: balance` with a `pretty` fallback; and a `.trim()` on string content, because `LINK_EXPIRES` and `EMAIL_EXIST_SIGN_CONTINUE` carry a **trailing space** that is not collapsed on a single centered line and pushed the sentence half a space off-centre.

### 3. 🐞 "OK" used to open the visitor's mail client
Five of the six statuses passed `btnService: 'redirect-to-home'`. In **this** module that case never redirected — `modules/dmz/index.js` built `mailto:?subject=<INVALID_LINK>&body=<current URL>` and assigned `window.location.href`. Pre-existing since the GitLab import. They now fall through to the popup's existing `close-popup` default and the dead handler is removed.

⚠️ The identically-named service in the **welcome** module is a genuine redirect (`location.href = endpoint + _K.module.welcome`) and is untouched — there is a test invariant guarding it.

### 4. Brand lockup on the revoked card only
Uses the existing `raw-logo-drumee-full` sprite, which carries the mark **and** the "drumee" wordmark in one `160x40` symbol whose paths are already `#433CC5` and which is `preserveAspectRatio="xMidYMid meet"`. So: no new asset, no `build:icons`, no hardcoded brand text, and it cannot distort. Rendered at 128×32.

Opt-in via `opt.logo`, set only by `TICKET_REVOKED`; the skeleton emits `null` for every other status and ui-core's `validChild` drops it. That commit is **purely additive — zero deleted lines.**

### Scope / blast radius
`Dmz.say()` has exactly one caller (`dmz/sharebox handleInfoStatus`) and `popup-message.js` exactly one consumer, so this is limited to the six recipient-side statuses: revoked · expired (incl. non-secure shares via the `dmz_expiry` override) · invalid link · email already registered · email not allowed · generic error. The skeleton's markup structure is unchanged; the restyle is CSS.

### Verification
- SCSS compiles standalone; `node --check` on all three JS files.
- Standalone harness `secure-share-dmz-status-popup-test.mjs` — **116/116**. It extracts and executes the **real** source (brace-balanced slice of `handleInfoStatus` plus the real skeleton factory against stubs) rather than a re-implementation. It asserts every status opens one popup with the right string and a `close-popup` button; healthy payloads open none; `INVALID_CREDENTIAL` still re-feeds the gate; the logo appears on the revoked card and on none of the other nine; a non-revoked card is still exactly `note + box-x`; and the source invariants (no mailto, welcome's redirect intact, no `--sb-*`, centering + balance, explicit font-weight).
- **Negative-controlled on the real files**: re-injecting the mailto handler and a `redirect-to-home` produced 8 failures / 4 invariants violated / exit 1; restored and md5-verified byte-identical. Two further controls cover the logo gate.
- **Verified live on the test endpoint (drumee.in) at bytecode level** and confirmed by Duy. In the deployed bundle: the new card CSS and the logo rule are present, `mailto:?subject=` is **0** across every bundle, and the old 600px/380px rules are gone.

### CI expectations
`check-source` fails by design on a hotfix head. ui-team's `Lint (bug rules only)` is red on the pre-existing repo config bug (`sourceType: "commonjs"` cannot parse ESM). SonarCloud ERROR is `new_coverage` 0% only — this repo has no coverage tooling.