### PR TITLE
fix(billing): plan headers are all the same height

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/plans.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/plans.js
@@ -173,11 +173,18 @@ function priceHeader(ui, fig, option, isCurrent) {
   const { title, priceLabel, priceAmount, pricePeriod, priceText, badge } = option;
 
   const priceKids = [];
-  if (priceLabel) {
-    priceKids.push(
-      Skeletons.Note({ className: `${fig}-price-label`, content: priceLabel }),
-    );
-  }
+  // The label row is rendered on EVERY card, blank where the plan has none.
+  // Only Sovereign carries one ("Start from"), and that single extra line made
+  // its tinted header 97px against 81px on the other three — the boxes did not
+  // line up and neither did the prices. Reserving the row equalises them by
+  // construction, so it survives a change of font size or label; pinning
+  // min-height to today's 97px would silently drift apart again.
+  priceKids.push(
+    Skeletons.Note({
+      className: `${fig}-price-label${priceLabel ? "" : " is-placeholder"}`,
+      content: priceLabel || " ",
+    }),
+  );
   if (priceAmount) {
     priceKids.push(
       Skeletons.Box.X({

--- a/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
+++ b/src/drumee/builtins/widget/settings/account/billing/skin/index.scss
@@ -209,6 +209,13 @@
         font-size: 14px;
         line-height: 1.4;
         color: var(--neutral-900);
+
+        // Holds the row open on the cards that have no label, so all four
+        // headers are the same height and the prices sit on one line.
+        // visibility, not display:none — the box has to keep occupying space.
+        &.is-placeholder {
+          visibility: hidden;
+        }
       }
 
       &-row {


### PR DESCRIPTION
[Billing UI] The four plan headers are now the same height.

### What was wrong

Sovereign Node is the only card carrying a price label ("Start from"). That single extra line made its tinted header **97px against 81px** on the other three, so the boxes did not line up and neither did the prices.

| | Free | Team | Business | Sovereign |
|---|---|---|---|---|
| header, before | 81 | 81 | 81 | **97** |
| header, after | 97 | 97 | 97 | 97 |
| price row offset, before | 35 | 35 | 35 | **51** |
| price row offset, after | 51 | 51 | 51 | 51 |

### How

The label row is rendered on **every** card, blank where the plan has none. That equalises the headers by construction: it survives a change of font size, of the label text, or a second plan gaining a label.

The obvious alternative — `min-height: 97px` — looks identical today and drifts apart silently the moment any of those change, because the number encodes the current title/label/price metrics (12+12 padding + 23 title + 16 label + 34 price row).

Two details worth knowing for anyone touching this later:

- The placeholder is a **non-breaking space**, not `" "`. A whitespace-only `Skeletons.Note` is dropped before it reaches the DOM — the plain-space version rendered nothing and changed nothing.
- `visibility: hidden`, not `display: none` — the box has to keep occupying its line.

### Verified on stage

97/97/97/97 with every price row at the same offset, on both the Monthly and Yearly tabs (the cycle switch re-renders the cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
