### PR TITLE
fix(gdrive): closing the migrate popup no longer closes the folder window

### DIFF
--- a/src/drumee/builtins/widget/migrate-gdrive-popup/index.js
+++ b/src/drumee/builtins/widget/migrate-gdrive-popup/index.js
@@ -791,7 +791,7 @@ class __migrate_gdrive_popup extends LetcBox {
     // took the folder window down with it (reported live). When we share the
     // parent with anyone else, remove only ourselves.
     const p = this.parent;
-    const soleChild = !!(p && p.children && p.children.length === 1);
+    const soleChild = p?.children?.length === 1;
     if (soleChild && _.isFunction(p.clear)) p.clear();
     else if (_.isFunction(this.goodbye)) this.goodbye();
     else this.softDestroy();

--- a/src/drumee/builtins/widget/migrate-gdrive-popup/index.js
+++ b/src/drumee/builtins/widget/migrate-gdrive-popup/index.js
@@ -784,7 +784,16 @@ class __migrate_gdrive_popup extends LetcBox {
       this.postService('google_drive.ack_result', { hub_id: Visitor.id, job_id: this._jobId })
         .catch(() => {});
     }
-    if (this.parent && _.isFunction(this.parent.clear)) this.parent.clear();
+    // parent.clear() is only right when the parent is a single-widget modal
+    // host (clearing resets its data-state — the stuck-overlay rule). Under
+    // Wm.launch the parent is the shared windowsLayer: clear() there wipes
+    // EVERY open window — closing this popup after a folder-window import
+    // took the folder window down with it (reported live). When we share the
+    // parent with anyone else, remove only ourselves.
+    const p = this.parent;
+    const soleChild = !!(p && p.children && p.children.length === 1);
+    if (soleChild && _.isFunction(p.clear)) p.clear();
+    else if (_.isFunction(this.goodbye)) this.goodbye();
     else this.softDestroy();
   }
 

--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -1377,15 +1377,24 @@ class __window_folder extends mfsInteract {
         // The window title tracks navigation the same way the nid does
         // (refreshBreadcrumbsUI msets hub_name to the current node's name).
         const destName = this.mget(_a.hub_name) || this.mget(_a.filename) || "";
+        const destHub = this.mget(_a.hub_id) || Visitor.id;
+        const destNidFinal = destNid || Visitor.get(_a.home_id);
         return Kind.waitFor("migrate_gdrive_popup").then(() => {
           Wm.launch(
             {
               kind: "migrate_gdrive_popup",
-              hub_id: this.mget(_a.hub_id) || Visitor.id,
-              nid: destNid || Visitor.get(_a.home_id),
+              hub_id: destHub,
+              nid: destNidFinal,
               destinationName: destName || undefined,
               direct: 1,
-              wm_unique_id: "migrate_gdrive_popup",
+              // Destination-scoped id (same scheme as window_folder-<hub>-<nid>).
+              // A plain shared id made singleton raise() a popup opened from
+              // ANOTHER destination (e.g. Settings after a folder, or folder B
+              // after folder A) with its stale destination — the user would
+              // import into the wrong place. Per-destination ids keep the
+              // no-duplicate guarantee per folder while giving each launch
+              // context its own popup.
+              wm_unique_id: `migrate_gdrive_popup-${destHub}-${destNidFinal}`,
             },
             { explicit: 1, singleton: 1 },
           );


### PR DESCRIPTION
## Bugs fixed

**1. Closing the migrate popup closed the open folder window too** (reported live)

`_close()` called `this.parent.clear()` unconditionally. Under `Wm.launch` the popup's parent is the shared **windowsLayer**, so `clear()` wiped every open window — after importing from a folder window, closing the popup took the folder window down with it.

Fix: `clear()` only when the popup is the parent's **sole child** (the single-widget modal-host case where clear() resets `data-state`); otherwise the popup removes only itself via `goodbye()`.

**2. Singleton reuse served a stale destination**

Both launch sites (folder `+ New` menu and Settings → Import) shared `wm_unique_id: "migrate_gdrive_popup"` with `singleton: 1`. If the popup was open from a folder and the user then hit *Migrate again* in Settings, `Wm.launch` just `raise()`d the stale popup — destination still the folder, `direct: 1` — so the import would land in the wrong place.

Fix: folder launches use a destination-scoped id `migrate_gdrive_popup-<hub_id>-<nid>` (same scheme as `window_folder-<hub>-<nid>`). Settings/desk keep the plain id — they both target Home so reuse there is correct.

## Verified on stage (paytest0724c / vudangnt endpoint)

- Folder templates → New → Migrate → import real Google Doc → **Migration complete** → close via X → popup gone, **folder window stays open**, no stray `.migrate-gdrive-popup` roots left in DOM
- Settings → Migrate again → destination **My home**, `direct: 0` (GoogleDriveMigration wrapper behaviour preserved)
- Folder popup open + Settings launch → **two independent popups** (templates/direct=1 and My home/direct=0), the Settings one on top showing the right destination; each closes independently, folder window unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)