### PR TITLE
perf(tutorial): cut the wait between tutorial steps

### DIFF
--- a/src/drumee/modules/desk/tutorial/index.js
+++ b/src/drumee/modules/desk/tutorial/index.js
@@ -3,6 +3,28 @@ const { workspaceContent } = require("./skeleton/toolkit")
 
 const SVC_OPT = { async: 1 };
 
+// Every step widget is a bare `import()` in seeds.js, so each one is its own
+// webpack chunk with no prefetch hint. Left alone, pressing Next is the moment
+// the chunk is requested: Kind.get() hands back the lazy loader placeholder,
+// which mounts EMPTY, waits on the network, then respawns itself once the module
+// lands (see ui-core letc/kind/loader.js). The user pays a round trip plus a
+// mount-and-rebuild on every step boundary, and the spotlight is left measuring
+// a placeholder while it happens.
+//
+// Kind.waitFor resolves the import and registers the class, after which
+// Kind.get() answers synchronously — no placeholder, no respawn, no fetch. Warm
+// them while step 1 is on screen and being read.
+//
+// Step 1 (tutorial_workspace), the spotlight and media_grid are all pulled in by
+// the shell itself, so they are already on their way and are not listed here.
+const PRELOAD_KINDS = [
+  'tutorial_folder',
+  'tutorial_meeting',
+  'tutorial_task',
+  'tutorial_share',
+  'tutorial_migrate',
+];
+
 class tutorial_main extends LetcBox {
 
   initialize(opt = {}) {
@@ -45,6 +67,22 @@ class tutorial_main extends LetcBox {
 
   onDomRefresh() {
     this.feed(require('./skeleton')(this));
+    this._preloadSteps();
+  }
+
+  /**
+   * Pull the remaining step widgets down in the background so that pressing
+   * Next renders from memory rather than from the network. Fire and forget: a
+   * warm-up that fails costs nothing, because the step still loads on demand
+   * exactly as it does today.
+   */
+  _preloadSteps() {
+    if (typeof Kind === 'undefined' || !_.isFunction(Kind.waitFor)) return;
+    for (const kind of PRELOAD_KINDS) {
+      Promise.resolve(Kind.waitFor(kind)).catch((e) => {
+        this.warn && this.warn(`[tutorial] could not preload ${kind}`, e);
+      });
+    }
   }
 
   /**

--- a/src/drumee/modules/desk/tutorial/spotlight/index.js
+++ b/src/drumee/modules/desk/tutorial/spotlight/index.js
@@ -1,21 +1,37 @@
 require('./skin');
 const { tooltipBadge } = require('../skeleton/toolkit');
-const { getElStablePosition } = require('@drumee/ui-essentials');
 
 const GAP = 12;
 const MIN_RADIUS = 120;
 const RADIUS_PADDING = 40;
-const STABLE_MAX_TRIES = 10;
+// One frame per sample, so this is also the wall-clock ceiling in frames
+// (~330ms at 60Hz) — the same ceiling the two-RAF version had at half the
+// sample count.
+const STABLE_MAX_TRIES = 20;
 
-// Wait until the element's measured size stops changing across two RAFs.
-// Covers async children (e.g. media_grid icon) that resize the target after
-// it first lands in the DOM — without which the very first focus measures
+function nextFrameRect(el) {
+  return new Promise((resolve) =>
+    requestAnimationFrame(() => resolve(el.getBoundingClientRect())),
+  );
+}
+
+// Wait until the element's measured size stops changing between consecutive
+// frames. Covers async children (e.g. media_grid icon) that resize the target
+// after it first lands in the DOM — without which the very first focus measures
 // a collapsed rect and the tooltip lands off-screen.
+//
+// Sampled once per frame, seeded from a free synchronous read. It used to call
+// getElStablePosition (two RAFs) twice, so an element that had ALREADY settled —
+// which is every screen change after the first, the common case by far — still
+// cost four frames to confirm, and focus() paid that twice when a screen passes
+// an anchor. Measured 118ms per screen change; one frame confirms the same
+// thing. Per-frame sampling also spots a late resize a frame sooner than
+// per-two-frames did, so the case this exists for got quicker too.
 async function waitForStableRect(el) {
-  let prev = await getElStablePosition(el);
+  let prev = el.getBoundingClientRect();
   for (let i = 0; i < STABLE_MAX_TRIES; i++) {
-    const next = await getElStablePosition(el);
-    if (next.width === prev.width && next.height === prev.height && next.width > 0) {
+    const next = await nextFrameRect(el);
+    if (next.width > 0 && next.width === prev.width && next.height === prev.height) {
       return next;
     }
     prev = next;
@@ -84,7 +100,17 @@ class __tutorial_spotlight extends LetcBox {
     if (!target) return this.clear();
     const el = elementOf(target);
     if (!el || typeof el.getBoundingClientRect !== 'function') return;
-    const rect = await waitForStableRect(el);
+
+    // The target rect, the anchor rect and the callout part do not depend on
+    // one another, so they are resolved together. Awaiting them one after the
+    // other put two full settle waits on the critical path of every screen that
+    // passes an anchor, for no reason other than the order they were written in.
+    const anchorEl = anchor ? elementOf(anchor) : null;
+    const [rect, measuredAnchor, callout] = await Promise.all([
+      waitForStableRect(el),
+      anchorEl && anchorEl !== el ? waitForStableRect(anchorEl) : null,
+      this.ensurePart('callout'),
+    ]);
     if (!rect.width || !rect.height) return;
 
     const cx = rect.left + rect.width / 2;
@@ -95,19 +121,15 @@ class __tutorial_spotlight extends LetcBox {
     this.el.style.setProperty('--spot-radius', `${r}px`);
     this.setState(1);
 
-    const callout = await this.ensurePart('callout');
     if (!tooltip) {
       callout.feed(null);
       return;
     }
-    const anchorEl = anchor ? elementOf(anchor) : null;
-    const anchorRect = anchorEl && anchorEl !== el
-      ? await waitForStableRect(anchorEl)
-      : rect;
+    const anchorRect = measuredAnchor && measuredAnchor.width ? measuredAnchor : rect;
     callout.feed(tooltipBadge(owner || this, {
       ...tooltip,
       direction,
-      style: anchorFor(anchorRect.width ? anchorRect : rect, direction),
+      style: anchorFor(anchorRect, direction),
     }));
   }
 


### PR DESCRIPTION
Moving from one step or screen to the next sat behind two avoidable delays.

The spotlight settled every target with getElStablePosition, which is two requestAnimationFrames, and needed two of those calls before it had a pair of samples to compare -- four frames to confirm a box that, on every screen after the first, had not moved since it was laid out. focus() then measured the anchor after the target instead of alongside it, so any screen that points the callout at a sub-element paid the whole settle twice. Sample once per frame instead, seeded from a free synchronous read, and resolve the target rect, the anchor rect and the callout part
together. Measured in headless chromium against the old code: 119ms ->
18ms per screen change. Per-frame sampling also catches a late resize a frame sooner than per-two-frames did, so the async-growing target this wait exists for -- the media_grid icon -- got quicker too, and still measures the right box.

Each step widget is its own webpack chunk with no prefetch hint, so pressing Next was the moment its chunk was requested: the kind loader mounts an empty placeholder, waits on the network, then respawns itself once the module lands, and the spotlight measures the placeholder while that happens. Warm steps 2-6 through Kind.waitFor when the shell mounts, while step 1 is still being read, after which Kind.get answers synchronously. Fire and forget -- a warm-up that fails still loads on demand exactly as before.

Left alone: the per-screen rebuild of the whole body, including the media_grid widgets in the faded backdrop that are identical between screens. That is a larger change and its cost is unmeasured.