### PR TITLE
fix(grid): repartition after a websocket insert, like every other path does

### DIFF
--- a/src/drumee/builtins/window/utils.js
+++ b/src/drumee/builtins/window/utils.js
@@ -703,6 +703,29 @@ class __window_mfs extends DrumeeMFS {
       } else {
         this.iconsList.append(data);
       }
+      // Re-partition, like every other insert path already does.
+      //
+      // An append is not additive at the DOM level: the CollectionView
+      // re-attaches EVERY child straight into .smart-container, so one new
+      // node tips all of them back out of .workspace-section/.folder-section/
+      // .file-section. Measured on a live desk — a single collection add left
+      // 139 tiles as direct children. .smart-container is a flex COLUMN, so
+      // until they are put back each tile is a full-width row: the grid reads
+      // as one column with N rows.
+      //
+      // Every sibling insert repairs that straight away — desk/wm create-folder
+      // and upload-progress' _revealInLayout both call
+      // _partitionFoldersAndFiles right after their append, folder/index.js
+      // schedules its sort. This path appended and did nothing, leaving the
+      // repair entirely to the rAF-debounced MutationObserver, which is why
+      // the collapse looked random and got worse the more files were uploaded.
+      //
+      // It fires for your OWN uploads, not just a peer's: the bundle uploader
+      // never sends an echoId, so the self-echo guard above can never match.
+      if (this.getViewMode && this.getViewMode() !== _a.row
+        && typeof this._partitionFoldersAndFiles === "function") {
+        this._partitionFoldersAndFiles(this.iconsList);
+      }
     }
     this.syncBounds();
   }


### PR DESCRIPTION
Uploading ~10 files intermittently left the grid as **one column of N rows**. Reported on Home / desk.

### An append is not additive

The CollectionView re-attaches **every** child straight into `.smart-container`, so one new node tips all of them back out of `.workspace-section` / `.folder-section` / `.file-section`. Measured on a live desk: **a single collection add left 139 tiles as direct children.**

`.smart-container` is a flex **column**, so until they are put back, each tile is a full-width row — the grid reads as one column with N rows.

### One path never repaired it

| insert path | repair after append |
|---|---|
| `desk/wm/index.js:371` create-folder | `_partitionFoldersAndFiles(list)` ✅ |
| `upload-progress/index.js:2240` `_revealInLayout` | `tw._partitionFoldersAndFiles(list)` ✅ |
| `folder/index.js:793` folder window | `_scheduleAlphabeticalGridSort(l)` ⚠️ debounced |
| **`utils.js:742` WS `newContent`** | **nothing** ❌ |

That last one is the shared handler the desk/Home uses. It appended and left the repair entirely to the rAF-debounced MutationObserver — which is why the collapse looked random and got worse the more files were uploaded.

It fires for your **own** uploads, not only a peer's: the bundle uploader never sends an `echoId` (`job.js`'s opt is `nid/hub_id/single/notify/replace`, and `uploadFile` only adds `filename/mimetype/filesize/socket_id`), so the self-echo guard at the top of `newContent` can never match.

### Measured on stage — same 10-insert burst through this exact handler

| | after 1st insert | after 10th | immediately | @100ms |
|---|---|---|---|---|
| **without this change** | **139 strays** | **148** | 148 | 0 (self-healed) |
| **with this change** | **0** | **0** | 0 | 0 |

### Correcting an earlier theory

The MutationObserver disconnect/reconnect "gap" blamed by the comments in this file is **not reachable**. `disconnect() → _doPartition() → observe()` is one unbroken synchronous stretch of an rAF callback, and single-threaded run-to-completion means no other task can execute between two of its statements. That comment describes a mechanism that cannot occur. PR #460, which was built on that premise, is a harmless idempotent safety net but does not address this. This commit fixes the mechanism that can actually happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
