### PR TITLE
feat(billing): Pro joins the redeem plan picker

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/index.js
@@ -352,6 +352,7 @@ function redeemBox(ui) {
       Skeletons.Box.X({
         className: `${fig}-pill-bar`,
         kids: [
+          planPill("pro", LOCALE.PRO || "Pro"),
           planPill("team", LOCALE.TEAM || "Team"),
           planPill("business", LOCALE.BUSINESS || "Business"),
         ],


### PR DESCRIPTION
Direct redeem (`promo.redeem` — free-period code, no checkout, no card) only ever accepted **org** plans, so a Pro-scoped code had nowhere to be spent: not at checkout (a 100%-off code has nothing to charge) and not here.

### The org assumption was in three layers

| Layer | Assumed | Now |
|---|---|---|
| `mkt_coupon_redeem` catalog lookup | `entity_type = 'org'` hardcoded | reads entity_type **from** the catalog |
| …quota write | `$.organization = 1`, keyed to org id | org → org-keyed; user → **payer**-keyed, organization left as the catalog has it |
| …ARGS_INVALID guard | `_org_id` always required | required only when the plan turns out to be an org plan (`ORG_REQUIRED`) |
| `promo.redeem` gate | `team|business` | `pro|team|business` |
| `promo.redeem` provisioning | always `_provisionOrg()` | skipped entirely for a personal plan |
| Redeem box plan pills | Team, Business | **Pro**, Team, Business |

Fixing only the type check would have been worse than the bug: it would have granted Pro **to an organisation the redeemer must never be given**, and moved their `domain_id` — the same irreversible side effect the validate-before-provision ordering exists to prevent.

The org/user split now mirrors `payment_apply_entitlement` exactly, so a Pro granted by coupon and a Pro bought through Stripe produce the same quota row.

### `org_id` now means "entitlement holder"

For a personal grant it holds the **uid**. The expiry worker feeds that column to `payment_clear_entitlement`, which keys on `payer_id` and already has an individual branch (it re-materialises a claim-reward row when the id belongs to a drumate) — so revocation needed no change at all.

### Verified end to end on stage

Created a Pro-scoped 60-day coupon, then through the **real UI**: pick Pro → enter code → Redeem → *"Code T_PRO60 applied — your pro plan runs until Oct 2, 2026"*, Pro card marked current.

- quota row keyed to the payer: `plan=pro, disk=50 GB, seat=1, organization=0, source=mkt-coupon`
- redemption row: `entity_type='user'`
- **no organisation created** (org count unchanged)
- `get_quota` — the path the app actually uses — returns `pro`
- expiry worker (`SIGUSR2`): quota row deleted, status `expired`, back to Free

Also confirmed the guard still bites: the same code redeemed as `team` answers `COUPON_PLAN_MISMATCH`.

Test coupon and all test rows removed; account left on Free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
