### PR TITLE
fix(promo): LAUNCH30 claim, cancel trial, Admin Console after explore

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -2768,5 +2768,10 @@
   "SEATS_TO_FILL_SUB": "Team works when there's a team. Invite someone to your workspace.",
   "PROMO_POSITION_LINE": "You're #{0} to claim this offer.",
   "PROMO_OFFER_ENDS": "Ends {0}.",
+  "PROMO_TRIAL_ENDS_ON": "Your free trial ends on {0}",
+  "PROMO_CANCEL_TITLE": "End free trial",
+  "PROMO_CANCEL_CONFIRM": "End trial",
+  "PROMO_CANCEL_IMMEDIATE": "Your free Team trial will end immediately. Your workspace returns to the Free plan right away — no card was ever charged.",
+  "PROMO_TRIAL_ENDED_TOAST": "Your free trial has ended. You're back on the Free plan.",
   "MIGRATE_GDRIVE_CANCELLING": "Cancelling…"
 }

--- a/src/drumee/builtins/widget/promo-launch30/index.js
+++ b/src/drumee/builtins/widget/promo-launch30/index.js
@@ -77,9 +77,47 @@ class __promo_launch30 extends LetcBox {
 
   // ───────── persistence ─────────
 
+  // ACL is scope:hub / src:owner (same as payment.*) — hub_id must be the
+  // caller's personal hub. Omitting it yields PERMISSION_DENIED 403 before
+  // the worker ever runs (reproduced 2026-07-31 against promo.claim).
+  _hubId() {
+    return this.mget(_a.hub_id) || Visitor.id;
+  }
+
   _markSeen() {
-    return this.postService(SERVICE.promo.dismiss, { surface: this._surface })
-      .catch((e) => this.warn && this.warn("[promo-launch30] dismiss failed", e));
+    return this.postService(SERVICE.promo.dismiss, {
+      hub_id: this._hubId(),
+      surface: this._surface,
+    }).catch((e) => this.warn && this.warn("[promo-launch30] dismiss failed", e));
+  }
+
+  /**
+   * org_provision moves the payer onto a new domain + Team quota. Bootstrap
+   * globals (Visitor.quota / domain_id, Organization) stay frozen on Free
+   * until refreshed — Desk's Admin Console gate (needsAdminConsoleUpgrade)
+   * then short-circuits to the Unlock upsell until a full page reload.
+   * Mirror init_globals from yp.get_env; fall back to the claim payload quota.
+   */
+  async _refreshSessionAfterClaim(data = {}) {
+    try {
+      const env = await this.fetchService(SERVICE.yp.get_env, { hub_id: Visitor.id });
+      if (env && env.user) {
+        if (typeof Visitor !== "undefined" && Visitor.respawn) Visitor.respawn(env.user);
+        else if (typeof Visitor !== "undefined" && Visitor.set) Visitor.set(env.user);
+        if (env.organization && typeof Organization !== "undefined" && Organization.set) {
+          Organization.set(env.organization);
+        }
+        if (env.hub && typeof Host !== "undefined" && Host.set) {
+          Host.set(env.hub);
+        }
+        return;
+      }
+    } catch (e) {
+      this.warn && this.warn("[promo-launch30] get_env after claim failed", e);
+    }
+    if (data.quota && typeof Visitor !== "undefined" && Visitor.respawn) {
+      Visitor.respawn({ plan: "team", quota: data.quota });
+    }
   }
 
   _claim() {
@@ -87,13 +125,24 @@ class __promo_launch30 extends LetcBox {
     this._claiming = true;
     this._render();
     const sourceSurface = this._surface === "billing" ? "billing_modal" : "home";
-    return this.postService(SERVICE.promo.claim, { source_surface: sourceSurface })
-      .then((res) => {
+    return this.postService(SERVICE.promo.claim, {
+      hub_id: this._hubId(),
+      source_surface: sourceSurface,
+    })
+      .then(async (res) => {
         // Absent/falsy status must NOT read as success — an ACL denial, a
         // network hiccup, or any unexpected response shape all come back
         // without a clean "OK" and must never silently advance to the
         // welcome screen (found during manual test 2026-07-31: a DENIED
         // response left no entitlement granted, yet the UI moved on).
+        if (res && (res.error || res.error_code === 403 || res.status === 403)) {
+          this._claiming = false;
+          this._render();
+          if (Wm && Wm.alert) {
+            Wm.alert(LOCALE.SOMETHING_WENT_WRONG || "Something went wrong. Please try again.");
+          }
+          return;
+        }
         const data = (res && res.data) || res || {};
         const status = data.status || (res && res.status);
         if (status !== "OK") {
@@ -109,6 +158,7 @@ class __promo_launch30 extends LetcBox {
           return;
         }
         this._trialEndsAt = data.trial_ends_at || null;
+        await this._refreshSessionAfterClaim(data);
         this._claiming = false;
         this._state = "welcome";
         this._render();
@@ -128,6 +178,24 @@ class __promo_launch30 extends LetcBox {
     else this.softDestroy();
   }
 
+  /**
+   * D2: land on Admin Console → Members with Invite open. org_provision
+   * rewrote domain/vhost — same stale-bootstrap problem billing solves with
+   * a full reload on payment.org_provisioned. Flags survive the reload;
+   * Desk opens Admin, apps-main opens Invite.
+   *
+   * triggerHandlers(toggle-apps) is a no-op here: Wm.launch does not wire
+   * uiHandler to Desk, so the service never reached the sidebar handler.
+   */
+  _exploreAfterClaim() {
+    try {
+      sessionStorage.setItem("drumee_promo_open_invite", "1");
+      sessionStorage.setItem("drumee_promo_open_admin", "1");
+    } catch (e) { /* private mode */ }
+    this._close();
+    window.location.reload();
+  }
+
   // ───────── event routing ─────────
 
   onUiEvent(cmd, args = {}) {
@@ -141,14 +209,7 @@ class __promo_launch30 extends LetcBox {
         return this._claim();
 
       case "promo-explore":
-        // D2 (design doc, 2026-07-30): land on Admin Console -> Members with
-        // the Invite panel already open — the trial is worthless until a
-        // second person joins. One-shot flag apps-main reads on mount and
-        // clears; decoupled from the toggle-apps case so no core desk change
-        // is needed to carry the intent across the plugin boundary.
-        try { sessionStorage.setItem("drumee_promo_open_invite", "1"); } catch (e) { /* private mode */ }
-        this.triggerHandlers({ service: "toggle-apps" });
-        return this._close();
+        return this._exploreAfterClaim();
 
       case "promo-later":
         return this._close();

--- a/src/drumee/builtins/widget/promo-launch30/skeleton/offer.js
+++ b/src/drumee/builtins/widget/promo-launch30/skeleton/offer.js
@@ -79,8 +79,11 @@ module.exports = function (ui) {
         service: claiming ? null : "promo-claim",
         uiHandler: [ui],
         kids: [
+          // active: 0 — label is click-through so the parent Box receives
+          // promo-claim (nested Note otherwise swallows the click).
           Skeletons.Note({
             className: `${pfx}__cta-label`,
+            active: 0,
             content: claiming
               ? (LOCALE.PROMO_CLAIMING || "Setting up your workspace…")
               : (LOCALE.PROMO_CLAIM_CTA || "Unlock My Free Month"),

--- a/src/drumee/builtins/widget/promo-launch30/skeleton/welcome.js
+++ b/src/drumee/builtins/widget/promo-launch30/skeleton/welcome.js
@@ -70,6 +70,7 @@ module.exports = function (ui) {
             kids: [
               Skeletons.Note({
                 className: `${pfx}__cta-label`,
+                active: 0,
                 content: LOCALE.PROMO_EXPLORE_CTA || "Start exploring now",
               }),
             ],
@@ -81,6 +82,7 @@ module.exports = function (ui) {
             kids: [
               Skeletons.Note({
                 className: `${pfx}__cta-label`,
+                active: 0,
                 content: LOCALE.PROMO_LATER_CTA || "Maybe later",
               }),
             ],

--- a/src/drumee/builtins/widget/settings/account/billing/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/index.js
@@ -96,6 +96,11 @@ class settings_billing extends LetcBox {
   // Fetch the caller's subscription mirror and derive the pending-cancel flags
   // the banner + cancel/resume actions read. A hard cancel removes the mirror
   // row → _subscription null → no banner (workspace already on Free).
+  //
+  // LAUNCH30 (no Stripe): when quota says Team but there is no subscription
+  // mirror, ask promo.get_state — a claimed_active trial drives the same
+  // banner + Cancel plan path via promo.cancel (immediate end), not
+  // payment.cancel_subscription (which would 404 as NO_SUBSCRIPTION).
   async _loadSubscription() {
     const raw = await this.fetchService(SERVICE.payment.subscription_status, { hub_id: Visitor.id })
       .catch(() => null);
@@ -104,6 +109,9 @@ class settings_billing extends LetcBox {
     // exactly the case that used to walk into a dead end.
     this._canBuy = raw && typeof raw.can_buy === "boolean" ? raw.can_buy : null;
     this._subscription = raw && raw.subscription_id ? raw : null;
+    // member_count is enriched on subscription_status even when there is no
+    // Stripe mirror (LAUNCH30 org) — keep it for cancel-consequence copy.
+    this._memberCount = ~~(raw && raw.member_count);
     const sub = this._subscription;
     const now = Math.floor(Date.now() / 1000);
     this._periodEnd = (sub && Number(sub.period_end)) || 0;
@@ -112,6 +120,7 @@ class settings_billing extends LetcBox {
     // sub, whose row is gone.
     this._isCanceling = !!(sub && sub.status === "canceled" && this._periodEnd > now);
     this._hasPaidSub = !!(sub && sub.subscription_id);
+    this._isPromoTrial = false;
     // Live subscription = nothing left to buy self-serve. The tier ladder is
     // free < team < (business | sovereign = sales-led), so a Team subscriber
     // has no higher self-serve tier to reach and no reason to re-buy the one
@@ -126,6 +135,19 @@ class settings_billing extends LetcBox {
     // in-place switch (which the server accepts while past_due) instead.
     this._hasActiveSub =
       !!(sub && /^(active|trialing|past_due)$/.test(sub.status || "")) || this._isCanceling;
+
+    if (!this._hasPaidSub && this._isPaidByQuota()) {
+      try {
+        const promo = await this.fetchService(SERVICE.promo.get_state, { hub_id: Visitor.id });
+        if (promo && promo.state === "claimed_active") {
+          this._isPromoTrial = true;
+          this._periodEnd = Number(promo.trial_ends_at) || this._periodEnd;
+          // Treat the free trial as a live entitlement for checkout gating —
+          // same as a paid Team sub: don't offer a second self-serve buy.
+          this._hasActiveSub = true;
+        }
+      } catch (e) { /* promo module optional / offline */ }
+    }
     return sub;
   }
 
@@ -150,8 +172,18 @@ class settings_billing extends LetcBox {
   _cancelConsequences() {
     const sub = this._subscription || {};
     const lines = [];
-    const when = this._periodEnd ? Dayjs(this._periodEnd * 1000).format("MMM D, YYYY") : "";
-    lines.push((LOCALE.CANCEL_KEEP_UNTIL || "You'll keep your current plan until {0}. After that your workspace returns to the Free plan (20 GB).").format(when));
+    if (this._isPromoTrial) {
+      // LAUNCH30: no card, no renew — Cancel ends Team immediately (same
+      // revert the expiry worker runs). Soft cancel-at-period-end would be a
+      // no-op: the trial already stops on trial_ends_at with nothing to bill.
+      lines.push(
+        LOCALE.PROMO_CANCEL_IMMEDIATE
+          || "Your free Team trial will end immediately. Your workspace returns to the Free plan right away — no card was ever charged.",
+      );
+    } else {
+      const when = this._periodEnd ? Dayjs(this._periodEnd * 1000).format("MMM D, YYYY") : "";
+      lines.push((LOCALE.CANCEL_KEEP_UNTIL || "You'll keep your current plan until {0}. After that your workspace returns to the Free plan (20 GB).").format(when));
+    }
     // Over-the-free-limit warning (Free = 20 GB, decimal).
     const usedBytes = (Visitor.diskUsed && Visitor.diskUsed()) || 0;
     if (usedBytes > 20000000000) {
@@ -165,8 +197,10 @@ class settings_billing extends LetcBox {
     // member_count, not `seats`: the latter is the plan's member CAP copied out
     // of quota, so on Business it announced that 100000 member seats were about
     // to be removed. The count is what the owner actually loses.
-    const seats = parseInt(sub.member_count, 10) || 0;
-    if (sub.entity_type === "org" && seats > 0) {
+    // Promo trials are always org-scoped (org_provision); use member_count
+    // from the subscription_status enrichment when present, else skip.
+    const seats = parseInt(sub.member_count, 10) || this._memberCount || 0;
+    if ((sub.entity_type === "org" || this._isPromoTrial) && seats > 0) {
       lines.push((LOCALE.CANCEL_TEAM_SEATS || "Your team's {0} member seats will be removed and each member drops to their own Free plan.").format(seats));
     }
     return lines.join("\n\n");
@@ -184,7 +218,8 @@ class settings_billing extends LetcBox {
   }
 
   async _confirmCancel() {
-    if ((!this._hasPaidSub && !this._isPaidByQuota()) || this._isCanceling) return;
+    if ((!this._hasPaidSub && !this._isPaidByQuota() && !this._isPromoTrial) || this._isCanceling) return;
+    if (this._isPromoTrial) return this._confirmCancelPromo();
     const ok = await Wm.confirm({
       title: LOCALE.CANCEL_SUBSCRIPTION || "Cancel subscription",
       message: this._cancelConsequences(),
@@ -210,6 +245,40 @@ class settings_billing extends LetcBox {
     this._isCanceling = true;
     if (typeof Butler !== "undefined" && Butler.say) Butler.say(LOCALE.SUBSCRIPTION_CANCELED_TOAST || "Your plan will be canceled at the end of the period.");
     this.fetchPlanData();
+  }
+
+  // LAUNCH30 Cancel plan — ends the free trial immediately (no Stripe).
+  async _confirmCancelPromo() {
+    const ok = await Wm.confirm({
+      title: LOCALE.PROMO_CANCEL_TITLE || "End free trial",
+      message: this._cancelConsequences(),
+      confirm: LOCALE.PROMO_CANCEL_CONFIRM || "End trial",
+      confirm_type: "danger",
+      cancel: LOCALE.KEEP_PLAN || "Keep plan",
+      cancel_type: "secondary",
+      mode: "hbf",
+    }).then(() => true).catch(() => false);
+    if (!ok) return;
+    const res = await this.postService(SERVICE.promo.cancel, { hub_id: Visitor.id }).catch(() => null);
+    const data = (res && res.data) || res || {};
+    const status = data.status || (res && res.status);
+    if (status !== "OK") {
+      if (Wm && Wm.alert) Wm.alert(LOCALE.SOMETHING_WENT_WRONG);
+      return;
+    }
+    this._isPromoTrial = false;
+    this._hasActiveSub = false;
+    this._periodEnd = 0;
+    // Refresh Visitor.quota immediately so the current-plan card flips to
+    // Free without waiting on the payment.plan_updated WS fan-out.
+    if (typeof Visitor !== "undefined" && Visitor.respawn) {
+      Visitor.respawn({ plan: "free", quota: data.quota });
+    }
+    if (typeof Butler !== "undefined" && Butler.say) {
+      Butler.say(LOCALE.PROMO_TRIAL_ENDED_TOAST || "Your free trial has ended. You're back on the Free plan.");
+    }
+    await this._loadSubscription();
+    if (!this.isDestroyed()) this.fetchPlanData();
   }
 
   async _resumeSubscription() {

--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/index.js
@@ -121,6 +121,29 @@ function subscriptionBanner(ui) {
     });
   }
 
+  // LAUNCH30 free trial — no Stripe renew. Banner names the trial end date
+  // and Cancel ends it immediately via promo.cancel (not cancel_subscription).
+  if (ui._isPromoTrial) {
+    return Skeletons.Box.X({
+      className: `${fig} ${fig}--active ${fig}--promo`,
+      kids: [
+        Skeletons.Note({
+          className: `${fig}-title`,
+          content: when
+            ? (LOCALE.PROMO_TRIAL_ENDS_ON || "Your free trial ends on {0}").format(when)
+            : (LOCALE.CURRENT_PLAN_BANNER || "You are on the {0} plan").format(planLabel),
+        }),
+        Skeletons.Note({
+          className: `${fig}-action ${fig}-cancel`,
+          content: LOCALE.PROMO_CANCEL_CONFIRM || LOCALE.CANCEL_PLAN || "End trial",
+          service: "cancel-subscription",
+          uiHandler: [ui],
+          bubble: false,
+        }),
+      ].filter(Boolean),
+    });
+  }
+
   return Skeletons.Box.X({
     className: `${fig} ${fig}--active`,
     kids: [

--- a/src/drumee/builtins/widget/settings/main/skin/index.scss
+++ b/src/drumee/builtins/widget/settings/main/skin/index.scss
@@ -488,10 +488,15 @@
       }
     }
 
+    // Email value shares the flex text column (min-width:0) — never hard-cap
+    // at 150px (that clipped addresses like launch30configtest@e…). Ellipsis
+    // only when the row truly runs out of space next to the Change button.
     &-row.email-row {
       .settings-main__inner-description {
-        max-width: 150px;
+        max-width: 100%;
         overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
   }

--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -354,6 +354,39 @@ class desk_module extends LetcBox {
     });
     await this.ensurePart("wrapper-popup");
     this.trigger(_e.ready);
+    // LAUNCH30 "Start exploring now" reloads so org_provision's domain move
+    // is picked up by get_env; then open Admin Console (+ Invite via
+    // apps-main's own sessionStorage flag).
+    this._maybeOpenPromoAdminAfterClaim();
+  }
+
+  /**
+   * After promo-launch30 explore → location.reload(), open Admin Console.
+   * Invite panel is opened by apps-main from drumee_promo_open_invite.
+   */
+  _maybeOpenPromoAdminAfterClaim() {
+    let open = false;
+    try {
+      open = sessionStorage.getItem("drumee_promo_open_admin") === "1";
+      if (open) sessionStorage.removeItem("drumee_promo_open_admin");
+    } catch (e) {
+      return;
+    }
+    if (!open) return;
+    // Don't fight desk-state restore back to Home.
+    this._restoreInFlight = false;
+    setTimeout(() => {
+      if (this.isDestroyed && this.isDestroyed()) return;
+      this.onUiEvent(
+        {
+          mget: (k) => (k === _a.service || k === "service" ? "toggle-apps" : null),
+          get(k) {
+            return this.mget(k);
+          },
+        },
+        { service: "toggle-apps" },
+      );
+    }, 400);
   }
 
   // ── [Reload] keep the desk where the user left it across a browser reload ──


### PR DESCRIPTION
## Summary
- Fix `promo.claim`/`dismiss` by always sending `hub_id` (ACL hub/owner).
- Nested CTA clicks: `active: 0` on label children.
- Billing: cancel LAUNCH30 trials via `promo.cancel` (no Stripe), with trial-aware banner copy.
- After claim, refresh session; **Start exploring now** reloads into Admin Console + Invite.
- Settings Account Credentials: stop clipping long emails (`max-width: 150px`).

## Test plan
- [ ] Free account sees LAUNCH30 offer; Unlock claim succeeds (no 403).
- [ ] Welcome → Start exploring now opens Admin Console with Invite.
- [ ] Sidebar Admin Console works without manual reload after claim.
- [ ] Billing shows free-trial end date; End trial returns to Free.
- [ ] Long email fully visible in Account Credentials.


Made with [Cursor](https://cursor.com)