### PR TITLE
feat(billing): deep link that opens Billing & subscription

### DIFF
--- a/src/drumee/index.web.js
+++ b/src/drumee/index.web.js
@@ -17,6 +17,18 @@
 const STYLE = "color: green; font-weight: bold;"
 let bunldes = new Map();
 
+// "#/desk/billing" — record the destination at the earliest point in the app,
+// before anything can navigate.
+//
+// The router already does this for campaign markers, and that is late enough
+// for them: they ride on the query string, which survives. A hash does not.
+// A signed-out visitor on this link is sent to sign in by a FULL page
+// navigation, and the hash is gone by the time the router of the SECOND
+// document runs — measured on stage, where the capture there saw only
+// "#/welcome/signin". Module scope here runs while the original URL is still
+// the original URL, and sessionStorage outlives the navigation.
+require('libs/billing-deep-link').captureFromUrl();
+
 /**
  * 
  */

--- a/src/drumee/libs/billing-deep-link.js
+++ b/src/drumee/libs/billing-deep-link.js
@@ -58,6 +58,9 @@ function urlWantsBilling() {
     const hash = String(window.location.hash || "");
     return PATH.test(hash) || ARG.test(hash);
   } catch (e) {
+    // Reading location cannot normally throw; if it does, this visit carries
+    // no readable destination and saying so is the only honest answer.
+    console.warn("[billing-deep-link] could not read location", e);
     return false;
   }
 }
@@ -101,7 +104,9 @@ function consume() {
     stored = sessionStorage.getItem(KEY) === "1";
     if (stored) sessionStorage.removeItem(KEY);
   } catch (e) {
-    /* fall through to the url */
+    // Blocked storage. The url is checked below regardless, so a signed-IN
+    // visitor still gets there; only the across-sign-in relay is lost.
+    console.warn("[billing-deep-link] sessionStorage unavailable", e);
   }
   return stored || urlWantsBilling();
 }

--- a/src/drumee/libs/billing-deep-link.js
+++ b/src/drumee/libs/billing-deep-link.js
@@ -1,0 +1,109 @@
+/**
+ * The "open Billing & subscription once I am signed in" intent.
+ *
+ * A shareable link — `#/desk/billing` — that lands on the billing screen
+ * whether or not the recipient has a live session:
+ *
+ *   signed in   the desk consumes the intent on boot and opens the page.
+ *   signed out  the router captures it, the visitor signs in, and the desk
+ *               that mounts afterwards opens the page.
+ *
+ * It exists as a stored intent rather than plain routing because the hash does
+ * not survive the sign-in: the signin plugin replaces it wholesale with
+ * "#/welcome/signin" (see the note on captureCampaignArrival in
+ * router/index.js, which is recorded early for exactly the same reason). By
+ * the time a module could read the URL, the destination is gone.
+ *
+ * sessionStorage only, deliberately. The relay has to outlive the full page
+ * reload that signing in triggers, which it does, and nothing more: a billing
+ * link is read and acted on in one sitting. `hub-deep-link` keeps a dated
+ * localStorage copy as well because a workspace INVITE is finished by signing
+ * UP, and email verification can land the recipient in a different tab — a
+ * journey this link does not have. Dying with the tab is the right lifetime
+ * here; a stale "open billing" surprising someone days later is not.
+ *
+ * Every entry point is defensive about storage itself: private mode and
+ * blocked storage both throw on access, and the honest answer there is "no
+ * intent" rather than a broken boot.
+ */
+
+const KEY = "drumee_billingDeepLink";
+
+/**
+ * Shapes that mean "open billing".
+ *
+ * Two of them, because they survive different things:
+ *
+ *   #/desk/billing    the readable form, for a link opened with a session.
+ *   ...?billing=1     an ARG anywhere in the hash. changeHost does
+ *                     `location.host = host`, which keeps path and hash — so
+ *                     an arg rides across the host switch a signed-in visitor
+ *                     gets sent through, where per-origin storage cannot
+ *                     follow.
+ */
+const PATH = /^#[/@]desk\/billing(?:[/?]|$)/i;
+const ARG = /[?&]billing=1(?:&|$)/i;
+
+/**
+ * Does the CURRENT url ask for the billing screen?
+ *
+ * Reads location.hash directly rather than Visitor.parseModule(): this runs
+ * from the router's initialize, before a module — and therefore before the
+ * Visitor helpers a module relies on — is in play.
+ *
+ * @returns {Boolean}
+ */
+function urlWantsBilling() {
+  try {
+    const hash = String(window.location.hash || "");
+    return PATH.test(hash) || ARG.test(hash);
+  } catch (e) {
+    return false;
+  }
+}
+
+/** Remember that this visit should end on the billing screen. */
+function arm() {
+  try {
+    sessionStorage.setItem(KEY, "1");
+  } catch (e) {
+    // Private mode. The signed-IN case still works — the desk reads the hash
+    // as a fallback — so this only costs the signed-out one.
+    console.warn("[billing-deep-link] sessionStorage unavailable", e);
+  }
+}
+
+/**
+ * Arm from the current url, if it asks for billing. Safe to call on every
+ * load; a url that says nothing leaves any armed intent untouched.
+ *
+ * @returns {Boolean} whether this load carried the link
+ */
+function captureFromUrl() {
+  if (!urlWantsBilling()) return false;
+  arm();
+  return true;
+}
+
+/**
+ * Take the intent, if there is one. Reading CLEARS it — an intent that is
+ * acted on twice would reopen billing over whatever the user did next.
+ *
+ * The url is accepted as a second source so the signed-in case does not
+ * depend on storage at all: there, the hash is still intact by the time the
+ * desk boots.
+ *
+ * @returns {Boolean} true when this boot should open the billing screen
+ */
+function consume() {
+  let stored = false;
+  try {
+    stored = sessionStorage.getItem(KEY) === "1";
+    if (stored) sessionStorage.removeItem(KEY);
+  } catch (e) {
+    /* fall through to the url */
+  }
+  return stored || urlWantsBilling();
+}
+
+module.exports = { arm, consume, captureFromUrl, urlWantsBilling, KEY };

