### PR TITLE
fix(billing): stop presenting a deferred cycle switch as a $0 purchase

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -2661,5 +2661,10 @@
   "HELP_FAQ_Q_LOGIN_ISSUE": "I can't log in, or my invite link doesn't work — what do I do?",
   "HELP_FAQ_A_LOGIN_ISSUE": "Reach out through the Contact Support links at the bottom of this page.",
   "HELP_FAQ_Q_REPORT_BUG": "Where do I report a bug or request a feature?",
-  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel."
+  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel.",
+  "PLAN_CHANGE_CONFIRMED": "Plan change confirmed",
+  "CYCLE_STARTS_SUBTITLE": "Your {0} plan starts on {1}.",
+  "CHARGED_TODAY": "Charged today",
+  "NEXT_CHARGE": "Next charge",
+  "NEXT_CHARGE_ON": "{0} on {1}"
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -2491,5 +2491,10 @@
   "HELP_FAQ_Q_LOGIN_ISSUE": "I can't log in, or my invite link doesn't work — what do I do?",
   "HELP_FAQ_A_LOGIN_ISSUE": "Reach out through the Contact Support links at the bottom of this page.",
   "HELP_FAQ_Q_REPORT_BUG": "Where do I report a bug or request a feature?",
-  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel."
+  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel.",
+  "PLAN_CHANGE_CONFIRMED": "Cambio de plan confirmado",
+  "CYCLE_STARTS_SUBTITLE": "Tu plan {0} comienza el {1}.",
+  "CHARGED_TODAY": "Cobrado hoy",
+  "NEXT_CHARGE": "Próximo cobro",
+  "NEXT_CHARGE_ON": "{0} el {1}"
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -2491,5 +2491,10 @@
   "HELP_FAQ_Q_LOGIN_ISSUE": "I can't log in, or my invite link doesn't work — what do I do?",
   "HELP_FAQ_A_LOGIN_ISSUE": "Reach out through the Contact Support links at the bottom of this page.",
   "HELP_FAQ_Q_REPORT_BUG": "Where do I report a bug or request a feature?",
-  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel."
+  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel.",
+  "PLAN_CHANGE_CONFIRMED": "Changement de formule confirmé",
+  "CYCLE_STARTS_SUBTITLE": "Votre formule {0} démarre le {1}.",
+  "CHARGED_TODAY": "Débité aujourd'hui",
+  "NEXT_CHARGE": "Prochain débit",
+  "NEXT_CHARGE_ON": "{0} le {1}"
 }

--- a/locale/km.json
+++ b/locale/km.json
@@ -2490,5 +2490,10 @@
   "HELP_FAQ_Q_LOGIN_ISSUE": "I can't log in, or my invite link doesn't work — what do I do?",
   "HELP_FAQ_A_LOGIN_ISSUE": "Reach out through the Contact Support links at the bottom of this page.",
   "HELP_FAQ_Q_REPORT_BUG": "Where do I report a bug or request a feature?",
-  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel."
+  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel.",
+  "PLAN_CHANGE_CONFIRMED": "ការប្ដូរគម្រោងត្រូវបានបញ្ជាក់",
+  "CYCLE_STARTS_SUBTITLE": "គម្រោង {0} របស់អ្នកចាប់ផ្ដើមនៅ {1}។",
+  "CHARGED_TODAY": "បានគិតថ្លៃថ្ងៃនេះ",
+  "NEXT_CHARGE": "ការគិតថ្លៃបន្ទាប់",
+  "NEXT_CHARGE_ON": "{0} នៅ {1}"
 }

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -2490,5 +2490,10 @@
   "HELP_FAQ_Q_LOGIN_ISSUE": "I can't log in, or my invite link doesn't work — what do I do?",
   "HELP_FAQ_A_LOGIN_ISSUE": "Reach out through the Contact Support links at the bottom of this page.",
   "HELP_FAQ_Q_REPORT_BUG": "Where do I report a bug or request a feature?",
