### PR TITLE
style(promo): LAUNCH30 uses Drumee design tokens, not the handoff palette

### DIFF
--- a/src/drumee/builtins/widget/promo-launch30/skin/index.scss
+++ b/src/drumee/builtins/widget/promo-launch30/skin/index.scss
@@ -1,6 +1,14 @@
-// LAUNCH30 promo modal — design doc 2026-07-30 (Modal A "offer" / Modal B
-// "welcome"). Indigo palette matches the design handoff exactly
-// (--indigo:#4F46E5 / --indigo-pale:#E4E2FF / --indigo-tint:#F2F1FF).
+// LAUNCH30 promo modal (Modal A "offer" / Modal B "welcome").
+//
+// Colours come from the Drumee design system, NOT from the original design
+// handoff's own indigo ramp: that handoff shipped a generic #4F46E5 /
+// #E4E2FF / #F2F1FF palette plus invented greys (#14142b, #8a8aa3,
+// #4a4a68), none of which are Drumee tokens — it read as a foreign product
+// bolted onto the desk. Brand primary is --primary-50 (#433cc5, the same
+// value as --area-personal), and every surface/foreground here now uses the
+// theme-aware --normal-* tokens so the modal follows light/dark like the
+// rest of the app instead of being pinned to a light-only palette.
+//
 // Portalled to <body> like rating-survey-popup — fixed + high z-index wins
 // over the desk chrome regardless of where Wm mounts the widget.
 .promo-launch30 {
@@ -8,7 +16,7 @@
     position: fixed;
     inset: 0;
     z-index: 99998;
-    font-family: var(--font-main, sans-serif);
+    font-family: var(--font-main);
   }
 
   &__backdrop {
@@ -17,8 +25,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 20px;
-    background: rgba(20, 20, 43, 0.42);
+    padding: var(--spacer-6);
+    background: var(--overlay-bg);
     backdrop-filter: blur(2px);
   }
 
@@ -27,8 +35,8 @@
     width: min(400px, 100%);
     max-height: 100%;
     overflow-y: auto;
-    background: var(--normal-bg-100, #ffffff);
-    border-radius: 22px;
+    background: var(--normal-bg-elevated);
+    border-radius: var(--corner-radius-6);
     padding: 26px;
     box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25), 0 1px 5.5px rgba(0, 0, 0, 0.13);
   }
@@ -40,7 +48,7 @@
     width: 26px;
     height: 26px;
     border-radius: 50%;
