### PR TITLE
fix(grid): re-check for tiles the partition observer could not have seen

### DIFF
--- a/src/drumee/builtins/window/utils.js
+++ b/src/drumee/builtins/window/utils.js
@@ -398,6 +398,11 @@ class __window_mfs extends DrumeeMFS {
     }
     this._partitionSettleTimer = setTimeout(() => {
       this._partitionSettleTimer = null;
+      // Last look before settling — an insert can also slip in between the
+      // partition pass and this timer.
+      if (this._hasUnpartitioned(listPart)) {
+        this._doPartition(listPart);
+      }
       if (this._partitionDebounce) {
         cancelAnimationFrame(this._partitionDebounce);
         this._partitionDebounce = null;
@@ -497,6 +502,19 @@ class __window_mfs extends DrumeeMFS {
             subtree: true,
           });
         }
+        // The observer was DISCONNECTED across _doPartition just above, so it
+        // could not record anything inserted in that window — and a
+        // MutationObserver does not backfill what it missed while detached.
+        // An upload lands its tiles in bursts, so one falling inside that gap
+        // is a matter of timing: it stays a direct child of the flex-column
+        // container and renders as a full-width row. Ten files, ten rows, one
+        // column — intermittently, which is what made it look random.
+        //
+        // Re-check instead of trusting the gap was empty. _doPartition rescans
+        // direct children each call, so a second pass is idempotent and cheap.
+        if (this._hasUnpartitioned(listPart)) {
+          this._doPartition(listPart);
+        }
         if (done) {
           if (this._partitionRetryTimer) {
             clearTimeout(this._partitionRetryTimer);
@@ -549,6 +567,28 @@ class __window_mfs extends DrumeeMFS {
       scrollEl.style.visibility = "visible";
       scrollEl.dataset.partitioning = 0;
     }
+  }
+
+  /**
+   * Items still sitting directly in .smart-container, outside the three
+   * section wrappers.
+   *
+   * These are the ones that render wrong: the container is a flex COLUMN
+   * (see the inline styles at the end of _doPartition), so an unpartitioned
+   * tile becomes a full-width row instead of a grid cell — ten uploads read
+   * as ten rows in one column.
+   */
+  _hasUnpartitioned(listPart) {
+    const scrollEl = listPart && listPart.el
+      && listPart.el.querySelector(".smart-container");
+    if (!scrollEl) return false;
+    return [...scrollEl.children].some(
+      (el) =>
+        el.dataset && el.dataset.filetype &&
+        !el.classList.contains("workspace-section") &&
+        !el.classList.contains("folder-section") &&
+        !el.classList.contains("file-section"),
+    );
   }
 
   _doPartition(listPart) {


### PR DESCRIPTION
### The mechanism

`.smart-container` is laid out as a **flex column** holding three grid wrappers (`workspace-section` / `folder-section` / `file-section`). A tile that never reaches a wrapper stays a direct child of that column and renders as a **full-width row** — ten uploads read as ten rows in one column, which is exactly the reported symptom.

`_doPartition` is what moves tiles into the wrappers, and the MutationObserver that triggers it is **disconnected across the call** so its own DOM moves do not re-trigger it:

```js
this._partitionObserver.disconnect();        // ①
const done = this._doPartition(listPart);    // ②  moves tiles
this._partitionObserver.observe(...);        // ③
```

Anything inserted between ① and ③ produces **no mutation record**, and a MutationObserver does not backfill what it missed while detached. An upload lands tiles in bursts, so whether one falls in that gap is a matter of timing — **which is why the symptom is intermittent**. And once `done` is true the retry timer is cleared, so a missed tile is never rescued.

The code already carries a comment describing this exact symptom being fixed once before (by keeping the observer alive after settle). That fix was necessary but not sufficient — it does not cover the disconnect window itself.

### The change

Re-check instead of trusting the gap was empty: after the pass, and again before the settle timer flips the "finished" flags, look for direct children still carrying `data-filetype` and partition again. `_doPartition` rescans direct children on every call, so the extra pass is idempotent and costs a DOM scan.

### ⚠️ Honest status — read before merging

This closes a gap that **provably exists in the code**, but it is **NOT confirmed to be the cause of the report.**

I could not reproduce the failure. 4 rounds × 10 files showed zero stray tiles — and a **control build without this change behaved identically**, so the test never exercised the race. Synthetic uploads finish too uniformly; real ones carry network jitter, thumbnail generation and websocket events.

Treat this as a **guard, not a verified cure**, and keep the report open until it has been seen surviving in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