-  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel."
+  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel.",
+  "PLAN_CHANGE_CONFIRMED": "Смена тарифа подтверждена",
+  "CYCLE_STARTS_SUBTITLE": "Ваш тариф {0} начнётся {1}.",
+  "CHARGED_TODAY": "Списано сегодня",
+  "NEXT_CHARGE": "Следующее списание",
+  "NEXT_CHARGE_ON": "{0} — {1}"
 }

--- a/locale/zh.json
+++ b/locale/zh.json
@@ -2490,5 +2490,10 @@
   "HELP_FAQ_Q_LOGIN_ISSUE": "I can't log in, or my invite link doesn't work — what do I do?",
   "HELP_FAQ_A_LOGIN_ISSUE": "Reach out through the Contact Support links at the bottom of this page.",
   "HELP_FAQ_Q_REPORT_BUG": "Where do I report a bug or request a feature?",
-  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel."
+  "HELP_FAQ_A_REPORT_BUG": "Report bugs and feature requests to Drumee through the Telegram support channel.",
+  "PLAN_CHANGE_CONFIRMED": "套餐变更已确认",
+  "CYCLE_STARTS_SUBTITLE": "您的{0}套餐将于 {1} 开始。",
+  "CHARGED_TODAY": "今日扣款",
+  "NEXT_CHARGE": "下次扣款",
+  "NEXT_CHARGE_ON": "{1} 扣款 {0}"
 }

--- a/src/drumee/builtins/widget/settings/account/billing/result/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/result/index.js
@@ -25,7 +25,14 @@ class settings_billing_result extends LetcBox {
       }).catch(() => null);
       if (this._receipt && this._receipt.status === "SESSION_NOT_FOUND") this._receipt = null;
       // A session that never got paid renders the failure shell instead.
-      if (this._receipt && this._receipt.payment_status && this._receipt.payment_status !== "paid") {
+      //
+      // 'no_payment_required' is NOT such a session: Stripe reports it when
+      // the session's total is 0, which is exactly what a deferred cycle
+      // switch produces (the new cycle idles on a trial until the paid period
+      // lapses). Treating it as unpaid showed "Payment Failure!" for a switch
+      // that had gone through — so only a genuinely unpaid session fails here.
+      const ps = this._receipt && this._receipt.payment_status;
+      if (ps && ps !== "paid" && ps !== "no_payment_required") {
         this._result = "cancel";
       }
     }