-    background: #f2f2f7;
+    background: var(--normal-bg-90);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -49,19 +57,19 @@
     svg {
       width: 11px;
       height: 11px;
-      fill: #8a8aa3;
-      stroke: #8a8aa3;
+      fill: var(--normal-fg-50);
+      stroke: var(--normal-fg-50);
     }
 
     &:hover {
-      background: #e8e8ef;
+      background: var(--normal-bg-80);
     }
   }
 
   &__confetti {
     font-size: 30px;
     line-height: 1;
-    margin-bottom: 6px;
+    margin-bottom: var(--spacer-3);
   }
 
   &__title {
@@ -69,24 +77,24 @@
     line-height: 1.25;
     font-weight: 600;
     letter-spacing: -0.03em;
-    color: var(--normal-fg-800, #14142b);
+    color: var(--normal-fg-800);
   }
 
   &__lead {
     font-size: 13px;
     line-height: 1.6;
-    color: var(--normal-fg-50, #4a4a68);
+    color: var(--normal-fg-20);
     margin-top: 9px;
   }
 
   &__benefits {
     list-style: none;
-    margin: 16px 0;
-    gap: 10px;
+    margin: var(--spacer-5) 0;
+    gap: var(--spacer-4);
   }
 
   &__benefit-row {
-    gap: 10px;
+    gap: var(--spacer-4);
     align-items: flex-start;
   }
 
@@ -99,8 +107,8 @@
     svg {
       width: 19px;
       height: 19px;
-      fill: #4f46e5;
-      stroke: #4f46e5;
+      fill: var(--primary-50);
+      stroke: var(--primary-50);
     }
   }
 
@@ -110,8 +118,8 @@
     flex-shrink: 0;
     margin-top: 1px;
     border-radius: 50%;
-    background: #f2f1ff;
-    color: #4f46e5;
+    background: var(--primary-10);
+    color: var(--primary-50);
     font-size: 11px;
     font-weight: 700;
     display: flex;
@@ -128,32 +136,32 @@
     font-size: 12.5px;
     line-height: 1.45;
     font-weight: 600;
-    color: var(--normal-fg-800, #14142b);
+    color: var(--normal-fg-800);
   }
 
   &__benefit-sub {
     font-size: 11.5px;
     line-height: 1.4;
-    color: var(--normal-fg-50, #8a8aa3);
+    color: var(--normal-fg-50);
   }
 
   &__cta-stack {
-    gap: 8px;
-    margin-top: 4px;
+    gap: var(--spacer-3);
+    margin-top: var(--spacer-2);
   }
 
   &__cta {
     width: 100%;
     justify-content: center;
     align-items: center;
-    padding: 12px;
-    border-radius: 999px;
-    background: #4f46e5;
+    padding: var(--spacer-4);
+    border-radius: var(--corner-radius-max);
+    background: var(--primary-50);
     cursor: pointer;
-    transition: filter 0.15s ease, opacity 0.15s ease;
+    transition: background 0.15s ease, opacity 0.15s ease;
 
     &:hover {
-      filter: brightness(0.94);
+      background: var(--primary-60);
     }
 
     &--busy {
@@ -162,11 +170,18 @@
       pointer-events: none;
     }
 
+    // Secondary action: brand tint fill with brand-dark label. Stays the
+    // light tint in both themes (it sits on the elevated card, paired with
+    // the solid primary CTA above it).
     &--ghost {
-      background: #e4e2ff;
+      background: var(--primary-10);
+
+      &:hover {
+        background: var(--primary-20);
+      }
 
       .promo-launch30__cta-label {
-        color: #332ca8;
+        color: var(--primary-70);
       }
     }
   }
@@ -174,23 +189,23 @@
   &__cta-label {
     font-size: 13.5px;
     font-weight: 600;
-    color: #ffffff;
+    color: var(--white);
   }
 
   &__fineprint {
     text-align: center;
     font-size: 11px;
-    color: var(--normal-fg-50, #8a8aa3);
+    color: var(--normal-fg-50);
     margin-top: 11px;
   }
 
   &__posline {
     font-size: 12px;
     font-weight: 500;
-    color: var(--normal-fg-50, #4a4a68);
-    background: rgba(79, 70, 229, 0.06);
-    border-radius: 10px;
-    padding: 10px 12px;
-    margin-bottom: 8px;
+    color: var(--normal-fg-20);
+    background: var(--primary-10);
+    border-radius: var(--corner-radius-3);
+    padding: var(--spacer-4) var(--spacer-4);
+    margin-bottom: var(--spacer-3);
   }
 }

--- a/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
+++ b/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
@@ -451,9 +451,9 @@
     z-index: 5;
     width: min(360px, calc(100% - 32px));
     padding: 14px 16px;
-    border-radius: 16px;
-    background: var(--white, #ffffff);
-    box-shadow: 0 12px 28px -8px rgba(20, 20, 43, 0.18), 0 2px 8px rgba(20, 20, 43, 0.08);
+    border-radius: var(--corner-radius-5);
+    background: var(--normal-bg-elevated);
+    box-shadow: 0 12px 28px -8px rgba(0, 0, 0, 0.18), 0 2px 8px rgba(0, 0, 0, 0.08);
 
     &-close {
       // Straddles the card's corner border (design mockup) rather than
@@ -464,8 +464,8 @@
       width: 22px;
       height: 22px;
       border-radius: 50%;
-      background: #f2f2f7;
-      border: 1px solid var(--white, #ffffff);
+      background: var(--normal-bg-90);
+      border: 1px solid var(--normal-bg-elevated);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -474,12 +474,12 @@
       svg {
         width: 9px;
         height: 9px;
-        fill: #8a8aa3;
-        stroke: #8a8aa3;
+        fill: var(--normal-fg-50);
+        stroke: var(--normal-fg-50);
       }
 
       &:hover {
-        background: #e8e8ef;
+        background: var(--normal-bg-80);
       }
     }
 
@@ -499,13 +499,13 @@
       font-weight: 600;
       font-size: 14px;
       line-height: 1.4;
-      color: var(--tertiary-grey-100);
+      color: var(--normal-fg-800);
     }
 
     &-sub {
       font-size: 12.5px;
       line-height: 1.4;
-      color: var(--normal-fg-50, #8a8aa3);
+      color: var(--normal-fg-50);
     }
 
     &-cta {
@@ -518,10 +518,12 @@
       font-size: 13.5px;
       line-height: 1.4;
       padding: 10px 18px;
-      border-radius: 999px;
+      border-radius: var(--corner-radius-max);
 
+      // --primary-60, matching the modal's own CTA hover: the same brand
+      // ramp step, so the pill and the modal it opens read as one feature.
       &:hover {
-        background: var(--primary-90);
+        background: var(--primary-60);
       }
     }
   }


### PR DESCRIPTION
The LAUNCH30 modal was built straight from the design handoff, which shipped its own indigo ramp (#4F46E5 / #E4E2FF / #F2F1FF) plus invented greys (#14142b, #8a8aa3, #4a4a68). None of those are Drumee tokens, so the promo read as a foreign product bolted onto the desk rather than part of it.

What changed:
- Brand primary is now --primary-50 (#433cc5) - the same value as --area-personal, so the CTA matches the sidebar folders. Hover uses --primary-60; tint surfaces and the secondary CTA use --primary-10 / -20 / -70.
- Every surface and foreground moves to the theme-aware --normal-* tokens, so the modal follows light/dark like the rest of the app instead of being pinned to a light-only palette.
- Radii and spacing use --corner-radius-* / --spacer-*.
- The billing claim pill gets the same treatment (it had inherited the same hardcoded greys), and its CTA hover moves from --primary-90 (near-black) to --primary-60 so the pill and the modal it opens read as one feature.
- Font was already correct (--font-main / Armin Grotesk) and is unchanged; the dead fallback literals beside it are removed.

Verified live on stage via computed styles, both modals and the pill:
- font-family: "Armin Grotesk", sans-serif
- CTA background: rgb(67, 60, 197) = #433cc5 (was #4f46e5)
- title: #34343a, body: #65656c, muted: #84848c (all --normal-fg-*)
- position line / ghost CTA: #e4e3ff (--primary-10)

All 22 tokens referenced were checked to exist in skin/vars + router/skin/themes before shipping.