### PR TITLE
Promote test → preview: LAUNCH30 delay, billing deep link, meeting avatar propagation, tutorial perf

### DIFF
--- a/patches/@drumee+ui-core+1.1.50.patch
+++ b/patches/@drumee+ui-core+1.1.50.patch
@@ -1,0 +1,146 @@
+diff --git a/node_modules/@drumee/ui-core/letc/user.js b/node_modules/@drumee/ui-core/letc/user.js
+index a288e64..4b85937 100644
+--- a/node_modules/@drumee/ui-core/letc/user.js
++++ b/node_modules/@drumee/ui-core/letc/user.js
+@@ -621,13 +621,21 @@ class __core_user extends Backbone.Model {
+    * @param {*} id 
+    * @returns 
+    */
+-  avatar(id, type = _a.vignette) {
++  avatar(id, type = _a.vignette, mtime) {
+     const a = this.get(_a.avatar);
+     if (/^http/.test(a)) {
+       return a;
+     }
+     id = id || this.id;
+-    const ts = `${this.get(_a.mtime)}` || "";
++    // `ts` versions the avatar OF `id`, so it has to come from that entity's own
++    // mtime (server bumps entity.mtime via entity_touch on avatar upload).
++    // Reading the local user's mtime unconditionally — the previous behaviour —
++    // is only correct when id IS the local user: for anyone else the token never
++    // moves when they change their avatar, so the URL stays byte-identical and
++    // the browser keeps serving the pre-change image. Callers that know the
++    // owner's mtime now pass it; the local mtime remains the fallback so
++    // call sites that don't are unchanged.
++    const ts = `${mtime != null ? mtime : this.get(_a.mtime)}`;
+     const { endpoint } = bootstrap();
+     let base = `${endpoint}avatar/${id}?type=${type}&ts=${ts}`;
+     return base
+diff --git a/node_modules/@drumee/ui-core/letc/widgets/profile/index.js b/node_modules/@drumee/ui-core/letc/widgets/profile/index.js
+index 13edb44..eda76e5 100644
+--- a/node_modules/@drumee/ui-core/letc/widgets/profile/index.js
++++ b/node_modules/@drumee/ui-core/letc/widgets/profile/index.js
+@@ -16,7 +16,23 @@ class __user_profile extends LetcBox {
+     });
+     this.declareHandlers();
+     let id = opt.id || opt.uid || opt.user_id || opt.drumate_id || opt.entity_id;
+-    this.mset({ id });
++    // `strict`: this widget renders one SPECIFIC other entity, so never
++    // substitute the local user — used by callers whose id arrives
++    // asynchronously (the remote meeting tile, whose uid comes from a Jitsi
++    // presence property). Those must show initials until the id lands.
++    //
++    // Every other caller keeps the long-standing contract that naming no entity
++    // means "the local user" — the sidebar footer avatar and the local meeting
++    // tile both rely on it. That used to be handled implicitly by
++    // Visitor.avatar()'s `id || this.id`; resolve it HERE instead, so the widget
++    // always knows which entity it is rendering and the no-id case can be told
++    // apart from the identity-pending case.
++    const strict = !!opt.strict;
++    if (id == null && !strict) id = Visitor.id;
++    // Version of THIS entity's avatar. Threaded into the URL so the cache token
++    // belongs to the avatar's owner rather than to whoever is looking at it.
++    // Deliberately NOT defaulted for the local user here — see _avatarVersion().
++    this.mset({ id, avatar_mtime: opt.avatar_mtime, strict });
+     if (opt.live_status) {
+       this.updateStatus = this.updateStatus.bind(this);
+       RADIO_BROADCAST.on(_e.peerData, this.updateStatus);
+@@ -52,10 +68,38 @@ class __user_profile extends LetcBox {
+    * 
+    */
+   restart(clearCache) {
+-    if (clearCache) delete __cache[this.mget(_a.id)]
++    if (clearCache) delete __cache[this._avatarKey()]
+     this.onDomRefresh()
+   }
+ 
++  /**
++   * Key for the "this avatar 404s" memo. It includes the avatar VERSION so that
++   * a user who had no avatar and then uploads one is retried: keyed on id alone,
++   * the miss was remembered for the whole session and every later widget for that
++   * id short-circuited straight to initials, so the new avatar could never appear.
++   */
++  _avatarKey() {
++    const v = this._avatarVersion();
++    return `${this.mget(_a.id)}:${v == null ? '' : v}`;
++  }
++
++  /**
++   * Version token for the avatar this widget renders.
++   *
++   * A remote entity's version has to be supplied by whoever knows it (the peer
++   * publishes it in userAttributes). For the LOCAL user we read Visitor's mtime
++   * live rather than capturing it at initialize time: the local user can change
++   * their own avatar while this widget is mounted, and reading it at render time
++   * is what lets the URL *and* the negative-cache key re-version on the spot.
++   */
++  _avatarVersion() {
++    const v = this.mget('avatar_mtime');
++    if (v != null) return v;
++    const id = this.mget(_a.id);
++    if (id != null && `${id}` === `${Visitor.id}`) return Visitor.get(_a.mtime);
++    return null;
++  }
++
+   /**
+    * 
+    * @param {*} src 
+@@ -63,7 +107,7 @@ class __user_profile extends LetcBox {
+    */
+   img() {
+     const imageType = this.mget(_a.type) || _a.vignette
+-    const src = Visitor.avatar(this.mget(_a.id), imageType)
++    const src = Visitor.avatar(this.mget(_a.id), imageType, this._avatarVersion())
+     return `
+       <img class="${this.fig.family}__icon ${this.fig.family}__picture picture" data-flow="x" src="${src}">
+     `
+@@ -168,8 +212,20 @@ class __user_profile extends LetcBox {
+    * 
+    */
+   loadImage() {
++    // Only reachable for a `strict` caller (initialize resolves everyone else to
++    // Visitor.id): the entity is known to be someone specific but its id has not
++    // arrived yet. Show initials and stop — Visitor.avatar() substitutes the
++    // LOCAL user's id when it gets none, so requesting here would render the
++    // VIEWER's own avatar in a peer's slot. Do not memoize: this is a pending
++    // state, not a missing avatar, and the caller re-renders once the id lands.
++    if (this.mget(_a.id) == null) {
++      this.el.dataset.default = 1;
++      this._show('i');
++      return;
++    }
++
+     // Optimization : prevent reload when marked as error
+-    if (__cache[this.mget(_a.id)]) {
++    if (__cache[this._avatarKey()]) {
+       this.el.dataset.default = 1;
+       this._show('i');
+       return;
+@@ -186,7 +242,7 @@ class __user_profile extends LetcBox {
+     };
+ 
+     const imageType = this.mget(_a.type) || _a.vignette
+-    img.src = Visitor.avatar(this.mget(_a.id), imageType);
++    img.src = Visitor.avatar(this.mget(_a.id), imageType, this._avatarVersion());
+   }
+ 
+   /**
+@@ -194,7 +250,7 @@ class __user_profile extends LetcBox {
+    * @param {*} e
+     */
+   _onError(e) {
+-    __cache[this.mget(_a.id)] = 1;
++    __cache[this._avatarKey()] = 1;
+     this.el.dataset.default = 1;
+     return this._show('i');
+   }

--- a/src/drumee/builtins/webrtc/endpoint/local/user/skeleton/index.js
+++ b/src/drumee/builtins/webrtc/endpoint/local/user/skeleton/index.js
@@ -30,7 +30,13 @@ const __skl_stream_local = function (_ui_) {
   // produce identical initials + color for the same person on every client.
   const avatar = {
     kind: KIND.profile,
-    id: _ui_.mget('avatar_id') || Visitor.profile().id,
+    // `Visitor.profile().id` is not dependably populated — the rest of the app
+    // uses `Visitor.id` as the canonical local id — and this is the self-view,
+    // so it is unambiguously the local user. Name them explicitly rather than
+    // leaning on a fallback further down the pipeline. No avatar_mtime: the
+    // profile widget reads Visitor's mtime live for the local user, so changing
+    // your own avatar mid-call re-versions this tile immediately.
+    id: _ui_.mget('avatar_id') || _ui_.mget(_a.uid) || Visitor.id,
     type: 'thumb',
     active: 0,
     firstname,

--- a/src/drumee/builtins/webrtc/endpoint/remote/user/index.js
+++ b/src/drumee/builtins/webrtc/endpoint/remote/user/index.js
@@ -12,13 +12,19 @@ class __remote_user extends __stream {
     this.participant = opt.participant;
     const displayName = this.participant.getDisplayName();
     try {
-      const { firstname, lastname, uid, username } = opt
+      const { firstname, lastname, uid, username, avatar_mtime } = opt
       this.mset({
         label: displayName || firstname || username || lastname,
         firstname: firstname || displayName,
         lastname,
         uid,
         username: displayName || username || firstname,
+        // Version of THIS peer's avatar, published in their userAttributes.
+        // Threaded into the KIND.profile spec so the avatar URL is versioned by
+        // its owner instead of by the viewer (see webrtc/room/jitsi
+        // broadcastJoining). Undefined until the property arrives, at which
+        // point onPropertyChanged msets it and re-feeds.
+        avatar_mtime,
       });
     } catch (e) {
 

--- a/src/drumee/builtins/webrtc/endpoint/remote/user/skeleton/index.js
+++ b/src/drumee/builtins/webrtc/endpoint/remote/user/skeleton/index.js
@@ -30,7 +30,19 @@ const __skl_stream_remote = function (_ui_) {
     active: 0,
     className: 'no-online-status',
     firstname,
-    lastname
+    lastname,
+    // Version the avatar URL by ITS OWNER's mtime, not the viewer's. Without
+    // this, a peer who changes their avatar produces a byte-identical URL on
+    // every other client, which then serves the pre-change image from the HTTP
+    // cache no matter how often the tile re-renders.
+    avatar_mtime: _ui_.mget("avatar_mtime"),
+    // This tile always belongs to a specific PEER, so the profile widget must
+    // never fall back to the local user when `uid` is still unknown — that is
+    // what made a joining peer's tile flash the viewer's own avatar. `uid` is
+    // undefined only between USER_JOINED and the userAttributes property
+    // arriving (see _participantAttributes / onPropertyChanged); until then the
+    // tile shows initials, and the property event re-feeds this skeleton.
+    strict: 1,
   };
 
   const topActions = Skeletons.Box.X({

--- a/src/drumee/builtins/webrtc/room/jitsi.js
+++ b/src/drumee/builtins/webrtc/room/jitsi.js
@@ -855,6 +855,13 @@ class __webrtc_room extends __room {
       quota: this.get(_a.quota),
       id: this.room.myUserId(),
       socket_id: Visitor.get(_a.socket_id),
+      // Version of OUR avatar (server bumps entity.mtime via entity_touch on
+      // upload). Peers need it to build a correctly-versioned avatar URL: the
+      // `ts` token in Visitor.avatar() is per-ENTITY, and each client is the
+      // only one that reliably knows its own current value. Without it every
+      // other client keeps requesting the byte-identical URL it already cached
+      // and shows the pre-change avatar.
+      avatar_mtime: Visitor.get(_a.mtime),
       muted,
       mic,
       participant_id: this.room.myUserId()
@@ -987,6 +994,53 @@ class __webrtc_room extends __room {
   notifyParticipantLeft(name) { }
 
   /**
+   * Identity a peer has already published in its `userAttributes` presence
+   * property, for seeding a tile at CREATION time.
+   *
+   * USER_JOINED fires before lib-jitsi-meet processes the presence child nodes
+   * (ChatRoom.onPresence runs processNode only after MUC_MEMBER_JOINED), so for
+   * a peer whose attributes were already in the presence we saw — i.e. everyone
+   * who was in the room before us — the property is readable right here, and
+   * PARTICIPANT_PROPERTY_CHANGED is still to come. For a peer that joins after
+   * us the property is genuinely not set yet and this returns {}; the later
+   * property event fills it in (onPropertyChanged).
+   *
+   * Seeding matters because the tile's avatar is a KIND.profile widget keyed on
+   * `uid`, and Visitor.avatar() falls back to the LOCAL user's id when it gets
+   * no id — so a tile rendered before `uid` is known silently requests the
+   * viewer's OWN avatar for the peer.
+   * @returns {Object}
+   */
+  _participantAttributes(participant) {
+    if (!participant || !_.isFunction(participant.getProperty)) return {};
+    let raw;
+    try {
+      raw = participant.getProperty(_a.userAttributes);
+    } catch (e) {
+      return {};
+    }
+    if (!raw) return {};
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (e) {
+      this.warn("unparsable userAttributes", e);
+      return {};
+    }
+    if (!_.isObject(data)) return {};
+    // Only the identity fields the tile renders from. `id`/`participant_id`/
+    // `socket_id`/`quota` are deliberately excluded: `id` is the model's
+    // collection key and the others are already supplied by the caller.
+    const out = {};
+    for (const k of [
+      _a.uid, _a.firstname, _a.lastname, _a.username, "avatar_mtime", "muted", "mic",
+    ]) {
+      if (data[k] != null) out[k] = data[k];
+    }
+    return out;
+  }
+
+  /**
    * That function is executed when the conference is joined by the remote user
    * this event is triggrered by Jitsi
    */
@@ -1014,7 +1068,11 @@ class __webrtc_room extends __room {
         participant,
         participant_id: id,
         peer: this.peer,
-        quota: this.mget(_a.quota)
+        quota: this.mget(_a.quota),
+        // Seed uid / name / avatar version when the peer already published them
+        // (see _participantAttributes) so the first paint renders THEIR avatar
+        // rather than requesting ours via Visitor.avatar's id fallback.
+        ...this._participantAttributes(participant),
       })
     );
     endpoint = this.__participants.children.last();

--- a/src/drumee/index.web.js
+++ b/src/drumee/index.web.js
@@ -17,6 +17,18 @@
 const STYLE = "color: green; font-weight: bold;"
 let bunldes = new Map();
 
+// "#/desk/billing" — record the destination at the earliest point in the app,
+// before anything can navigate.
+//
+// The router already does this for campaign markers, and that is late enough
+// for them: they ride on the query string, which survives. A hash does not.
+// A signed-out visitor on this link is sent to sign in by a FULL page
+// navigation, and the hash is gone by the time the router of the SECOND
+// document runs — measured on stage, where the capture there saw only
+// "#/welcome/signin". Module scope here runs while the original URL is still
+// the original URL, and sessionStorage outlives the navigation.
+require('libs/billing-deep-link').captureFromUrl();
+
 /**
  * 
  */

--- a/src/drumee/libs/billing-deep-link.js
+++ b/src/drumee/libs/billing-deep-link.js
@@ -58,6 +58,9 @@ function urlWantsBilling() {
     const hash = String(window.location.hash || "");
     return PATH.test(hash) || ARG.test(hash);
   } catch (e) {
+    // Reading location cannot normally throw; if it does, this visit carries
+    // no readable destination and saying so is the only honest answer.
+    console.warn("[billing-deep-link] could not read location", e);
     return false;
   }
 }
@@ -101,7 +104,9 @@ function consume() {
     stored = sessionStorage.getItem(KEY) === "1";
     if (stored) sessionStorage.removeItem(KEY);
   } catch (e) {
-    /* fall through to the url */
+    // Blocked storage. The url is checked below regardless, so a signed-IN
+    // visitor still gets there; only the across-sign-in relay is lost.
+    console.warn("[billing-deep-link] sessionStorage unavailable", e);
   }
   return stored || urlWantsBilling();
 }

--- a/src/drumee/libs/billing-deep-link.js
+++ b/src/drumee/libs/billing-deep-link.js
@@ -1,0 +1,109 @@
+/**
+ * The "open Billing & subscription once I am signed in" intent.
+ *
+ * A shareable link — `#/desk/billing` — that lands on the billing screen
+ * whether or not the recipient has a live session:
+ *
+ *   signed in   the desk consumes the intent on boot and opens the page.
+ *   signed out  the router captures it, the visitor signs in, and the desk
+ *               that mounts afterwards opens the page.
+ *
+ * It exists as a stored intent rather than plain routing because the hash does
+ * not survive the sign-in: the signin plugin replaces it wholesale with
+ * "#/welcome/signin" (see the note on captureCampaignArrival in
+ * router/index.js, which is recorded early for exactly the same reason). By
+ * the time a module could read the URL, the destination is gone.
+ *
+ * sessionStorage only, deliberately. The relay has to outlive the full page
+ * reload that signing in triggers, which it does, and nothing more: a billing
+ * link is read and acted on in one sitting. `hub-deep-link` keeps a dated
+ * localStorage copy as well because a workspace INVITE is finished by signing
+ * UP, and email verification can land the recipient in a different tab — a
+ * journey this link does not have. Dying with the tab is the right lifetime
+ * here; a stale "open billing" surprising someone days later is not.
+ *
+ * Every entry point is defensive about storage itself: private mode and
+ * blocked storage both throw on access, and the honest answer there is "no
+ * intent" rather than a broken boot.
+ */
+
+const KEY = "drumee_billingDeepLink";
+
+/**
+ * Shapes that mean "open billing".
+ *
+ * Two of them, because they survive different things:
+ *
+ *   #/desk/billing    the readable form, for a link opened with a session.
+ *   ...?billing=1     an ARG anywhere in the hash. changeHost does
+ *                     `location.host = host`, which keeps path and hash — so
+ *                     an arg rides across the host switch a signed-in visitor
+ *                     gets sent through, where per-origin storage cannot
+ *                     follow.
+ */
+const PATH = /^#[/@]desk\/billing(?:[/?]|$)/i;
+const ARG = /[?&]billing=1(?:&|$)/i;
+
+/**
+ * Does the CURRENT url ask for the billing screen?
+ *
+ * Reads location.hash directly rather than Visitor.parseModule(): this runs
+ * from the router's initialize, before a module — and therefore before the
+ * Visitor helpers a module relies on — is in play.
+ *
+ * @returns {Boolean}
+ */
+function urlWantsBilling() {
+  try {
+    const hash = String(window.location.hash || "");
+    return PATH.test(hash) || ARG.test(hash);
+  } catch (e) {
+    return false;
+  }
+}
+
+/** Remember that this visit should end on the billing screen. */
+function arm() {
+  try {
+    sessionStorage.setItem(KEY, "1");
+  } catch (e) {
+    // Private mode. The signed-IN case still works — the desk reads the hash
+    // as a fallback — so this only costs the signed-out one.
+    console.warn("[billing-deep-link] sessionStorage unavailable", e);
+  }
+}
+
+/**
+ * Arm from the current url, if it asks for billing. Safe to call on every
+ * load; a url that says nothing leaves any armed intent untouched.
+ *
+ * @returns {Boolean} whether this load carried the link
+ */
+function captureFromUrl() {
+  if (!urlWantsBilling()) return false;
+  arm();
+  return true;
+}
+
+/**
+ * Take the intent, if there is one. Reading CLEARS it — an intent that is
+ * acted on twice would reopen billing over whatever the user did next.
+ *
+ * The url is accepted as a second source so the signed-in case does not
+ * depend on storage at all: there, the hash is still intact by the time the
+ * desk boots.
+ *
+ * @returns {Boolean} true when this boot should open the billing screen
+ */
+function consume() {
+  let stored = false;
+  try {
+    stored = sessionStorage.getItem(KEY) === "1";
+    if (stored) sessionStorage.removeItem(KEY);
+  } catch (e) {
+    /* fall through to the url */
+  }
+  return stored || urlWantsBilling();
+}
+
+module.exports = { arm, consume, captureFromUrl, urlWantsBilling, KEY };

--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -1,6 +1,7 @@
 require("welcome/skin");
 require("builtins/window/confirm/skin");
 const { canUpgradePlan, billingAvailable, needsAdminConsoleUpgrade } = require("libs/billing");
+const billingDeepLink = require("libs/billing-deep-link");
 const { captureUtm, campaignArrival } = require("libs/campaign");
 const hubDeepLink = require("libs/hub-deep-link");
 
@@ -366,6 +367,31 @@ class desk_module extends LetcBox {
     // is picked up by get_env; then open Admin Console (+ Invite via
     // apps-main's own sessionStorage flag).
     this._maybeOpenPromoAdminAfterClaim();
+  }
+
+  /**
+   * "#/desk/billing" — a shareable link that lands on Billing & subscription.
+   *
+   * Called from two places because there are two ways to arrive. Boot covers
+   * the cold load and the return from sign-in (the intent was stored by the
+   * router before the hash was replaced); route() covers clicking the link in
+   * a tab that already has the desk mounted, where nothing re-boots.
+   *
+   * Gated by canUpgradePlan for the same reason the sidebar's own
+   * "upgrade-plan" is: an install with no payment backend, or a member who is
+   * not the org owner, would land on a page that can only dead-end. A link
+   * anyone can forward is exactly the "stray trigger" that gate was written
+   * for, so it is honoured here rather than trusted.
+   *
+   * @returns {Boolean} whether the billing screen was opened
+   */
+  _maybeOpenBillingDeepLink() {
+    if (!billingDeepLink.consume()) return false;
+    if (!canUpgradePlan()) return false;
+    // Don't let desk-state restore pull the screen back to the remembered one.
+    this._restoreInFlight = false;
+    this.openBillingPage();
+    return true;
   }
 
   /**
@@ -1867,6 +1893,10 @@ class desk_module extends LetcBox {
     // is a no-op unless a workspace is actually armed, and it hides itself while
     // either flow is on screen — see _showInvitedWorkspaceLoader.
     this._showInvitedWorkspaceLoader();
+    // Before the two full-screen flows: the billing link is an explicit
+    // destination the visitor asked for, and letting the reward flow or the
+    // LAUNCH30 offer land on top of it would bury it.
+    this._maybeOpenBillingDeepLink();
     return this._maybeStartRewardFlow()
       .then(() => this._maybeShowPromoLaunch30("home", { defer: true }))
       .then(() => this._waitForHomePopups())
@@ -1975,6 +2005,12 @@ class desk_module extends LetcBox {
     if (args.hasOwnProperty("wm") && window.Wm) {
       return window.Wm.route();
     }
+    // The billing link clicked while the desk is already UP: only hashchange
+    // fires, home has long since settled, and nothing is about to render over
+    // the screen — so open it here and now. On a cold load this stands down
+    // and _afterHomeSettled does it instead, because opening before
+    // loadDefault() only gets Home painted on top (seen on stage).
+    if (this._homeSettledDone && this._maybeOpenBillingDeepLink()) return;
     this._pending = { available: false };
     // The server-side profile.onboarded flag is authoritative: a user who has
     // completed onboarding (persisted via onboarding.update_profile -> onboarded=1)

--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -346,14 +346,21 @@ class desk_module extends LetcBox {
     );
     this.feed(require("./skeleton")(this));
     await this.ensurePart("desk-content");
-    // NOTE: keep the restore BEFORE the wrapper-popup await — the current
-    // skeleton has no "wrapper-popup" part, so that promise never resolves
-    // and anything after it is dead code.
     this._restoreDeskState().catch((e) => {
       this._restoreInFlight = false;
       this.warn && this.warn("[Reload] restore failed", e);
     });
-    await this.ensurePart("wrapper-popup");
+    // There used to be an `await this.ensurePart("wrapper-popup")` here, with
+    // a note warning that the skeleton has no such part so the promise never
+    // resolves. The note was right and the await stayed anyway — which made
+    // BOTH lines below dead code. ensurePart has no timeout (ui-core
+    // collection-view): a part that never renders leaves the promise pending
+    // for the life of the desk.
+    //
+    // So `_e.ready` had never fired, and LAUNCH30's "Start exploring now"
+    // never reached the Admin Console: it sets its flags, reloads, and the
+    // reader below was simply never called. Nothing listens for `_e.ready`
+    // today, so letting it fire is inert; the promo handler is the point.
     this.trigger(_e.ready);
     // LAUNCH30 "Start exploring now" reloads so org_provision's domain move
     // is picked up by get_env; then open Admin Console (+ Invite via
@@ -1694,6 +1701,54 @@ class desk_module extends LetcBox {
   }
 
   /**
+   * How long an account works in Drumee before the LAUNCH30 offer appears.
+   *
+   * Five minutes, measured from the home screen settling. Not a cumulative
+   * across-sessions figure — a plain timer in the session that would otherwise
+   * have shown the popup immediately, which is what "let them use it first"
+   * actually needs. Reload before it fires and the wait restarts; the offer is
+   * unchanged and still waiting, so nothing is lost.
+   */
+  static get PROMO_OFFER_DELAY_MS() {
+    return 5 * 60 * 1000;
+  }
+
+  /**
+   * Arm the LAUNCH30 offer for later. Returns at once.
+   *
+   * Re-armed on every home settle, so the timer is cleared first: two
+   * schedules would fire two launches, and Wm's singleton only dedupes what is
+   * already on screen.
+   *
+   * The state fetched now is reused when it fires. It can only go stale by the
+   * user claiming or dismissing in the meantime, and both of those destroy the
+   * eligibility this timer exists to act on. Duplicate windows are Wm's job —
+   * the launch below carries wm_unique_id + singleton, the same protection the
+   * immediate path has always relied on.
+   */
+  _schedulePromoOffer(surface, state) {
+    clearTimeout(this._promoOfferTimer);
+    this._promoOfferTimer = setTimeout(async () => {
+      if (this.isDestroyed && this.isDestroyed()) return;
+      try {
+        await Kind.waitFor("promo_launch30");
+      } catch (e) {
+        return;
+      }
+      if (this.isDestroyed && this.isDestroyed()) return;
+      Wm.launch({
+        kind: "promo_launch30",
+        surface,
+        state: "offer",
+        position: state.position,
+        campaign_ends_at: state.campaign_ends_at,
+        hub_id: Visitor.id,
+        wm_unique_id: "promo_launch30",
+      }, { explicit: 1, singleton: 1 });
+    }, this.constructor.PROMO_OFFER_DELAY_MS);
+  }
+
+  /**
    * LAUNCH30 — "Start your 1-month Team Plan today". Design doc 2026-07-30.
    * Self-gates on the server (SERVICE.promo.get_state): eligible only on
    * Free, never claimed, not already inside another organisation, and not
@@ -1716,7 +1771,8 @@ class desk_module extends LetcBox {
    *   undefined if a concurrent call was already in flight or the fetch
    *   failed.
    */
-  async _maybeShowPromoLaunch30(surface) {
+  async _maybeShowPromoLaunch30(surface, opt = {}) {
+    const defer = !!opt.defer;
     if (this._promoLaunch30InFlight) return;
     this._promoLaunch30InFlight = true;
     try {
@@ -1728,6 +1784,20 @@ class desk_module extends LetcBox {
       }
       if (!state) return;
       if (state.state === "eligible_unseen") {
+        // The OFFER waits until the account has actually used Drumee for a
+        // while. It used to fire the moment the home screen settled — for a
+        // brand-new account that is the instant the tutorial ends, so the
+        // first thing someone saw after being shown around was a full-screen
+        // pitch, before they had opened a single file. Hold it back and let
+        // them work first (PROMO_OFFER_DELAY_MS).
+        //
+        // Deferred, never awaited: _afterHomeSettled chains the
+        // invited-workspace prompt behind this call, and awaiting a
+        // five-minute timer would hold that prompt for five minutes too.
+        if (defer) {
+          this._schedulePromoOffer(surface, state);
+          return state;
+        }
         try {
           await Kind.waitFor("promo_launch30");
         } catch (e) {
@@ -1798,7 +1868,7 @@ class desk_module extends LetcBox {
     // either flow is on screen — see _showInvitedWorkspaceLoader.
     this._showInvitedWorkspaceLoader();
     return this._maybeStartRewardFlow()
-      .then(() => this._maybeShowPromoLaunch30("home"))
+      .then(() => this._maybeShowPromoLaunch30("home", { defer: true }))
       .then(() => this._waitForHomePopups())
       .then((clear) =>
         clear

--- a/src/drumee/modules/desk/tutorial/index.js
+++ b/src/drumee/modules/desk/tutorial/index.js
@@ -3,6 +3,28 @@ const { workspaceContent } = require("./skeleton/toolkit")
 
 const SVC_OPT = { async: 1 };
 
+// Every step widget is a bare `import()` in seeds.js, so each one is its own
+// webpack chunk with no prefetch hint. Left alone, pressing Next is the moment
+// the chunk is requested: Kind.get() hands back the lazy loader placeholder,
+// which mounts EMPTY, waits on the network, then respawns itself once the module
+// lands (see ui-core letc/kind/loader.js). The user pays a round trip plus a
+// mount-and-rebuild on every step boundary, and the spotlight is left measuring
+// a placeholder while it happens.
+//
+// Kind.waitFor resolves the import and registers the class, after which
+// Kind.get() answers synchronously — no placeholder, no respawn, no fetch. Warm
+// them while step 1 is on screen and being read.
+//
+// Step 1 (tutorial_workspace), the spotlight and media_grid are all pulled in by
+// the shell itself, so they are already on their way and are not listed here.
+const PRELOAD_KINDS = [
+  'tutorial_folder',
+  'tutorial_meeting',
+  'tutorial_task',
+  'tutorial_share',
+  'tutorial_migrate',
+];
+
 class tutorial_main extends LetcBox {
 
   initialize(opt = {}) {
@@ -45,6 +67,22 @@ class tutorial_main extends LetcBox {
 
   onDomRefresh() {
     this.feed(require('./skeleton')(this));
+    this._preloadSteps();
+  }
+
+  /**
+   * Pull the remaining step widgets down in the background so that pressing
+   * Next renders from memory rather than from the network. Fire and forget: a
+   * warm-up that fails costs nothing, because the step still loads on demand
+   * exactly as it does today.
+   */
+  _preloadSteps() {
+    if (typeof Kind === 'undefined' || !_.isFunction(Kind.waitFor)) return;
+    for (const kind of PRELOAD_KINDS) {
+      Promise.resolve(Kind.waitFor(kind)).catch((e) => {
+        this.warn && this.warn(`[tutorial] could not preload ${kind}`, e);
+      });
+    }
   }
 
   /**

--- a/src/drumee/modules/desk/tutorial/spotlight/index.js
+++ b/src/drumee/modules/desk/tutorial/spotlight/index.js
@@ -1,21 +1,37 @@
 require('./skin');
 const { tooltipBadge } = require('../skeleton/toolkit');
-const { getElStablePosition } = require('@drumee/ui-essentials');
 
 const GAP = 12;
 const MIN_RADIUS = 120;
 const RADIUS_PADDING = 40;
-const STABLE_MAX_TRIES = 10;
+// One frame per sample, so this is also the wall-clock ceiling in frames
+// (~330ms at 60Hz) — the same ceiling the two-RAF version had at half the
+// sample count.
+const STABLE_MAX_TRIES = 20;
 
-// Wait until the element's measured size stops changing across two RAFs.
-// Covers async children (e.g. media_grid icon) that resize the target after
-// it first lands in the DOM — without which the very first focus measures
+function nextFrameRect(el) {
+  return new Promise((resolve) =>
+    requestAnimationFrame(() => resolve(el.getBoundingClientRect())),
+  );
+}
+
+// Wait until the element's measured size stops changing between consecutive
+// frames. Covers async children (e.g. media_grid icon) that resize the target
+// after it first lands in the DOM — without which the very first focus measures
 // a collapsed rect and the tooltip lands off-screen.
+//
+// Sampled once per frame, seeded from a free synchronous read. It used to call
+// getElStablePosition (two RAFs) twice, so an element that had ALREADY settled —
+// which is every screen change after the first, the common case by far — still
+// cost four frames to confirm, and focus() paid that twice when a screen passes
+// an anchor. Measured 118ms per screen change; one frame confirms the same
+// thing. Per-frame sampling also spots a late resize a frame sooner than
+// per-two-frames did, so the case this exists for got quicker too.
 async function waitForStableRect(el) {
-  let prev = await getElStablePosition(el);
+  let prev = el.getBoundingClientRect();
   for (let i = 0; i < STABLE_MAX_TRIES; i++) {
-    const next = await getElStablePosition(el);
-    if (next.width === prev.width && next.height === prev.height && next.width > 0) {
+    const next = await nextFrameRect(el);
+    if (next.width > 0 && next.width === prev.width && next.height === prev.height) {
       return next;
     }
     prev = next;
@@ -84,7 +100,17 @@ class __tutorial_spotlight extends LetcBox {
     if (!target) return this.clear();
     const el = elementOf(target);
     if (!el || typeof el.getBoundingClientRect !== 'function') return;
-    const rect = await waitForStableRect(el);
+
+    // The target rect, the anchor rect and the callout part do not depend on
+    // one another, so they are resolved together. Awaiting them one after the
+    // other put two full settle waits on the critical path of every screen that
+    // passes an anchor, for no reason other than the order they were written in.
+    const anchorEl = anchor ? elementOf(anchor) : null;
+    const [rect, measuredAnchor, callout] = await Promise.all([
+      waitForStableRect(el),
+      anchorEl && anchorEl !== el ? waitForStableRect(anchorEl) : null,
+      this.ensurePart('callout'),
+    ]);
     if (!rect.width || !rect.height) return;
 
     const cx = rect.left + rect.width / 2;
@@ -95,19 +121,15 @@ class __tutorial_spotlight extends LetcBox {
     this.el.style.setProperty('--spot-radius', `${r}px`);
     this.setState(1);
 
-    const callout = await this.ensurePart('callout');
     if (!tooltip) {
       callout.feed(null);
       return;
     }
-    const anchorEl = anchor ? elementOf(anchor) : null;
-    const anchorRect = anchorEl && anchorEl !== el
-      ? await waitForStableRect(anchorEl)
-      : rect;
+    const anchorRect = measuredAnchor && measuredAnchor.width ? measuredAnchor : rect;
     callout.feed(tooltipBadge(owner || this, {
       ...tooltip,
       direction,
-      style: anchorFor(anchorRect.width ? anchorRect : rect, direction),
+      style: anchorFor(anchorRect, direction),
     }));
   }
 

--- a/src/drumee/router/index.js
+++ b/src/drumee/router/index.js
@@ -20,6 +20,7 @@ require("./skin");
 
 const { getModule, moduleName } = require('./modules');
 const { captureCampaignArrival } = require('libs/campaign');
+const billingDeepLink = require('libs/billing-deep-link');
 
 class drumee_router extends LetcBox {
   constructor(...args) {
@@ -46,6 +47,10 @@ class drumee_router extends LetcBox {
     // signin plugin replaces the hash wholesale with "#/welcome/signin", so the
     // markers are gone by the time a module could look for them.
     captureCampaignArrival();
+    // Same reason, same moment: "#/desk/billing" must be remembered before the
+    // signin plugin replaces the hash, or a signed-out visitor loses the
+    // destination the link named.
+    billingDeepLink.captureFromUrl();
     localStorage.main_domain = bootstrap().main_domain;
     this._buffer = [];
     this._loaded = {
@@ -378,6 +383,9 @@ class drumee_router extends LetcBox {
     // the usual case, since the recipient is normally already on a Drumee page.
     // A no-op when the URL carries no campaign params.
     captureCampaignArrival();
+    // Warm arrival for the billing link too — clicking it in a tab that
+    // already runs the app never re-enters initialize().
+    billingDeepLink.captureFromUrl();
     let page = /^\/.*(.+)\.htm?/;
     if (page.test(location.pathname) || page.test(Host.get(_a.homepage))) {
       this.loadBootstrap();


### PR DESCRIPTION
Promotion of `test` → `preview`. Client-side only — no DB payload, no new server call.

## Payload

| Commits | Change |
|---|---|
| `6189896f`, `1a696ce0` (#455) | **LAUNCH30 held until the account has used Drumee** — the offer is armed on a delay instead of firing on first paint. Pure `setTimeout` gating over the existing `promo_launch30` kind; no new service or procedure. |
| `a36ed5d5`, `8b939d4d`, `f0143582` (#456) | **billing deep link** — new `src/drumee/libs/billing-deep-link.js` plus `router/index.js` and `index.web.js`; a url can now open Billing & subscription directly, and says something when the deep-link storage is blocked. URL + storage only. |
| `209e4a62` (#457) | **meeting: a changed avatar reaches every participant** — webrtc local/remote user endpoints and `room/jitsi.js`, plus a new `patches/@drumee+ui-core+1.1.50.patch` covering `letc/user.js` and the profile widget. |
| `d96929a5` (#459) | **tutorial**: cut the wait between steps (`desk/tutorial/`, `spotlight/`). |

## Verification

- `git merge-tree preview test` merges **clean**, and the merged tree is byte-identical to the `test` tree ⇒ `test` is a strict superset.
- `compare/test...preview` reports **0 files** — `preview` holds no unique content; its 2-commit lead is merge commits only.
- `@drumee/ui-core` is `^1.1.50` on both branches and **1.1.50 is the newest published version**, so the new patch filename matches what `npm install` resolves and patch-package applies cleanly.
- **No `.sql` in the payload** — nothing to apply to the prod DB.

## CI

`Lint (bug rules only)`, `Secret scan`, `Dependency audit`, `Deploy` all green on the `test` head. `SonarCloud Code Analysis` is red — **also red on the current `preview` head** (`9bd1220a`), i.e. the standing new-code-coverage condition, not a regression from this payload.

## Follow-up worth doing separately

`@drumee/ui-core` is pinned with a caret and the deploy runs a plain `npm install` (the lockfile is gitignored). When 1.1.51 is published the range floats, `@drumee+ui-core+1.1.50.patch` stops matching, patch-package fails in `postinstall` and the deploy step exits 1. Pinning the version exactly would remove that trap.