--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -1,6 +1,7 @@
 require("welcome/skin");
 require("builtins/window/confirm/skin");
 const { canUpgradePlan, billingAvailable, needsAdminConsoleUpgrade } = require("libs/billing");
+const billingDeepLink = require("libs/billing-deep-link");
 const { captureUtm, campaignArrival } = require("libs/campaign");
 const hubDeepLink = require("libs/hub-deep-link");
 
@@ -366,6 +367,31 @@ class desk_module extends LetcBox {
     // is picked up by get_env; then open Admin Console (+ Invite via
     // apps-main's own sessionStorage flag).
     this._maybeOpenPromoAdminAfterClaim();
+  }
+
+  /**
+   * "#/desk/billing" — a shareable link that lands on Billing & subscription.
+   *
+   * Called from two places because there are two ways to arrive. Boot covers
+   * the cold load and the return from sign-in (the intent was stored by the
+   * router before the hash was replaced); route() covers clicking the link in
+   * a tab that already has the desk mounted, where nothing re-boots.
+   *
+   * Gated by canUpgradePlan for the same reason the sidebar's own
+   * "upgrade-plan" is: an install with no payment backend, or a member who is
+   * not the org owner, would land on a page that can only dead-end. A link
+   * anyone can forward is exactly the "stray trigger" that gate was written
+   * for, so it is honoured here rather than trusted.
+   *
+   * @returns {Boolean} whether the billing screen was opened
+   */
+  _maybeOpenBillingDeepLink() {
+    if (!billingDeepLink.consume()) return false;
+    if (!canUpgradePlan()) return false;
+    // Don't let desk-state restore pull the screen back to the remembered one.
+    this._restoreInFlight = false;
+    this.openBillingPage();
+    return true;
   }
 
   /**
@@ -1867,6 +1893,10 @@ class desk_module extends LetcBox {
     // is a no-op unless a workspace is actually armed, and it hides itself while
     // either flow is on screen — see _showInvitedWorkspaceLoader.
     this._showInvitedWorkspaceLoader();
+    // Before the two full-screen flows: the billing link is an explicit
+    // destination the visitor asked for, and letting the reward flow or the
+    // LAUNCH30 offer land on top of it would bury it.
+    this._maybeOpenBillingDeepLink();
     return this._maybeStartRewardFlow()
       .then(() => this._maybeShowPromoLaunch30("home", { defer: true }))
       .then(() => this._waitForHomePopups())
@@ -1975,6 +2005,12 @@ class desk_module extends LetcBox {
     if (args.hasOwnProperty("wm") && window.Wm) {
       return window.Wm.route();
     }
+    // The billing link clicked while the desk is already UP: only hashchange
+    // fires, home has long since settled, and nothing is about to render over
+    // the screen — so open it here and now. On a cold load this stands down
+    // and _afterHomeSettled does it instead, because opening before
+    // loadDefault() only gets Home painted on top (seen on stage).
+    if (this._homeSettledDone && this._maybeOpenBillingDeepLink()) return;
     this._pending = { available: false };
     // The server-side profile.onboarded flag is authoritative: a user who has
     // completed onboarding (persisted via onboarding.update_profile -> onboarded=1)

--- a/src/drumee/router/index.js
+++ b/src/drumee/router/index.js
@@ -20,6 +20,7 @@ require("./skin");
 
 const { getModule, moduleName } = require('./modules');
 const { captureCampaignArrival } = require('libs/campaign');
+const billingDeepLink = require('libs/billing-deep-link');
 
 class drumee_router extends LetcBox {
   constructor(...args) {
@@ -46,6 +47,10 @@ class drumee_router extends LetcBox {
     // signin plugin replaces the hash wholesale with "#/welcome/signin", so the
     // markers are gone by the time a module could look for them.
     captureCampaignArrival();
+    // Same reason, same moment: "#/desk/billing" must be remembered before the
+    // signin plugin replaces the hash, or a signed-out visitor loses the
+    // destination the link named.
+    billingDeepLink.captureFromUrl();
     localStorage.main_domain = bootstrap().main_domain;
     this._buffer = [];
     this._loaded = {
@@ -378,6 +383,9 @@ class drumee_router extends LetcBox {
     // the usual case, since the recipient is normally already on a Drumee page.
     // A no-op when the URL carries no campaign params.
     captureCampaignArrival();
+    // Warm arrival for the billing link too — clicking it in a tab that
+    // already runs the app never re-enters initialize().
+    billingDeepLink.captureFromUrl();
     let page = /^\/.*(.+)\.htm?/;
     if (page.test(location.pathname) || page.test(Host.get(_a.homepage))) {
       this.loadBootstrap();


### PR DESCRIPTION
A link that opens **Billing & subscription** directly.

```
https://<host>/-/<endpoint>/#/desk/billing
https://<host>/-/<endpoint>/#/desk?billing=1
```

**Signed in it works today. Signed out it does not yet** — that half hit a structural blocker, detailed below. Flagging it rather than shipping it quietly.

### How it works

| piece | role |
|---|---|
| `libs/billing-deep-link` | `arm` / `consume` / `captureFromUrl`, sessionStorage |
| `index.web.js` | captures at app entry — the earliest point that runs while the URL is still the one the user clicked |
| `router` | captures on cold **and** warm arrival (a hashchange in a tab already running the app never re-enters `initialize`) |
| `desk` | consumes and opens the page |

Consumption is deliberately **not** at desk boot. Opening there works and is then immediately undone — `loadDefault()` renders Home over it a moment later. Measured on stage: the intent was consumed, the screen was Home. It runs from `_afterHomeSettled` instead, ahead of the reward flow and the LAUNCH30 offer so neither buries a destination the visitor explicitly asked for, and from `route()` for a warm arrival.

Gated by `canUpgradePlan` — the same rule the sidebar's own `upgrade-plan` uses. A link anyone can forward is exactly the stray trigger that gate exists for.

Two URL shapes because they survive different things: the path form reads better; the arg form rides through `changeHost`, which does `location.host = host` and so keeps path and hash where per-origin storage cannot follow.

### Not done — the signed-out case

A signed-out visitor on a workspace subdomain is sent to the **main host** to sign in, and the hash is replaced with `#/welcome/signin` on the way. The destination is lost in both carriers at once:

- `sessionStorage` is **per-origin** and cannot cross the host switch
- the hash that would have carried it is **gone**

Capturing earlier does not help — verified from the app entry, which is as early as ui-team runs.

The existing pattern for this is a signin-URL arg: the workspace-invite CTA is `#/welcome/signin?hub_id=…`, and the welcome module arms it there. Making **one** link serve both cases needs welcome to arm a billing arg the same way **and** to stop rendering the signin form to someone already authenticated — `welcome.route()` does not check `Visitor.isOnline()` today. That second half is a behaviour change reaching other flows, so it is left as a decision rather than folded in here.

### Verified on stage (signed in)

Both shapes land on **Home › Billing & subscription** with the plan cards rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
