### PR TITLE
feat(workspace): report sharebox and team hubs to the referral board

### DIFF
--- a/src/drumee/builtins/media/form/index.js
+++ b/src/drumee/builtins/media/form/index.js
@@ -79,40 +79,16 @@ class __form_folder extends LetcBox {
   }
 
   /**
-   * Report a workspace this form just created, for the analytics Referral
-   * users table (Workspaces column + Activated badge).
-   *
-   * Fired from the form rather than from the server because this is the only
-   * place that knows which of the three types the user picked. `personal` is
-   * not a hub — it is the home-root folder created above — so nothing on the
-   * server side can tell it apart from any other folder afterwards.
-   *
-   * Never awaited and never checked. The callers open a permission panel or
-   * the Manage-access dock immediately after; waiting on an analytics row
-   * would trade a visible delay for a number on an admin dashboard. Guarded on
-   * the service existing so a UI running against an older server quietly does
-   * nothing, and wrapped so a rejected post can never surface as a form error.
+   * Report a workspace this form just created. See libs/track-workspace —
+   * the sharebox and team windows create hubs the same board counts, so the
+   * reporting lives in one place rather than three.
    *
    * @param {String} type "team" | "share" | "personal"
    * @param {Object} opt  { wid, area, filename }
    * @returns {Promise<Object|null>} the service's answer, or null
    */
   _trackWorkspace(type, opt = {}) {
-    if (typeof SERVICE === "undefined" || !SERVICE.desk || !SERVICE.desk.track_workspace) {
-      return Promise.resolve(null);
-    }
-    try {
-      return this.postService(SERVICE.desk.track_workspace, {
-        hub_id: Visitor.id,
-        wid: opt.wid,
-        type,
-        area: opt.area,
-        filename: opt.filename,
-      }).catch(() => null);
-    } catch (e) {
-      /* tracking must never break workspace creation */
-      return Promise.resolve(null);
-    }
+    return require("libs/track-workspace").trackWorkspace(this, type, opt);
   }
 
   _submit() {

--- a/src/drumee/builtins/window/hub/sharebox/index.js
+++ b/src/drumee/builtins/window/hub/sharebox/index.js
@@ -92,6 +92,20 @@ class __window_hub_sharebox extends mfsInteract {
       hub_id: Visitor.id,
       pid: this.mget(_a.nid)
     }).then((data) => {
+      // A sharebox is an `area: share` hub, which is exactly what the
+      // analytics Referral users table counts as a workspace — but this window
+      // does not go through the create-workspace form, so nothing reported it.
+      // The board only picked these up when someone re-ran
+      // backfill_workspace_track by hand; now the column moves as it happens.
+      // Fire-and-forget, after creation succeeded.
+      const hub = _.isArray(data) ? data[0] : data;
+      if (hub && !hub.error) {
+        require("libs/track-workspace").trackWorkspace(this, "share", {
+          wid: hub.hub_id || hub.id,
+          area: hub.area || _a.share,
+          filename: this.formData.name,
+        });
+      }
       this._checkCreation(data);
     }).catch((err) => {
       this.onServerError(err);

--- a/src/drumee/builtins/window/hub/team/index.js
+++ b/src/drumee/builtins/window/hub/team/index.js
@@ -67,6 +67,19 @@ class __window_hub_team extends mfsInteract {
       hub_id: Visitor.id,
       pid: this.mget(_a.nid)
     }).then((data) => {
+      // A team hub is `area: private`, which the analytics Referral users
+      // table counts as a workspace — but this window bypasses the
+      // create-workspace form, so nothing reported it and the board only saw
+      // it when backfill_workspace_track was re-run by hand. Fire-and-forget,
+      // after creation succeeded.
+      const hub = _.isArray(data) ? data[0] : data;
+      if (hub && !hub.error) {
+        require("libs/track-workspace").trackWorkspace(this, "team", {
+          wid: hub.hub_id || hub.id,
+          area: hub.area || _a.private,
+          filename: this._data.name,
+        });
+      }
       this._checkCreation(data);
     }).catch((err) => {
       this.onServerError(err);

--- a/src/drumee/libs/track-workspace.js
+++ b/src/drumee/libs/track-workspace.js
@@ -1,0 +1,54 @@
+/**
+ * Report a workspace the user just created, for the analytics Referral users
+ * table (Workspaces column, and the Activated badge that now requires one).
+ *
+ * WHY THE CLIENT REPORTS THIS AT ALL. The obvious server-side count — hubs
+ * owned — cannot see the whole picture. The create-workspace form's `personal`
+ * type is a home-root FOLDER, not a hub: it never reaches yp.hub, so nothing
+ * after the fact can tell it apart from any other folder. The client is the
+ * only place that knows a workspace was what the user asked for.
+ *
+ * NEVER AWAITED, NEVER THROWS, NEVER BLOCKS. Callers open a permission panel
+ * or navigate immediately afterwards; waiting on an analytics row would trade
+ * a visible delay for a number on an admin dashboard. Guarded on the service
+ * existing so a UI running against an older server quietly does nothing.
+ *
+ * The posted row is written by the router's `log` flag (acl/desk.json
+ * track_workspace), and the handler pushes the caller's updated referral row
+ * to any open dashboard — which is what makes the Workspaces column move
+ * within a second rather than on the board's two-minute poll.
+ *
+ * `wid` MUST be the hub id, not actual_home_id: analytics-server's
+ * backfill_workspace_track keys its NOT EXISTS guard on the hub id, so a live
+ * row only suppresses the backfilled one when the two agree. Get it wrong and
+ * the workspace is counted twice.
+ *
+ * @param {Object} ui      the widget doing the reporting (needs postService)
+ * @param {String} type    "team" | "share" | "personal" — a LITERAL, not _a.*:
+ *   the ACL declares it required and enum-checked, so resolving it through the
+ *   attribute lexicon would turn a missing key into a silently dropped row.
+ * @param {Object} opt     { wid, area, filename }
+ * @returns {Promise<Object|null>} the service's answer, or null
+ */
+function trackWorkspace(ui, type, opt = {}) {
+  if (!ui || typeof ui.postService !== "function") return Promise.resolve(null);
+  if (typeof SERVICE === "undefined" || !SERVICE.desk || !SERVICE.desk.track_workspace) {
+    return Promise.resolve(null);
+  }
+  try {
+    return ui
+      .postService(SERVICE.desk.track_workspace, {
+        hub_id: Visitor.id,
+        wid: opt.wid,
+        type,
+        area: opt.area,
+        filename: opt.filename,
+      })
+      .catch(() => null);
+  } catch (e) {
+    /* tracking must never break workspace creation */
+    return Promise.resolve(null);
+  }
+}
+
+module.exports = { trackWorkspace };


### PR DESCRIPTION
The Workspaces column on the analytics Referral users table counts desk.track_workspace events, and only the create-workspace form was firing them. The sharebox window (area share) and the team window (area private) create hubs the SAME column counts, but neither reported, so those workspaces reached the board only when someone re-ran backfill_workspace_track by hand — not live, and not on the two-minute poll either.

Both now report on success, so the column moves within a second of the click like the form's three types already do.

The website window is deliberately left out: it creates an area:public hub, which backfill_workspace_track excludes along with the other system hubs, so reporting it would start counting something the board has never counted.

The posting itself moves to libs/track-workspace. Three callers needed it and the rules it encodes are easy to get wrong in a copy: `wid` must be the HUB id because the backfill's NOT EXISTS guard keys on that (get it wrong and the workspace is counted twice), `type` must be a literal because the ACL enum- checks it and a lexicon miss would be a silently dropped row, and the whole thing must stay fire-and-forget so analytics can never break a creation.