### PR TITLE
fix(billing): stop offering Cancel on a plan that has no subscription

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/index.js
@@ -227,8 +227,23 @@ class settings_billing extends LetcBox {
     return /^(team|business|sovereign|enterprise)$/.test(plan);
   }
 
+  /**
+   * Is there anything to cancel? A quota alone is not.
+   *
+   * `_isPaidByQuota` says the workspace HOLDS a paid tier, which is not the
+   * same as holding a subscription: a plan granted by hand, and a plan whose
+   * subscription was already terminated (the entitlement is kept until
+   * period_end, the mirror row is not), both read as paid with nothing behind
+   * them. payment.cancel_subscription answers NO_SUBSCRIPTION for those, and
+   * the caller got "Something went wrong" for pressing a button that could
+   * never have worked. A LAUNCH30 trial IS cancellable — through promo.cancel.
+   */
+  _hasCancellablePlan() {
+    return !!(this._hasPaidSub || this._isPromoTrial);
+  }
+
   async _confirmCancel() {
-    if ((!this._hasPaidSub && !this._isPaidByQuota() && !this._isPromoTrial) || this._isCanceling) return;
+    if (!this._hasCancellablePlan() || this._isCanceling) return;
     if (this._isPromoTrial) return this._confirmCancelPromo();
     const ok = await Wm.confirm({
       title: LOCALE.CANCEL_SUBSCRIPTION || "Cancel subscription",
@@ -1742,7 +1757,7 @@ class settings_billing extends LetcBox {
           // purchase. Sending it to checkout asked the user to "buy" a $0 plan
           // they already fall back to, and on the server that is a NO_PRICE
           // dead end. With no subscription there is simply nothing to do.
-          if (this._hasPaidSub || this._isPaidByQuota()) this._confirmCancel();
+          if (this._hasCancellablePlan()) this._confirmCancel();
         } else if (/^(pro|team|business)$/.test(planValue)) {
           // A live subscription means the click is a plan SWITCH: warn
           // (supersede) and route through checkout — the buyer always sees

--- a/src/drumee/builtins/widget/settings/account/billing/skeleton/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/skeleton/index.js
@@ -85,8 +85,9 @@ function subscriptionBanner(ui) {
   // render the banner from the very first paint and let the renew date fill
   // in once the mirror lands (ticket 2026-07-22).
   const quotaPlan = String(((Visitor.quota && Visitor.quota()) || {}).plan || "").toLowerCase();
-  // Shared with the "Cancel plan" click guard (_isPaidByQuota) so the button
-  // is never rendered clickable without also being armed.
+  // Decides only whether the banner APPEARS. Whether it carries a Cancel
+  // action is a separate question (_hasCancellablePlan, below) — holding a
+  // paid tier and holding a cancellable subscription are not the same thing.
   const paidByQuota = ui._isPaidByQuota ? ui._isPaidByQuota() : /^(pro|team|enterprise)$/.test(quotaPlan);
   if (!ui._hasPaidSub && !paidByQuota) return null;
   const fig = `${ui.fig.family}__sub-banner`;
@@ -165,13 +166,24 @@ function subscriptionBanner(ui) {
             : (LOCALE.SUBSCRIPTION_RENEWS_ON || "Your subscription renews on {0}").format(when))
           : (LOCALE.CURRENT_PLAN_BANNER || "You are on the {0} plan").format(planLabel),
       }),
-      Skeletons.Note({
-        className: `${fig}-action ${fig}-cancel`,
-        content: LOCALE.CANCEL_PLAN || "Cancel plan",
-        service: "cancel-subscription",
-        uiHandler: [ui],
-        bubble: false,
-      }),
+      // Only offer Cancel when something can actually be cancelled. The
+      // banner itself renders off the QUOTA so it appears on first paint,
+      // before the subscription mirror lands — but a quota is not a
+      // subscription. A hand-granted plan, and one whose subscription has
+      // already been terminated (the entitlement is kept until period_end,
+      // the mirror row is not), both read as paid with nothing behind them,
+      // and cancel_subscription answers NO_SUBSCRIPTION. Offering the button
+      // there turned a plan the user cannot cancel into "Something went
+      // wrong" (reported on preview, lexis@drumee.org).
+      ui._hasCancellablePlan && ui._hasCancellablePlan()
+        ? Skeletons.Note({
+          className: `${fig}-action ${fig}-cancel`,
+          content: LOCALE.CANCEL_PLAN || "Cancel plan",
+          service: "cancel-subscription",
+          uiHandler: [ui],
+          bubble: false,
+        })
+        : null,
     ].filter(Boolean),
   });
 }


### PR DESCRIPTION
The banner deliberately renders off the **quota** so it appears on first paint, before the subscription mirror lands. Its Cancel action was gated the same way — and holding a paid tier is not the same as holding a subscription.

Two states read as paid with nothing behind them:

- a plan **granted by hand** (no Stripe subscription ever existed)
- a plan whose subscription has **already been terminated** — the entitlement is kept until `period_end`, the mirror row is not

`payment.cancel_subscription` answers `NO_SUBSCRIPTION` for both, and the client turns that into *"Something went wrong. Please reload and try again."* So the button could never have worked, and its failure told the user to retry something that fails identically every time.

### Reported on preview

`lexis@drumee.org` holds a Team quota (`source='stripe'`, `period_end` 2027-08-01) while `yp.subscription_new` is **empty for the entire deployment** — nothing to cancel, and pressing Cancel only produced the error.

### Fix

Gate the action on `_hasCancellablePlan()`: a real subscription mirror, or a LAUNCH30 trial (which cancels through `promo.cancel`, not this path). The Free-plan card click routes through the same check, since reaching Free from a paid tier *is* the cancel.

### Consequence worth naming

For a genuinely subscribed user the Cancel action now appears when the mirror lands rather than on first paint. A button that shows a moment later beats one that errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
