### PR TITLE
fix(meeting): a changed avatar now reaches every participant

### DIFF
--- a/patches/@drumee+ui-core+1.1.50.patch
+++ b/patches/@drumee+ui-core+1.1.50.patch
@@ -1,0 +1,146 @@
+diff --git a/node_modules/@drumee/ui-core/letc/user.js b/node_modules/@drumee/ui-core/letc/user.js
+index a288e64..4b85937 100644
+--- a/node_modules/@drumee/ui-core/letc/user.js
++++ b/node_modules/@drumee/ui-core/letc/user.js
+@@ -621,13 +621,21 @@ class __core_user extends Backbone.Model {
+    * @param {*} id 
+    * @returns 
+    */
+-  avatar(id, type = _a.vignette) {
++  avatar(id, type = _a.vignette, mtime) {
+     const a = this.get(_a.avatar);
+     if (/^http/.test(a)) {
+       return a;
+     }
+     id = id || this.id;
+-    const ts = `${this.get(_a.mtime)}` || "";
++    // `ts` versions the avatar OF `id`, so it has to come from that entity's own
++    // mtime (server bumps entity.mtime via entity_touch on avatar upload).
++    // Reading the local user's mtime unconditionally — the previous behaviour —
++    // is only correct when id IS the local user: for anyone else the token never
++    // moves when they change their avatar, so the URL stays byte-identical and
++    // the browser keeps serving the pre-change image. Callers that know the
++    // owner's mtime now pass it; the local mtime remains the fallback so
++    // call sites that don't are unchanged.
++    const ts = `${mtime != null ? mtime : this.get(_a.mtime)}`;
+     const { endpoint } = bootstrap();
+     let base = `${endpoint}avatar/${id}?type=${type}&ts=${ts}`;
+     return base
+diff --git a/node_modules/@drumee/ui-core/letc/widgets/profile/index.js b/node_modules/@drumee/ui-core/letc/widgets/profile/index.js
+index 13edb44..eda76e5 100644
+--- a/node_modules/@drumee/ui-core/letc/widgets/profile/index.js
++++ b/node_modules/@drumee/ui-core/letc/widgets/profile/index.js
+@@ -16,7 +16,23 @@ class __user_profile extends LetcBox {
+     });
+     this.declareHandlers();
+     let id = opt.id || opt.uid || opt.user_id || opt.drumate_id || opt.entity_id;
+-    this.mset({ id });
++    // `strict`: this widget renders one SPECIFIC other entity, so never
++    // substitute the local user — used by callers whose id arrives
++    // asynchronously (the remote meeting tile, whose uid comes from a Jitsi
++    // presence property). Those must show initials until the id lands.
++    //
++    // Every other caller keeps the long-standing contract that naming no entity
++    // means "the local user" — the sidebar footer avatar and the local meeting
++    // tile both rely on it. That used to be handled implicitly by
++    // Visitor.avatar()'s `id || this.id`; resolve it HERE instead, so the widget
++    // always knows which entity it is rendering and the no-id case can be told
++    // apart from the identity-pending case.
++    const strict = !!opt.strict;
++    if (id == null && !strict) id = Visitor.id;
++    // Version of THIS entity's avatar. Threaded into the URL so the cache token
++    // belongs to the avatar's owner rather than to whoever is looking at it.
++    // Deliberately NOT defaulted for the local user here — see _avatarVersion().
++    this.mset({ id, avatar_mtime: opt.avatar_mtime, strict });
+     if (opt.live_status) {
+       this.updateStatus = this.updateStatus.bind(this);
+       RADIO_BROADCAST.on(_e.peerData, this.updateStatus);
+@@ -52,10 +68,38 @@ class __user_profile extends LetcBox {
+    * 
+    */
+   restart(clearCache) {
+-    if (clearCache) delete __cache[this.mget(_a.id)]
++    if (clearCache) delete __cache[this._avatarKey()]
+     this.onDomRefresh()
+   }
+ 
++  /**
++   * Key for the "this avatar 404s" memo. It includes the avatar VERSION so that
++   * a user who had no avatar and then uploads one is retried: keyed on id alone,
++   * the miss was remembered for the whole session and every later widget for that
++   * id short-circuited straight to initials, so the new avatar could never appear.
++   */
++  _avatarKey() {
++    const v = this._avatarVersion();
++    return `${this.mget(_a.id)}:${v == null ? '' : v}`;
++  }
++
++  /**
++   * Version token for the avatar this widget renders.
++   *
++   * A remote entity's version has to be supplied by whoever knows it (the peer
++   * publishes it in userAttributes). For the LOCAL user we read Visitor's mtime
++   * live rather than capturing it at initialize time: the local user can change
++   * their own avatar while this widget is mounted, and reading it at render time
++   * is what lets the URL *and* the negative-cache key re-version on the spot.
++   */
++  _avatarVersion() {
++    const v = this.mget('avatar_mtime');
++    if (v != null) return v;
++    const id = this.mget(_a.id);
++    if (id != null && `${id}` === `${Visitor.id}`) return Visitor.get(_a.mtime);
++    return null;
++  }
++
+   /**
+    * 
+    * @param {*} src 
+@@ -63,7 +107,7 @@ class __user_profile extends LetcBox {
+    */
+   img() {
+     const imageType = this.mget(_a.type) || _a.vignette
+-    const src = Visitor.avatar(this.mget(_a.id), imageType)
++    const src = Visitor.avatar(this.mget(_a.id), imageType, this._avatarVersion())
+     return `
+       <img class="${this.fig.family}__icon ${this.fig.family}__picture picture" data-flow="x" src="${src}">
+     `
+@@ -168,8 +212,20 @@ class __user_profile extends LetcBox {
+    * 
+    */
+   loadImage() {
++    // Only reachable for a `strict` caller (initialize resolves everyone else to
++    // Visitor.id): the entity is known to be someone specific but its id has not
++    // arrived yet. Show initials and stop — Visitor.avatar() substitutes the
++    // LOCAL user's id when it gets none, so requesting here would render the
++    // VIEWER's own avatar in a peer's slot. Do not memoize: this is a pending
++    // state, not a missing avatar, and the caller re-renders once the id lands.
++    if (this.mget(_a.id) == null) {
++      this.el.dataset.default = 1;
++      this._show('i');
++      return;
++    }
++
+     // Optimization : prevent reload when marked as error
+-    if (__cache[this.mget(_a.id)]) {
++    if (__cache[this._avatarKey()]) {
+       this.el.dataset.default = 1;
+       this._show('i');
+       return;
+@@ -186,7 +242,7 @@ class __user_profile extends LetcBox {
+     };
+ 
+     const imageType = this.mget(_a.type) || _a.vignette
+-    img.src = Visitor.avatar(this.mget(_a.id), imageType);
++    img.src = Visitor.avatar(this.mget(_a.id), imageType, this._avatarVersion());
+   }
+ 
+   /**
+@@ -194,7 +250,7 @@ class __user_profile extends LetcBox {
+    * @param {*} e
+     */
+   _onError(e) {
+-    __cache[this.mget(_a.id)] = 1;
++    __cache[this._avatarKey()] = 1;
+     this.el.dataset.default = 1;
+     return this._show('i');
+   }

--- a/src/drumee/builtins/webrtc/endpoint/local/user/skeleton/index.js
+++ b/src/drumee/builtins/webrtc/endpoint/local/user/skeleton/index.js
@@ -30,7 +30,13 @@ const __skl_stream_local = function (_ui_) {
   // produce identical initials + color for the same person on every client.
   const avatar = {
     kind: KIND.profile,
-    id: _ui_.mget('avatar_id') || Visitor.profile().id,
+    // `Visitor.profile().id` is not dependably populated — the rest of the app
+    // uses `Visitor.id` as the canonical local id — and this is the self-view,
+    // so it is unambiguously the local user. Name them explicitly rather than
+    // leaning on a fallback further down the pipeline. No avatar_mtime: the
+    // profile widget reads Visitor's mtime live for the local user, so changing
+    // your own avatar mid-call re-versions this tile immediately.
+    id: _ui_.mget('avatar_id') || _ui_.mget(_a.uid) || Visitor.id,
     type: 'thumb',
     active: 0,
     firstname,

--- a/src/drumee/builtins/webrtc/endpoint/remote/user/index.js
+++ b/src/drumee/builtins/webrtc/endpoint/remote/user/index.js
@@ -12,13 +12,19 @@ class __remote_user extends __stream {
     this.participant = opt.participant;
     const displayName = this.participant.getDisplayName();
     try {
-      const { firstname, lastname, uid, username } = opt
+      const { firstname, lastname, uid, username, avatar_mtime } = opt
       this.mset({
         label: displayName || firstname || username || lastname,
         firstname: firstname || displayName,
         lastname,
         uid,
         username: displayName || username || firstname,
+        // Version of THIS peer's avatar, published in their userAttributes.
+        // Threaded into the KIND.profile spec so the avatar URL is versioned by
+        // its owner instead of by the viewer (see webrtc/room/jitsi
+        // broadcastJoining). Undefined until the property arrives, at which
+        // point onPropertyChanged msets it and re-feeds.
+        avatar_mtime,
       });
     } catch (e) {
 

--- a/src/drumee/builtins/webrtc/endpoint/remote/user/skeleton/index.js
+++ b/src/drumee/builtins/webrtc/endpoint/remote/user/skeleton/index.js
@@ -30,7 +30,19 @@ const __skl_stream_remote = function (_ui_) {
     active: 0,
     className: 'no-online-status',
     firstname,
-    lastname
+    lastname,
+    // Version the avatar URL by ITS OWNER's mtime, not the viewer's. Without
+    // this, a peer who changes their avatar produces a byte-identical URL on
+    // every other client, which then serves the pre-change image from the HTTP
+    // cache no matter how often the tile re-renders.
+    avatar_mtime: _ui_.mget("avatar_mtime"),
+    // This tile always belongs to a specific PEER, so the profile widget must
+    // never fall back to the local user when `uid` is still unknown — that is
+    // what made a joining peer's tile flash the viewer's own avatar. `uid` is
+    // undefined only between USER_JOINED and the userAttributes property
+    // arriving (see _participantAttributes / onPropertyChanged); until then the
+    // tile shows initials, and the property event re-feeds this skeleton.
+    strict: 1,
   };
 
   const topActions = Skeletons.Box.X({

--- a/src/drumee/builtins/webrtc/room/jitsi.js
+++ b/src/drumee/builtins/webrtc/room/jitsi.js
@@ -855,6 +855,13 @@ class __webrtc_room extends __room {
       quota: this.get(_a.quota),
       id: this.room.myUserId(),
       socket_id: Visitor.get(_a.socket_id),
+      // Version of OUR avatar (server bumps entity.mtime via entity_touch on
+      // upload). Peers need it to build a correctly-versioned avatar URL: the
+      // `ts` token in Visitor.avatar() is per-ENTITY, and each client is the
+      // only one that reliably knows its own current value. Without it every
+      // other client keeps requesting the byte-identical URL it already cached
+      // and shows the pre-change avatar.
+      avatar_mtime: Visitor.get(_a.mtime),
       muted,
       mic,
       participant_id: this.room.myUserId()
@@ -987,6 +994,53 @@ class __webrtc_room extends __room {
   notifyParticipantLeft(name) { }
 
   /**
+   * Identity a peer has already published in its `userAttributes` presence
+   * property, for seeding a tile at CREATION time.
+   *
+   * USER_JOINED fires before lib-jitsi-meet processes the presence child nodes
+   * (ChatRoom.onPresence runs processNode only after MUC_MEMBER_JOINED), so for
+   * a peer whose attributes were already in the presence we saw — i.e. everyone
+   * who was in the room before us — the property is readable right here, and
+   * PARTICIPANT_PROPERTY_CHANGED is still to come. For a peer that joins after
+   * us the property is genuinely not set yet and this returns {}; the later
+   * property event fills it in (onPropertyChanged).
+   *
+   * Seeding matters because the tile's avatar is a KIND.profile widget keyed on
+   * `uid`, and Visitor.avatar() falls back to the LOCAL user's id when it gets
+   * no id — so a tile rendered before `uid` is known silently requests the
+   * viewer's OWN avatar for the peer.
+   * @returns {Object}
+   */
+  _participantAttributes(participant) {
+    if (!participant || !_.isFunction(participant.getProperty)) return {};
+    let raw;
+    try {
+      raw = participant.getProperty(_a.userAttributes);
+    } catch (e) {
+      return {};
+    }
+    if (!raw) return {};
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (e) {
+      this.warn("unparsable userAttributes", e);
+      return {};
+    }
+    if (!_.isObject(data)) return {};
+    // Only the identity fields the tile renders from. `id`/`participant_id`/
+    // `socket_id`/`quota` are deliberately excluded: `id` is the model's
+    // collection key and the others are already supplied by the caller.
+    const out = {};
+    for (const k of [
+      _a.uid, _a.firstname, _a.lastname, _a.username, "avatar_mtime", "muted", "mic",
+    ]) {
+      if (data[k] != null) out[k] = data[k];
+    }
+    return out;
+  }
+
+  /**
    * That function is executed when the conference is joined by the remote user
    * this event is triggrered by Jitsi
    */
@@ -1014,7 +1068,11 @@ class __webrtc_room extends __room {
         participant,
         participant_id: id,
         peer: this.peer,
-        quota: this.mget(_a.quota)
+        quota: this.mget(_a.quota),
+        // Seed uid / name / avatar version when the peer already published them
+        // (see _participantAttributes) so the first paint renders THEIR avatar
+        // rather than requesting ours via Visitor.avatar's id fallback.
+        ...this._participantAttributes(participant),
       })
     );
     endpoint = this.__participants.children.last();


### PR DESCRIPTION
Visitor.avatar() versioned the avatar of `id` with the mtime of whoever was LOOKING at it. The cache-busting token was scoped to the wrong entity: the URL one client builds for another's avatar is avatar/{them}?type=…&ts={my mtime}, so a peer changing their picture left that URL byte-identical and the browser went on serving the response it had already cached. Re-rendering could not help — the tile does re-render, on PARTICIPANT_PROPERTY_CHANGED, and asks for the same bytes.

The server side was already right: entity_touch bumps entity.mtime on avatar upload, so a per-user version exists. Nothing transmitted or consumed it.

That is the asymmetry people reported. On your own client your own profile change re-sets Visitor, and because ts is one value shared by every avatar URL in the app, all of them re-fetch — so you see everyone correctly. On everybody else's client nothing about them changed, their token is frozen, and you stay stale for them. A later joiner appearing to "fix" the whole room is the same mechanism from the other side: something replaces the viewer's own mtime and re-versions every avatar at once, which is why participants whose metadata never changed all correct at the same instant. Only a shared token can do that.

So: publish our own avatar version in the conference userAttributes, thread it through the remote tile into the profile widget, and have Visitor.avatar() use the owner's version when the caller knows it. The local mtime remains the fallback, so call sites that pass none are unchanged.

Two supporting changes fall out of it:

  - onRemoteUserJoined seeds uid/name/version from the peer's already published presence property. USER_JOINED fires before lib-jitsi-meet processes the presence child nodes (ChatRoom.onPresence runs processNode only after MUC_MEMBER_JOINED), so for anyone already in the room the property is readable at tile-creation time. Unseeded, the tile painted once with no uid.

  - the profile widget's negative cache ("this avatar 404s") was keyed on id alone and never invalidated, so a user who had no avatar and then uploaded one stayed on initials for the rest of the session, immune to any re-render. Keyed on id:version now, so a new version is retried.

The widget also resolves its entity explicitly rather than leaning on Visitor.avatar()'s `id || this.id`. A null id meant two different things — "the local user" for the sidebar footer avatar and the self-view tile, "the id has not arrived yet" for a remote tile — and only the second may skip the request. Callers rendering a specific peer now say strict: 1; everyone else resolves to Visitor.id. The local user's version is read live, so changing your own avatar re-versions the URL and the cache key on the spot instead of at mount time.

The ui-core half ships as a patch-package patch alongside the existing @drumee/* ones, and should be upstreamed into @drumee/ui-core.

Not covered: the Participants roster and attendee cards render avatars from hub_get_members_by_type, which does not project mtime. They need `e.mtime AS avatar_mtime` server-side before they can be versioned too.