--- a/src/drumee/builtins/widget/settings/account/billing/result/skeleton/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/result/skeleton/index.js
@@ -78,8 +78,33 @@ function billing_result(ui) {
     : null;
   const planName = r.plan ? r.plan.replace(/^./, (c) => c.toUpperCase()) : "";
 
+  // A DEFERRED cycle switch bills nothing today — the new cycle idles on a
+  // Stripe trial until the already-paid period lapses. Stripe therefore
+  // reports amount_total 0, and this modal used to present that as
+  // "Payment Success! / Total Payment $0.00" over a $290 switch, which reads
+  // as a failed or free purchase. Name the two amounts instead: what was
+  // taken today (nothing) and what falls due when the plan actually starts.
+  // The billing page banner already branches on the same state.
+  const deferred = ok && !!r.defer;
+  const startsAt = r.starts_at
+    ? Dayjs(Number(r.starts_at) * 1000).format("MMMM D, YYYY")
+    : null;
+  const periodLabel = /^year/.test(String(r.period || ""))
+    ? (LOCALE.YEARLY || "Yearly")
+    : (LOCALE.MONTHLY || "Monthly");
+  const upcoming = money(r.upcoming_amount, r.currency);
+
   const total = money(r.amount_total, r.currency);
   const details = [
+    // Only meaningful while the switch is pending; once it starts, the
+    // billing page is the place that tracks renewals.
+    deferred && upcoming && startsAt
+      ? detailRow(
+        fig,
+        LOCALE.NEXT_CHARGE || "Next charge",
+        (LOCALE.NEXT_CHARGE_ON || "{0} on {1}").format(upcoming, startsAt),
+      )
+      : null,
     detailRow(fig, LOCALE.INVOICE_NUMBER || "Invoice number", r.invoice_number),
     // Figma: success shows "Payment date", failure shows "Payment time" —
     // same field, different label per state.
@@ -99,15 +124,21 @@ function billing_result(ui) {
     }),
     Skeletons.Note({
       className: `${fig}__title`,
-      content: ok
-        ? LOCALE.PAYMENT_SUCCESS_TITLE || "Payment Success!"
-        : LOCALE.PAYMENT_FAILURE_TITLE || "Payment Failure!",
+      // "Payment Success!" is a lie when nothing was paid — a deferred switch
+      // confirms a scheduled change, not a charge.
+      content: deferred
+        ? LOCALE.PLAN_CHANGE_CONFIRMED || "Plan change confirmed"
+        : ok
+          ? LOCALE.PAYMENT_SUCCESS_TITLE || "Payment Success!"
+          : LOCALE.PAYMENT_FAILURE_TITLE || "Payment Failure!",
     }),
     Skeletons.Note({
       className: `${fig}__subtitle`,
-      content: ok
-        ? (LOCALE.PAYMENT_SUCCESS_TEXT || "Upgraded successfully. You are now in {0} plan.").format(planName || LOCALE.TEAM)
-        : LOCALE.PAYMENT_FAILURE_TEXT || "Your payment could not be processed.",
+      content: deferred && startsAt
+        ? (LOCALE.CYCLE_STARTS_SUBTITLE || "Your {0} plan starts on {1}.").format(periodLabel, startsAt)
+        : ok
+          ? (LOCALE.PAYMENT_SUCCESS_TEXT || "Upgraded successfully. You are now in {0} plan.").format(planName || LOCALE.TEAM)
+          : LOCALE.PAYMENT_FAILURE_TEXT || "Your payment could not be processed.",
     }),
   ];
 
@@ -118,7 +149,11 @@ function billing_result(ui) {
         kids: [
           Skeletons.Note({
             className: `${fig}__total-label`,
-            content: LOCALE.TOTAL_PAYMENT || "Total Payment",
+            // The $0 needs a label that explains itself: it is today's
+            // charge, not the price of the plan.
+            content: deferred
+              ? LOCALE.CHARGED_TODAY || "Charged today"
+              : LOCALE.TOTAL_PAYMENT || "Total Payment",
           }),
           Skeletons.Note({ className: `${fig}__total-value`, content: total }),
         ],


### PR DESCRIPTION
Switching Team monthly → yearly with *defer* charges nothing that day — the new cycle idles on a Stripe trial until the already-paid period lapses, and the $290 falls due when it starts. The post-checkout modal reported that as:

> **Payment Success!**
> Upgraded successfully. You are now in Team plan.
> Total Payment — **$0.00**

which reads as a failed or free purchase, and contradicts the confirmation dialog shown seconds earlier (*"Nothing is charged today"*).

### What changed

- A deferred session now renders **"Plan change confirmed / Your Yearly plan starts on September 3, 2026"**, labels the zero **"Charged today"** so it explains itself, and adds a **Next charge** row with the real figure and date. A normal purchase keeps the receipt it had.
- `no_payment_required` is no longer treated as an unpaid session. Stripe reports it whenever a session total is 0 — exactly what a deferred switch produces — so that branch could show *"Payment Failure!"* for a switch that had gone through.
- 5 new locale keys, mirrored across all 6 languages.

Needs server-team PR (`fix/checkout-result-defer`), which supplies `defer` / `starts_at` / `upcoming_amount`.

### Verified

End to end on stage with a real Stripe session (`cs_test_a17MCHpM…`, Team month → year deferred, `sub_1U0P60DjnMxCeY360v5xvadK`, status `trialing`):

```
Plan change confirmed
Your Yearly plan starts on September 3, 2026.
Charged today          $0.00
Next charge            $290.00 on September 3, 2026
Invoice number         O2SFY5HP-0010
Payment date           August 3, 2026 - 23:52
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)