### PR TITLE
fix(billing): Pro priced at $0.00 wherever the catalog is unseeded

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/index.js
@@ -966,10 +966,16 @@ class settings_billing extends LetcBox {
     );
     if (row && row.amount != null) return Number(row.amount) / 100;
     // Offline fallbacks only — the catalog above is the truth. Yearly is
-    // 10 x monthly — two months free (product decision 2026-07-29). The
-    // retired B2C entries (pro, pro_seat, storage_*) are gone with the
-    // plans themselves.
+    // 10 x monthly — two months free (product decision 2026-07-29).
+    //
+    // `pro` belongs here again. This map was written when Pro was retired,
+    // and the 2026-08-03 revival added the plan everywhere except this
+    // fallback — so on any deployment whose catalog is not seeded with Stripe
+    // price ids, Pro alone priced at zero while Team and Business read
+    // correctly off their entries. It is not caught by the `?? 5` in the plan
+    // card either: this returns 0, and `??` only falls back on null.
     const fb = {
+      pro: { month: 5, year: 50 },
       team: { month: 29, year: 290 },
       business: { month: 99, year: 990 },
     };


### PR DESCRIPTION
`_catPrice` falls back to a hardcoded table when the server catalog carries no amount — which is what happens whenever a deployment's `yp.plan` rows have no Stripe price id. That table was written when Pro was **retired**, and the 2026-08-03 revival added the plan everywhere except here:

```js
const fb = {
  team:     { month: 29, year: 290 },
  business: { month: 99, year: 990 },
};   // ← no `pro`
return (fb[code] && fb[code][period]) || 0;
```

So Pro alone returned `0` while Team and Business read correctly.

The plan card's own `?? 5` does not save it — `_catPrice` returns **0**, not null, and `??` only falls back on null/undefined.

### Why it never showed on stage

Stage's catalog **is** seeded, so the real Stripe amount wins and the fallback is never reached. On prod every active USD row is unseeded:

```
currency  active  rows  null_price
eur       0       4     0
usd       1       6     6     ← pro/team/business × month/year
```

The fallback is doing all the work there, and Pro was the one entry missing from it.

### Scope

Display only. On a deployment with an unseeded catalog, `payment.checkout` still answers `NO_PRICE` for **every** plan — seeding the live price ids is a separate, out-of-band step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
