### PR TITLE
fix(billing): an all-plans promo code was refused on Pro

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -2563,7 +2563,7 @@
   "PROMO_CODE_EMAIL_USED": "This email has already used a partner promo code.",
   "PROMO_CODE_ACTIVE_SUB": "Promo codes apply to new paid subscriptions only.",
   "PROMO_CODE_WITH_DEFER": "Promo codes cannot be combined with a deferred billing-cycle switch.",
-  "PROMO_CODE_PLAN": "This promo code applies to Team or Business plans only.",
+  "PROMO_CODE_PLAN": "This promo code applies to paid plans only.",
   "PROMO_CODE_PLAN_ONLY": "This promo code can only be used on the {0} plan.",
   "PROMO_CODE_FAILED": "Could not apply this promo code. Please try again.",
   "PROMO_CODE_APPLIED": "Code {0} applied",

--- a/locale/es.json
+++ b/locale/es.json
@@ -2395,7 +2395,7 @@
   "PROMO_CODE_EMAIL_USED": "Este correo ya ha usado un código promocional de partner.",
   "PROMO_CODE_ACTIVE_SUB": "Los códigos promocionales solo se aplican a nuevas suscripciones de pago.",
   "PROMO_CODE_WITH_DEFER": "Los códigos promocionales no se pueden combinar con un cambio de ciclo diferido.",
-  "PROMO_CODE_PLAN": "Este código promocional solo aplica a los planes Team o Business.",
+  "PROMO_CODE_PLAN": "Este código promocional solo aplica a los planes de pago.",
   "PROMO_CODE_PLAN_ONLY": "Este código promocional solo se puede usar en el plan {0}.",
   "PROMO_CODE_FAILED": "No se pudo aplicar este código promocional. Inténtalo de nuevo.",
   "PROMO_CODE_APPLIED": "Código {0} aplicado",

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -2395,7 +2395,7 @@
   "PROMO_CODE_EMAIL_USED": "Cet e-mail a déjà utilisé un code promo partenaire.",
   "PROMO_CODE_ACTIVE_SUB": "Les codes promo s'appliquent uniquement aux nouveaux abonnements payants.",
   "PROMO_CODE_WITH_DEFER": "Les codes promo ne peuvent pas être combinés avec un changement de cycle différé.",
-  "PROMO_CODE_PLAN": "Ce code promo s'applique uniquement aux plans Team ou Business.",
+  "PROMO_CODE_PLAN": "Ce code promo s'applique uniquement aux forfaits payants.",
   "PROMO_CODE_PLAN_ONLY": "Ce code promo est utilisable uniquement sur le forfait {0}.",
   "PROMO_CODE_FAILED": "Impossible d'appliquer ce code promo. Veuillez réessayer.",
   "PROMO_CODE_APPLIED": "Code {0} appliqué",

--- a/locale/km.json
+++ b/locale/km.json
@@ -2394,7 +2394,7 @@
   "PROMO_CODE_EMAIL_USED": "This email has already used a partner promo code.",
   "PROMO_CODE_ACTIVE_SUB": "Promo codes apply to new paid subscriptions only.",
   "PROMO_CODE_WITH_DEFER": "Promo codes cannot be combined with a deferred billing-cycle switch.",
-  "PROMO_CODE_PLAN": "This promo code applies to Team or Business plans only.",
+  "PROMO_CODE_PLAN": "កូដប្រូម៉ូសិននេះអាចប្រើបានតែលើគម្រោងបង់ប្រាក់ប៉ុណ្ណោះ។",
   "PROMO_CODE_PLAN_ONLY": "កូដប្រូម៉ូសិននេះអាចប្រើបានតែលើគម្រោង {0} ប៉ុណ្ណោះ។",
   "PROMO_CODE_FAILED": "Could not apply this promo code. Please try again.",
   "PROMO_CODE_APPLIED": "បានអនុវត្តលេខកូដ {0}",

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -2394,7 +2394,7 @@
   "PROMO_CODE_EMAIL_USED": "This email has already used a partner promo code.",
   "PROMO_CODE_ACTIVE_SUB": "Promo codes apply to new paid subscriptions only.",
   "PROMO_CODE_WITH_DEFER": "Promo codes cannot be combined with a deferred billing-cycle switch.",
-  "PROMO_CODE_PLAN": "This promo code applies to Team or Business plans only.",
+  "PROMO_CODE_PLAN": "Этот промокод действует только для платных тарифов.",
   "PROMO_CODE_PLAN_ONLY": "Этот промокод действует только для тарифа {0}.",
   "PROMO_CODE_FAILED": "Could not apply this promo code. Please try again.",
   "PROMO_CODE_APPLIED": "Код {0} применён",

--- a/locale/zh.json
+++ b/locale/zh.json
@@ -2394,7 +2394,7 @@
   "PROMO_CODE_EMAIL_USED": "This email has already used a partner promo code.",
   "PROMO_CODE_ACTIVE_SUB": "Promo codes apply to new paid subscriptions only.",
   "PROMO_CODE_WITH_DEFER": "Promo codes cannot be combined with a deferred billing-cycle switch.",
-  "PROMO_CODE_PLAN": "This promo code applies to Team or Business plans only.",
+  "PROMO_CODE_PLAN": "此优惠码仅可用于付费方案。",
   "PROMO_CODE_PLAN_ONLY": "此优惠码仅可用于 {0} 方案。",
   "PROMO_CODE_FAILED": "Could not apply this promo code. Please try again.",
   "PROMO_CODE_APPLIED": "已应用代码 {0}",

