### PR TITLE
fix(secure-share): make the open-notification toggle stick after the link exists

### DIFF
--- a/src/drumee/builtins/window/secure-share/index.js
+++ b/src/drumee/builtins/window/secure-share/index.js
@@ -31,6 +31,8 @@ class __window_secure_share extends mfsInteract {
     this._customExpiryDays = 0;
     this._expiryOn         = false;
     this._notifyOnOpen     = true;   // notify the sender when a recipient opens (default ON)
+    this._createdToken     = null;   // token of the link generated in this panel session
+    this._notifySeq        = 0;      // guards out-of-order notify_on_open responses
     // v2: Recipients mode is MULTI-select — download/chat/edit are independent
     // capabilities, not a hierarchy. can_view is the implicit baseline (empty set).
     this._capabilities     = new Set();
@@ -253,6 +255,46 @@ class __window_secure_share extends mfsInteract {
     // Scope to the notify row — there are two `__toggle` elements in the panel.
     const toggle = this.el.querySelector(`.${pfx}__notify-row .${pfx}__toggle`);
     if (toggle) toggle.dataset.on = this._notifyOnOpen ? 'yes' : '';
+    // The flip above stays local and instant, and still seeds the NEXT create.
+    // But this row sits BELOW the Get-link button, so once a link exists the
+    // preference belongs to THAT link and has to be persisted: notify_on_open
+    // used to be create-time only, so turning the toggle off after pressing
+    // Get link changed nothing and the sender kept being notified.
+    if (this._createdToken) this._persistNotifyOnOpen(this._createdToken);
+  }
+
+  /**
+   * Persist the notify-on-open preference for a link that already exists.
+   * Reverts the switch when the server did not store what we asked for, so the
+   * panel can never show "off" while the sender is still being notified — that
+   * mismatch is the whole bug. Fire-and-forget: the toggle already moved.
+   */
+  async _persistNotifyOnOpen(token) {
+    const intended = this._notifyOnOpen ? 1 : 0;
+    const seq      = ++this._notifySeq;
+    let stored;
+    try {
+      const res = await this.postService(SERVICE.secure_share.set_notify_on_open, {
+        token,
+        hub_id         : this.mget(_a.hub_id),
+        notify_on_open : intended,
+      });
+      // postService resolves undefined on a transport failure (it routes through
+      // onServerComplain rather than throwing), so treat anything that is not an
+      // explicit OK as "did not persist".
+      stored = (res && res.status === 'OK') ? Number(res.notify_on_open) : undefined;
+    } catch (e) {
+      stored = undefined;
+    }
+    // A newer click superseded this one — its own response owns the switch.
+    if (seq !== this._notifySeq) return;
+    if (stored === intended) return;
+    // Show the truth: the server's value when it gave one, otherwise the state
+    // from before this click (we already flipped it above).
+    this._notifyOnOpen = (stored === 1) ? true : (stored === 0 ? false : !this._notifyOnOpen);
+    const toggle = this.el.querySelector(`.${this.fig.family}__notify-row .${this.fig.family}__toggle`);
+    if (toggle) toggle.dataset.on = this._notifyOnOpen ? 'yes' : '';
+    Butler.say(LOCALE.SOMETHING_WENT_WRONG);
   }
 
   // Custom expiry via the range calendar. The picker reports the span between
@@ -626,6 +668,10 @@ class __window_secure_share extends mfsInteract {
 
     if (data && data.link) {
       this.mset({ link: data.link });
+      // Remember which link this panel just generated: the notify toggle below
+      // the Get-link button belongs to THAT link. Captured outside the
+      // _linkResult guard so it is set even if the result row is absent.
+      this._createdToken = data.id || data.token || null;
       if (this._linkResult) {
         const pfx   = this.fig.family;
         const token = data.id || data.token;
@@ -708,8 +754,10 @@ class __window_secure_share extends mfsInteract {
     });
     if (this._customExpiry) this._customExpiry.el.dataset.mode = _a.closed;
 
-    // Reset notify-on-open → ON (default)
+    // Reset notify-on-open → ON (default). Drop the tracked link too, so the
+    // reset toggle seeds the next create instead of writing to the old link.
     this._notifyOnOpen = true;
+    this._createdToken = null;
     const notifyToggle = this.el.querySelector(`.${pfx}__notify-row .${pfx}__toggle`);
     if (notifyToggle) notifyToggle.dataset.on = 'yes';
   }
@@ -732,6 +780,9 @@ class __window_secure_share extends mfsInteract {
     // Figma revoke → disable: the generated-link row collapses and "Get link"
     // reappears. Harmless when revoking from a share-list row (already closed).
     if (this._linkResult) this._linkResult.el.dataset.mode = _a.closed;
+    // Stop tracking a link that no longer exists, so the notify toggle goes back
+    // to seeding the next create rather than writing to a revoked token.
+    if (this._createdToken && this._createdToken === token) this._createdToken = null;
     this._loadShares();
     this._loadAccessEvents();
   }

--- a/src/drumee/builtins/window/secure-share/index.js
+++ b/src/drumee/builtins/window/secure-share/index.js
@@ -282,16 +282,21 @@ class __window_secure_share extends mfsInteract {
       // postService resolves undefined on a transport failure (it routes through
       // onServerComplain rather than throwing), so treat anything that is not an
       // explicit OK as "did not persist".
-      stored = (res && res.status === 'OK') ? Number(res.notify_on_open) : undefined;
+      stored = res?.status === 'OK' ? Number(res.notify_on_open) : undefined;
     } catch (e) {
-      stored = undefined;
+      // stored stays undefined → treated as "did not persist" below.
+      this.warn('[secure_share] set_notify_on_open failed:', e && e.message);
     }
     // A newer click superseded this one — its own response owns the switch.
     if (seq !== this._notifySeq) return;
     if (stored === intended) return;
     // Show the truth: the server's value when it gave one, otherwise the state
     // from before this click (we already flipped it above).
-    this._notifyOnOpen = (stored === 1) ? true : (stored === 0 ? false : !this._notifyOnOpen);
+    let truth;
+    if (stored === 1)      truth = true;
+    else if (stored === 0) truth = false;
+    else                   truth = !this._notifyOnOpen;
+    this._notifyOnOpen = truth;
     const toggle = this.el.querySelector(`.${this.fig.family}__notify-row .${this.fig.family}__toggle`);
     if (toggle) toggle.dataset.on = this._notifyOnOpen ? 'yes' : '';
     Butler.say(LOCALE.SOMETHING_WENT_WRONG);

--- a/src/drumee/lex/services.json
+++ b/src/drumee/lex/services.json
@@ -160,6 +160,7 @@
     "list": "secure_share.list",
     "revoke": "secure_share.revoke",
     "delete": "secure_share.delete",
+    "set_notify_on_open": "secure_share.set_notify_on_open",
     "respond_to_access_request": "secure_share.respond_to_access_request"
   },
   "reward_hub": {


### PR DESCRIPTION
## Problem

The **"Notify me when someone opens this"** row sits *below* the Get-link button, but `notify_on_open` was sent only in the create payload. `_toggleNotify()` flipped a local field and a `dataset` attribute and made **no server call** — so the natural gesture (press Get link, then turn notifications off underneath it) never reached the database. The sender kept receiving "Someone opened …" with the switch visibly off.

Prod: **420 of 421 tokens are at `1`**.

## Change

- The local flip **stays instant and still seeds the next create**, so behaviour when no link has been generated is byte-identical to before — that path makes no request at all.
- Once a link exists, the preference belongs to **that** link and is persisted via `secure_share.set_notify_on_open`.
- The switch **reverts and says so** (`SOMETHING_WENT_WRONG`) whenever the server did not store what was asked — a transport failure (`postService` resolves `undefined`), a `NOT_FOUND`, or a value mismatch. It can never read "off" while the sender is still being notified, which was the whole bug.
- A sequence counter drops superseded responses, so rapid clicking cannot let a stale answer overwrite a newer one.
- The tracked token is cleared on form reset and when that link is revoked, so the toggle never writes to a dead link.

Depends on drumee/server-team#151 and drumee/schemas#112.

## Repo conventions

- **No new locale key** — reuses the existing `SOMETHING_WENT_WRONG`, so no 6-language mirroring.
- **No new import**: `SERVICE`, `_a`, `Butler` and `LOCALE` are injected globals, and `Butler.say` already has 5 call sites in this same file.
- Server call goes through `postService(SERVICE.…)`; `set_notify_on_open` added to `lex/services.json` (**+1/−0**, one key, every other module byte-equal).
- No raw DOM/HTML construction.

## Verification

New harness `~/secure-share-notify-toggle-test.mjs` — **23/23**. It *extracts and executes the real* `_toggleNotify` / `_persistNotifyOnOpen` (brace-balanced slice against stubs) rather than re-implementing them, so it can actually fail when this file regresses. Covers: no-link ⇒ zero service calls · correct service and payload · stored-equals-intended ⇒ switch holds · server disagrees ⇒ reverts to the stored value · transport failure ⇒ reverts to pre-click · `NOT_FOUND` ⇒ reverts · a throwing `postService` never escapes · a stale response cannot move the switch.

**Four negative controls**, including one against unfixed `origin/preview`:
- dropping the persist call (the original bug) ⇒ 3 failures
- dropping the sequence guard ⇒ stale response moves the switch, invariant violated
- dropping the revert ⇒ 5 failures, "switch must never read OFF while the server has it ON" violated
- unfixed tree ⇒ clean single failure

Also `node --check` clean, and verified end-to-end on drumee.in by Duy: notify off ⇒ sender gets no notification, while the open still appears in the access list.

## Note on CI

`check-source` fails by design on a hotfix head (this is not the `test` branch). Lint may surface pre-existing debt in touched files; SonarCloud's `new_coverage` condition can never pass in this repo (no test runner).