### PR TITLE
fix(secure-share): track the access list by email again, revoke column hidden

### DIFF
--- a/src/drumee/builtins/window/secure-share/index.js
+++ b/src/drumee/builtins/window/secure-share/index.js
@@ -568,34 +568,26 @@ class __window_secure_share extends mfsInteract {
     if (open) this._loadAccessEvents();
   }
 
-  // The access table is keyed on LINKS, with each link's visits counted next to
-  // it — so it needs both lists: the links themselves (which carries the ones
-  // nobody has opened yet, and each link's status) and the visit log to count and
-  // date them. Fetched together; a failure of either leaves the other usable.
+  // The table is keyed on the ACCESS EVENTS themselves — one row per visit — so
+  // the visit log is the only list it needs. (It was briefly keyed on links, which
+  // additionally fetched secure_share.list for their status and never-opened rows;
+  // see the archive memory before reinstating that.)
   async _loadAccessEvents() {
     if (!this._accessEvents) return;
     const nid    = this.mget(_a.nid);
     const hub_id = this.mget(_a.hub_id);
     const events_skl = require('./skeleton/access-events');
-
-    const [links, events] = await Promise.all([
-      this.postService(SERVICE.secure_share.list, { nid, hub_id }).catch(() => []),
-      this.postService(SERVICE.secure_share.list_access_events, { nid, hub_id }).catch(() => []),
-    ]);
-    const list = Array.isArray(links) ? links : [];
-
-    // Group the visits under the link they came through.
-    const byToken = {};
-    if (Array.isArray(events)) {
-      for (const ev of events) {
-        if (!ev || !ev.token_id) continue;
-        (byToken[ev.token_id] = byToken[ev.token_id] || []).push(ev);
-      }
+    let list = [];
+    try {
+      const rows = await this.postService(SERVICE.secure_share.list_access_events, { nid, hub_id });
+      if (Array.isArray(rows)) list = rows;
+    } catch (e) {
+      list = [];
     }
-
-    this._accessEvents.feed(events_skl(this, list, byToken));
-    // Count in the toggle header is now the number of links, matching the rows
-    // shown. Empty/error → plain label (no "(0)"), like Shared-links.
+    this._accessEvents.feed(events_skl(this, list));
+    // Reflect the access count in the toggle header (e.g. "View access list (12)"),
+    // mirroring the Shared-links label. Count = rows shown = total access events.
+    // Empty/error → plain label (no "(0)"), like Shared-links.
     if (this._accessEventsLabel) {
       this._accessEventsLabel.el.textContent = list.length
         ? `${LOCALE.SECURE_SHARE_VIEW_ACCESS_LIST} (${list.length})`

--- a/src/drumee/builtins/window/secure-share/skeleton/access-events.js
+++ b/src/drumee/builtins/window/secure-share/skeleton/access-events.js
@@ -1,137 +1,103 @@
-// Access table of the v2 sharing panel — one row per LINK.
+// Per-access-event table for the v2 "View access list" (Figma 2.2.3):
+// avatar · Email · Access Time · Duration · ⊖. Fed by
+// SERVICE.secure_share.list_access_events — one row per visit, so the same
+// person appears once per open.
 //
-// It used to be one row per access EVENT: the same person appeared once per
-// visit, anonymous hits showed as unactionable "Public" rows, and the ⊖ on a row
-// revoked the whole LINK that visit came through — which other rows were often
-// sharing. Acting on one row silently cut other people while the row itself
-// stayed on screen, so a revoke that had in fact worked read as a no-op.
-//
-// A link is what the sender creates and what revoking acts on, so the link is
-// the row, with its visits counted in the Opens column. Links nobody has opened
-// are listed too — with the event list they had no row at all, so once the
-// shared-links section was hidden they could not be revoked from anywhere.
-//
-// Who opened a given link (and revoking one of them individually) belongs to the
-// per-link popup, which the server already backs via secure_share.revoke_email.
+// This is the ORIGINAL email-keyed log, restored on Lexis's request. It briefly
+// carried one row per LINK instead (Shared with / Last opened / Opens), which
+// matched what revoking actually does — see the archive memory for why that was
+// built and how to bring it back; the SCSS for both layouts is still in skin/.
 
-// Who a link admits, from the v2 allowed_emails array; legacy rows fall back to
-// recipient_email. A "@domain" entry admits anyone at that domain.
+// The Action column is hidden for now: Lexis is redesigning where the revoke
+// affordance lives. The column is kept behind this flag — with its header cell,
+// so header and rows can never disagree on the column count — and the ⊖ is wired
+// to the panel's live revoke path, so flipping this to `true` restores a working
+// button rather than a dead one.
 //
-// A link that requires an email WITHOUT an allow-list ("require email to view",
-// any address) has an empty allowed_emails — exactly like a genuinely public
-// link — so it used to fall through and read "Public link" even after someone
-// had identified themselves. `opens` carries the visits, whose recipient_email
-// is the address the viewer actually typed, so such a link is labelled with its
-// real audience instead.
-//
-// The openers are used ONLY when the link requires an email. On a public link a
-// signed-in viewer is also recorded with their account address (dmz.js falls
-// back to it), and showing that would wrongly present an open link as belonging
-// to one person.
-const __linkLabel = function(row, opens) {
-  let emails = null;
-  try {
-    emails = row.allowed_emails
-      ? (typeof row.allowed_emails === 'string' ? JSON.parse(row.allowed_emails) : row.allowed_emails)
-      : null;
-  } catch (e) {
-    emails = null;
-  }
-  if (Array.isArray(emails) && emails.length) {
-    const pretty = emails
-      .map(e => String(e || '').trim())
-      .filter(Boolean)
-      .map(e => e.startsWith('@') ? `${LOCALE.SECURE_SHARE_ANYONE_AT} ${e}` : e);
-    if (!pretty.length)      return LOCALE.SECURE_SHARE_PUBLIC_LINK;
-    if (pretty.length === 1) return pretty[0];
-    return `${pretty[0]} +${pretty.length - 1}`;
-  }
-  if (row.recipient_email) return row.recipient_email;
-  if (row.require_email) {
-    // Deduplicate: the same person re-opening produces several visits.
-    const seen = [];
-    (Array.isArray(opens) ? opens : []).forEach((o) => {
-      const e = String((o && o.recipient_email) || '').trim();
-      if (e && seen.indexOf(e) === -1) seen.push(e);
-    });
-    if (seen.length === 1) return seen[0];
-    if (seen.length > 1)   return `${seen[0]} +${seen.length - 1}`;
-    // Nobody has identified themselves yet — say what the link admits.
-    return LOCALE.SECURE_SHARE_ANY_EMAIL;
-  }
-  return LOCALE.SECURE_SHARE_PUBLIC_LINK;
+// While it is false a created link can only be revoked from the Get-link result
+// row, in the same session (the SHARED LINKS section stays hidden too). That is a
+// deliberate product decision, not an oversight.
+const SHOW_REVOKE_COLUMN = false;
+
+// Compact "2h 10m" / "45m" / "30s" duration from a second count (matches Figma).
+const __fmtDuration = function(secs) {
+  secs = Math.max(0, parseInt(secs, 10) || 0);
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  if (h && m) return `${h}h ${m}m`;
+  if (h)      return `${h}h`;
+  if (m)      return `${m}m`;
+  return `${secs}s`;
 };
 
-const __skl_secure_share_access_events = function(_ui_, links, eventsByToken) {
+const __skl_secure_share_access_events = function(_ui_, rows) {
   const pfx = _ui_.fig.family;
 
   const header = Skeletons.Box.X({
     className : `${pfx}__events-cols`,
     kids      : [
-      Skeletons.Note({ className: `${pfx}__events-col col-email`,    content: LOCALE.SECURE_SHARE_COL_SHARED_WITH }),
-      Skeletons.Note({ className: `${pfx}__events-col col-time`,     content: LOCALE.SECURE_SHARE_COL_LAST_OPENED }),
-      Skeletons.Note({ className: `${pfx}__events-col col-duration`, content: LOCALE.SECURE_SHARE_COL_OPENS }),
-      Skeletons.Note({ className: `${pfx}__events-col col-action`,   content: LOCALE.SECURE_SHARE_COL_ACTION }),
+      Skeletons.Note({ className: `${pfx}__events-col col-email`,    content: LOCALE.EMAIL }),
+      Skeletons.Note({ className: `${pfx}__events-col col-time`,     content: LOCALE.SECURE_SHARE_COL_ACCESS_TIME }),
+      Skeletons.Note({ className: `${pfx}__events-col col-duration`, content: LOCALE.SECURE_SHARE_COL_DURATION }),
+      ...(SHOW_REVOKE_COLUMN
+        ? [Skeletons.Note({ className: `${pfx}__events-col col-action`, content: LOCALE.SECURE_SHARE_COL_ACTION })]
+        : []),
     ]
   });
 
-  if (!Array.isArray(links) || !links.length) {
+  // Public shares are excluded server-side by secure_share_list_access_events
+  // (it returns events only for gated tokens, plus IDENTIFIED opens of a public
+  // link), so every row here is a real secure-share access — render them all, no
+  // client-side visitor filtering.
+  if (!Array.isArray(rows) || !rows.length) {
     return Skeletons.Box.Y({
       className : `${pfx}__events-table`,
       kids      : [
         header,
-        Skeletons.Note({ className: `${pfx}__events-empty`, content: LOCALE.SECURE_SHARE_NO_SHARES })
+        Skeletons.Note({ className: `${pfx}__events-empty`, content: LOCALE.SECURE_SHARE_NO_ACCESS_EVENTS })
       ]
     });
   }
 
-  const rowKids = links.map((row) => {
-    const token = row.id;
-    const opens = (eventsByToken && eventsByToken[token]) || [];
-    // `status` is computed by secure_share_list (active / revoked / expired).
-    const isActive    = row.status === 'active';
-    const statusLabel = row.revoked_at
-      ? LOCALE.SECURE_SHARE_STATUS_REVOKED
-      : LOCALE.SECURE_SHARE_STATUS_EXPIRED;
-
-    // Last open comes from the visit log; last_accessed on the token can predate
-    // the per-visit events, so prefer the events and fall back to the token.
-    const lastSeen = opens.reduce((max, o) => Math.max(max, o.last_seen_at || 0), 0)
-      || row.last_accessed || 0;
-    const timeStr  = lastSeen
-      ? Dayjs.unix(lastSeen).format('MMM D, h:mm A')
-      : LOCALE.SECURE_SHARE_NEVER_ACCESSED;
+  const rowKids = rows.map((r) => {
+    // The server resolves recipient_email from actor_id for signed-in opens of a
+    // link with no email gate, so an unlabelled row really is an unattributable
+    // one.
+    const email   = r.recipient_email || LOCALE.SECURE_SHARE_PUBLIC;
+    const timeStr = r.entered_at ? Dayjs.unix(r.entered_at).format('MMM D, h:mm A') : '';
+    const durStr  = __fmtDuration(r.duration);
 
     return Skeletons.Box.X({
       className : `${pfx}__events-row`,
-      dataset   : { token },
       kids      : [
         Skeletons.Box.X({
           className : `${pfx}__events-cell col-email`,
           kids      : [
-            Skeletons.Image.Svg({ className: `${pfx}__events-link-icon`, ico: 'apps-link-simple' }),
-            Skeletons.Note({ className: `${pfx}__events-email`, content: __linkLabel(row, opens) })
+            Skeletons.Avatar('default', `${pfx}__events-avatar`, email),
+            Skeletons.Note({ className: `${pfx}__events-email`, content: email })
           ]
         }),
         Skeletons.Note({ className: `${pfx}__events-cell col-time`,     content: timeStr }),
-        Skeletons.Note({ className: `${pfx}__events-cell col-duration`, content: `${opens.length}` }),
-        Skeletons.Box.X({
-          className : `${pfx}__events-cell col-action`,
-          // Only a live link can be revoked; a revoked or expired one reports its
-          // state instead of offering an action that has already been taken.
-          kids      : isActive ? [
-            Skeletons.Box.X({
-              className : `${pfx}__events-revoke-btn button`,
-              service   : 'revoke-secure-share',
-              token     : token,
-              uiHandler : [_ui_],
-              kidsOpt   : { active: 0 },
-              kids      : [Skeletons.Note({ content: LOCALE.SECURE_SHARE_REVOKE })]
-            })
-          ] : [
-            Skeletons.Note({ className: `${pfx}__events-revoked`, content: statusLabel })
-          ]
-        })
+        Skeletons.Note({ className: `${pfx}__events-cell col-duration`, content: durStr }),
+        ...(SHOW_REVOKE_COLUMN ? [
+          Skeletons.Box.X({
+            className : `${pfx}__events-cell col-action`,
+            // ⊖ revokes the share LINK (token) this visit came through, cutting
+            // everyone who used it — same effect, and the same 'revoke-secure-share'
+            // handler, as the Get-link row's Revoke. token_id from the access-event
+            // SP IS the share id secure_share_revoke matches on.
+            kids      : r.token_id ? [
+              Skeletons.Button.Svg({
+                ico       : 'ban',
+                className : `${pfx}__events-revoke`,
+                service   : 'revoke-secure-share',
+                tooltips  : LOCALE.SECURE_SHARE_REVOKE_RECIPIENT,
+                token     : r.token_id,
+                uiHandler : [_ui_],
+              })
+            ] : []
+          })
+        ] : []),
       ]
     });
   });

--- a/src/drumee/builtins/window/secure-share/skin/index.scss
+++ b/src/drumee/builtins/window/secure-share/skin/index.scss
@@ -878,19 +878,33 @@
     white-space: nowrap;
   }
 
-  // column widths shared by header + rows
+  // Column widths, shared by header + rows so the two can never drift apart.
+  //
+  // The three data columns are PROPORTIONAL, in the Figma table's own ratio
+  // (Email 44 / Access Time 34 / Duration 22 of the row once the action column is
+  // out). Previously only Email was elastic while Access Time and Duration sat at
+  // fixed 90px / 50px, so on the 450px panel Email took 63% of the row and the
+  // other two stayed cramped no matter how much space there was — and they could
+  // not grow at all if the panel ever got wider.
+  //
+  // flex-basis 0 makes the grow factors the sole allocator (the content's natural
+  // width stops skewing the split). The min-widths keep Access Time and Duration
+  // legible when the panel is narrow; Email is the only shrinkable column
+  // (min-width 0), so it absorbs the squeeze and ellipsises, which is the right
+  // trade — an address truncates readably, "Jun 12, 10:23 AM" does not.
   &__events-col.col-email,
-  &__events-cell.col-email    { flex: 1; min-width: 0; gap: var(--spacer-2); }
+  &__events-cell.col-email    { flex: 44 1 0; min-width: 0; gap: var(--spacer-2); }
   &__events-col.col-time,
-  &__events-cell.col-time     { width: 90px; flex-shrink: 0; }
+  &__events-cell.col-time     { flex: 34 0 0; min-width: 76px; }
   &__events-col.col-duration,
-  &__events-cell.col-duration { width: 50px; flex-shrink: 0; }
-  // overflow:visible so the revoke button's hover tooltip can escape the cell.
-  // 64px (was 30px): wide enough for the "Revoked" state label as well as the
-  // ⊖ glyph, so neither clips. Header and rows share this rule, so the columns
-  // stay aligned; the email column is flex:1 and simply gives up the 34px.
+  &__events-cell.col-duration { flex: 22 0 0; min-width: 48px; }
+  // Action stays a FIXED 64px and out of the proportional split: it holds either
+  // the ⊖ glyph or the "Revoked" label, both fixed-size, and scaling it would only
+  // add dead space. 64px (was 30px) is what the label needs so neither state
+  // clips. overflow:visible lets the revoke button's hover tooltip escape the cell.
+  // Currently hidden — see SHOW_REVOKE_COLUMN in skeleton/access-events.js.
   &__events-col.col-action,
-  &__events-cell.col-action   { width: 64px; flex-shrink: 0; justify-content: flex-end; text-align: right; overflow: visible; }
+  &__events-cell.col-action   { flex: 0 0 64px; justify-content: flex-end; text-align: right; overflow: visible; }
 
   // Figma: avatar 16px, round.
   &__events-avatar {


### PR DESCRIPTION
Restores the secure-share **access list** to the original per-email visit log, and hides the revoke column, per Lexis.

Verified by Duy on drumee.in. The whole `secure-share/` dir on this branch is **byte-identical to `origin/test`** (the build he checked).

### What changes

**1. Access list tracks emails again** — `Email | Access Time | Duration`, avatar per row, **one row per open**, so a repeat visitor appears once per visit (Figma 2.2.3). It had been re-keyed on LINKS (`Shared with | Last opened | Opens`), which matched what revoking actually does but is not the tracking Lexis wants.

**2. The Action column is hidden** behind `SHOW_REVOKE_COLUMN = false` while Lexis redesigns where the revoke affordance belongs. The column is kept whole behind the flag — header cell included, so header and rows can never disagree on the column count — so re-enabling it later is a one-line flip.

> The hidden button was re-pointed from `revoke-access-recipient` to **`revoke-secure-share`**. `revoke-access-recipient` no longer has an `onUiEvent` case (it was deleted when the revoke paths were unified into `_revokeShare`), so restoring the old skeleton verbatim would have wired a **silently dead control** the moment anyone flipped the flag.

**3. Columns are proportional** — previously only Email was elastic while Access Time / Duration sat at fixed `90px` / `50px`, so on the 450px panel Email took 63% of the row and the other two stayed cramped no matter how much space there was. All three now share the row in the Figma table's own ratio (44 / 34 / 22): at 378px Email goes 238→166px, Access Time 90→128px, Duration 50→83px, and every column scales with the panel.

### Scope

**UI only — no schema, no server, no locale, no SCSS token, no DB action.** Exactly 3 files, all under `builtins/window/secure-share/`.

- `secure_share_list_access_events` already returns `recipient_email`, `entered_at` and `duration` — unchanged, nothing to apply to any DB.
- All six locales already carry the restored keys (`EMAIL`, `SECURE_SHARE_COL_ACCESS_TIME`, `COL_DURATION`, `COL_ACTION`, `SECURE_SHARE_PUBLIC`, `NO_ACCESS_EVENTS`). The link-keyed keys this replaces were **English-only**, so this also closes a 5-language gap.
- `_loadAccessEvents` is back to the single `list_access_events` fetch and is **byte-identical (code, comments aside) to the version that ran on prod for weeks**.
- Deliberately untouched: `skeleton/main.js` (SHARED LINKS stays hidden), `skeleton/share-row.js`, and the Get-link row's own Revoke button.

### Known consequence, deliberate

With the Action column and the SHARED LINKS section both hidden, an **already-created link can only be revoked from the Get-link result row, in the same session**. Duy's explicit decision; the per-recipient revoke backend (`secure_share.revoke_email` + the `denied_emails` deny list) is already shipped and applied to the prod DB, and is waiting on Lexis's popup design.

### Verification

- Standalone harness **55/55** with **4 negative controls** that all trip (header-only gate, rows-only gate, dead-handler wiring, flag left true) — ui-team has no test runner. Covers both flag states, degenerate input, and malformed durations.
- Column widths checked with a flexbox solver (basis → grow → min-violation freeze) at 14 row widths in both the 3- and 4-column states: exact fill, min-widths honoured, monotonic, header width == row width at every size.
- Bytecode/CSS verified on the deployed drumee.in build: old skeleton markers (`eventsByToken`, `PUBLIC_LINK`, `ANYONE_AT`, `ANY_EMAIL`) all gone, `SECURE_SHARE_REVOKE_RECIPIENT` absent (the gated button is compiled out, not shipped as a runtime branch), and the new proportional rules live on both the header and row selectors.
- Merge into `preview` simulated: conflict-free, and the merged tree's `secure-share/` dir is exactly this branch's content.

### CI note

`check-source` fails **by design** on a non-`test` head — that is the guard this hotfix-branch flow always trips. Opened as an isolated branch off `preview` rather than a whole-branch `test → preview` PR so it does not sweep #469 (`Fix/document get info`), which is not mine to promote.