--- a/src/drumee/builtins/widget/settings/account/billing/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/index.js
@@ -287,7 +287,13 @@ class settings_billing extends LetcBox {
   // still async-false, and clicking it during that window silently no-opped.
   _isPaidByQuota() {
     const plan = String(((Visitor.quota && Visitor.quota()) || {}).plan || "").toLowerCase();
-    return /^(team|business|sovereign|enterprise)$/.test(plan);
+    // `pro` belongs here — it is a paid tier. It was missing for the same
+    // reason the promo gate above was: the plan was revived on 2026-08-03,
+    // after this list was written. The skeleton's own fallback for this
+    // method already counted it (skeleton/index.js paidByQuota), so the two
+    // disagreed and a Pro subscriber's "Cancel plan" banner stayed inert for
+    // the round-trip this method exists to cover.
+    return /^(pro|team|business|sovereign|enterprise)$/.test(plan);
   }
 
   /**
@@ -1197,14 +1203,14 @@ class settings_billing extends LetcBox {
           || "Promo codes cannot be combined with a deferred billing-cycle switch.";
       case "COUPON_PLAN_UNSUPPORTED":
         return LOCALE.PROMO_CODE_PLAN
-          || "This promo code applies to Team or Business plans only.";
+          || "This promo code applies to paid plans only.";
       // Code is targeted at ONE plan and this is not it. Naming that plan
       // turns a dead end into an instruction — the user can switch to it.
       case "COUPON_PLAN_MISMATCH": {
         const scope = String(data && data.plan_scope || "").trim();
         if (!scope) {
           return LOCALE.PROMO_CODE_PLAN
-            || "This promo code does not apply to the selected plan.";
+            || "This promo code applies to paid plans only.";
         }
         const named = scope.charAt(0).toUpperCase() + scope.slice(1);
         return (LOCALE.PROMO_CODE_PLAN_ONLY
@@ -1255,10 +1261,20 @@ class settings_billing extends LetcBox {
       return;
     }
 
+    // Couponable plans, mirroring the server (payment.preview_coupon and
+    // payment.checkout both test /^(pro|team|business)$/). Pro was left out
+    // when it was revived on 2026-08-03: the server and the procs were
+    // updated for it, this gate was not, so an all-plans code typed on a Pro
+    // checkout was refused HERE and never reached preview_coupon.
+    //
+    // This list is about which plans can be BOUGHT with a code at all — the
+    // per-code targeting is plan_scope, and only the server may judge it
+    // (mkt_coupon_validate/reserve/redeem all enforce it). Answering
+    // COUPON_PLAN_MISMATCH locally would guess at data we do not hold.
     const plan = checkout.selectedPlan || "team";
-    if (!/^(team|business)$/.test(plan)) {
+    if (!/^(pro|team|business)$/.test(plan)) {
       checkout.promoError = LOCALE.PROMO_CODE_PLAN
-        || "This promo code applies to Team or Business plans only.";
+        || "This promo code applies to paid plans only.";
       this.updateRightPanel();
       return;
     }


### PR DESCRIPTION
Creating a promo code with **plan scope "all"** and typing it on a **Pro** checkout answered *"This promo code applies to Team or Business plans only."* and never reached the server.

### The refusal was entirely client-side

`_applyPromoCode` still tested `/^(team|business)$/` — written before Pro was revived on 2026-08-03. Everything behind that gate already handled Pro. Verified layer by layer rather than assumed:

| Layer | Check | Result |
|---|---|---|
| **schemas** (stage, executed) | `CALL mkt_coupon_validate('T_FREE2M', …, 'pro', 86400)` | returns the coupon row ✅ |
| **schemas** — negative control | same call with a `plan_scope='team'` code | `COUPON_PLAN_MISMATCH` ✅ (targeting still enforced) |
| **server** | `payment.preview_coupon` (payment.js:184), `payment.checkout` (:466) | both `/^(pro\|team\|business)$/` ✅ |
| **prod DB** (executed) | `mkt_coupon.plan_scope` column | present ✅ |
| **prod DB** | `mkt_coupon_redeem` carries the 2026-08-03 catalog `entity_type` fix | present ✅ |
| **prod DB** | `yp.plan` rows for `pro` | 4 rows, active, with Stripe prices ✅ |

**The suspected missing prod schema is not the cause** — that deployment is complete. The FE gate was the only thing refusing Pro.

### What changed

- `_applyPromoCode` now mirrors the server: `/^(pro|team|business)$/`. This list only decides which plans may carry a code **at all**; per-code targeting is `plan_scope` and only the server may judge it (`mkt_coupon_validate` / `_reserve` / `_redeem` all enforce it), so the client must not narrow it further — answering `COUPON_PLAN_MISMATCH` locally would guess at data it does not hold.
- **Second instance of the same omission, same file:** `_isPaidByQuota` left Pro out of the paid tiers, so a Pro subscriber's "Cancel plan" banner stayed inert for exactly the round-trip that method was added (2026-07-22) to cover. The skeleton's own fallback for this method already counted Pro, so the two disagreed — that disagreement is what surfaced it.
- `PROMO_CODE_PLAN`: *"Team or Business plans only"* → *"paid plans only"*, mirrored across all six locales using each one's existing wording from the sibling key `PROMO_CODE_PLAN_ONLY` (优惠码/方案, промокод/тариф, កូដប្រូម៉ូសិន/គម្រោង).

### Verification status — read this before merging

Proven: the DB behaviour above (executed live, both directions), the server source gates, the prod schema state, and that the rebuilt stage bundle carries the new gate.

**Not** proven: a click-through of the Pro checkout → type code → Apply. The Chrome DevTools MCP deadlocked on a stale browser profile partway through (two server instances holding the same `userDataDir`) and could not be recovered without restarting the session. The change is a regex widening on a path whose every downstream layer is verified above, but the button itself was not clicked — worth one manual pass on stage before this reaches users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
