### PR TITLE
fix(promo): LAUNCH30 claim pill matches design (floating card)

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/index.js
@@ -1711,6 +1711,15 @@ class settings_billing extends LetcBox {
         this._reopenPromoOffer();
         return false;
 
+      case "promo-pill-dismiss":
+        // Hides the card for THIS page view only — the offer itself is
+        // already "seen" (server-side) and stays live here until claimed
+        // or the campaign ends (design doc), so there is no server call:
+        // the next visit to this page re-renders the card.
+        this._promoPillDismissed = true;
+        this.feed(require("./skeleton").default(this));
+        return false;
+
     }
   }
 

--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/index.js
@@ -178,47 +178,63 @@ function subscriptionBanner(ui) {
 /**
  * LAUNCH30 persistent reminder (design doc 2026-07-30, tester feedback
  * 2026-07-31 #3: "don't spam the popup — a small pill lives here instead").
- * Shown once the full offer modal has been seen on ANY surface but the
- * account still hasn't claimed and the campaign is still live — get_state's
- * "eligible_seen". ui._promoState is the SAME answer
- * Desk._maybeShowPromoLaunch30 already fetched on this page's mount (see
- * billing/index.js onDomRefresh) — no extra round trip. "Claim now"
- * re-opens Modal A directly (a deliberate re-entry, not the automatic
- * first-time show).
+ * Floating card, top-right of the page (design mockup) — NOT an in-flow
+ * banner, so it never shifts the plan cards below it. Shown once the full
+ * offer modal has been seen on ANY surface but the account still hasn't
+ * claimed and the campaign is still live — get_state's "eligible_seen".
+ * ui._promoState is the SAME answer Desk._maybeShowPromoLaunch30 already
+ * fetched on this page's mount (see billing/index.js onDomRefresh) — no
+ * extra round trip. "Claim now" re-opens Modal A directly (a deliberate
+ * re-entry, not the automatic first-time show). The close X only hides the
+ * card for this page view (ui._promoPillDismissed, a local render flag) —
+ * the offer itself already lives here until claimed or the campaign ends
+ * (design doc's own "recovered state" note), so dismissing the card is not
+ * another server-tracked "seen" surface.
  * @param {Object} ui - UI instance
  * @returns {Object|null} Skeletons component
  */
 function claimPill(ui) {
   const promo = ui._promoState;
-  if (!promo || promo.state !== "eligible_seen") return null;
+  if (!promo || promo.state !== "eligible_seen" || ui._promoPillDismissed) return null;
   const fig = `${ui.fig.family}__promo-pill`;
   const endDate = promo.campaign_ends_at
     ? Dayjs.unix(promo.campaign_ends_at).format("MMM D, YYYY")
     : "";
-  return Skeletons.Box.X({
+  return Skeletons.Box.Z({
     className: fig,
     kids: [
-      Skeletons.Box.Y({
-        className: `${fig}-text`,
-        kids: [
-          Skeletons.Note({
-            className: `${fig}-title`,
-            content: LOCALE.PROMO_PILL_TITLE || "Your free month of Team is still yours to claim.",
-          }),
-          endDate
-            ? Skeletons.Note({
-                className: `${fig}-sub`,
-                content: (LOCALE.PROMO_OFFER_ENDS || "Ends {0}.").format(endDate),
-              })
-            : null,
-        ].filter(Boolean),
-      }),
-      Skeletons.Note({
-        className: `${fig}-cta`,
-        content: LOCALE.PROMO_PILL_CTA || "Claim now",
-        service: "promo-pill-claim",
+      Skeletons.Button.Svg({
+        className: `${fig}-close`,
+        ico: "cross",
+        service: "promo-pill-dismiss",
         uiHandler: [ui],
-        bubble: false,
+      }),
+      Skeletons.Box.X({
+        className: `${fig}-row`,
+        kids: [
+          Skeletons.Box.Y({
+            className: `${fig}-text`,
+            kids: [
+              Skeletons.Note({
+                className: `${fig}-title`,
+                content: LOCALE.PROMO_PILL_TITLE || "Your free month of Team is still yours to claim.",
+              }),
+              endDate
+                ? Skeletons.Note({
+                    className: `${fig}-sub`,
+                    content: (LOCALE.PROMO_OFFER_ENDS || "Ends {0}.").format(endDate),
+                  })
+                : null,
+            ].filter(Boolean),
+          }),
+          Skeletons.Note({
+            className: `${fig}-cta`,
+            content: LOCALE.PROMO_PILL_CTA || "Claim now",
+            service: "promo-pill-claim",
+            uiHandler: [ui],
+            bubble: false,
+          }),
+        ],
       }),
     ],
   });

--- a/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
+++ b/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
@@ -13,6 +13,8 @@
   &__main {
     width: 100%;
     gap: var(--spacer-2);
+    // Containing block for __promo-pill's floating position (Box.Z).
+    position: relative;
   }
 
   // Measure the space the billing content actually gets, not the window: this
@@ -438,33 +440,72 @@
     }
   }
 
-  // LAUNCH30 persistent reminder (tester feedback 2026-07-31 #3) — same box
-  // shape as __sub-banner, kept visually distinct with the promo's own
-  // primary-purple accent so it doesn't read as a real subscription status.
+  // LAUNCH30 persistent reminder (tester feedback 2026-07-31 #3) — a
+  // FLOATING card, top-right (design mockup), not an in-flow banner: it
+  // must never shift the plan cards below it, and it sits over the
+  // Monthly/Yearly toggle rather than pushing it down.
   &__promo-pill {
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacer-4);
-    margin-top: var(--spacer-4);
-    padding: 10px 12px 10px 16px;
-    border-radius: 12px;
-    background: var(--primary-10);
+    position: absolute;
+    top: 8px;
+    right: 0;
+    z-index: 5;
+    width: min(360px, calc(100% - 32px));
+    padding: 14px 16px;
+    border-radius: 16px;
+    background: var(--white, #ffffff);
+    box-shadow: 0 12px 28px -8px rgba(20, 20, 43, 0.18), 0 2px 8px rgba(20, 20, 43, 0.08);
+
+    &-close {
+      // Straddles the card's corner border (design mockup) rather than
+      // sitting inset inside the padding.
+      position: absolute;
+      top: -8px;
+      right: -8px;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: #f2f2f7;
+      border: 1px solid var(--white, #ffffff);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+
+      svg {
+        width: 9px;
+        height: 9px;
+        fill: #8a8aa3;
+        stroke: #8a8aa3;
+      }
+
+      &:hover {
+        background: #e8e8ef;
+      }
+    }
+
+    &-row {
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--spacer-4);
+      padding-right: 22px; // clears the close button
+    }
 
     &-text {
       gap: 2px;
+      min-width: 0;
     }
 
     &-title {
       font-weight: 600;
       font-size: 14px;
-      line-height: 22px;
+      line-height: 1.4;
       color: var(--tertiary-grey-100);
     }
 
     &-sub {
       font-size: 12.5px;
       line-height: 1.4;
-      color: var(--primary-purple-100);
+      color: var(--normal-fg-50, #8a8aa3);
     }
 
     &-cta {
@@ -474,10 +515,10 @@
       color: var(--white);
       background: var(--primary-50);
       font-weight: 600;
-      font-size: 14px;
-      line-height: 22px;
-      padding: 10px 20px;
-      border-radius: 4px;
+      font-size: 13.5px;
+      line-height: 1.4;
+      padding: 10px 18px;
+      border-radius: 999px;
 
       &:hover {
         background: var(--primary-90);


### PR DESCRIPTION
The persistent reminder pill on Billing & subscription was built as an in-flow banner; the design mockup is a floating card, top-right, overlapping the Monthly/Yearly toggle instead of pushing it down.

Switched to Box.Z (absolute position) with a close button that straddles the card's corner border (per the mockup), and a local-only dismiss - the offer itself stays server-seen (get_state's eligible_seen), closing the card just hides it for this page view, per the design doc's own recovered-state note (lives here until claimed or the campaign ends).

Follow-up to PR #427 (same feature, visual-only refinement against the design mockup).

Test plan: live-verified on stage - floating card renders top-right, close button numerically confirmed straddling both the top and right edges of the card, Claim now still re-opens Modal A correctly.