### PR TITLE
perf(folder): stop the window-title render loop that delayed every folder open

### DIFF
--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -1035,9 +1035,25 @@ class __window_folder extends mfsInteract {
       // filename workspace root takes its name from hub_name). Set `child`
       // DIRECTLY — calling ensurePart for this part here would replay
       // onPartReady and loop forever.
+      //
+      // `child.set()` re-enters this handler: set → mould → render →
+      // onBeforeRender → registerPart → triggerMethod(part:ready) → here. That
+      // recursed ~945 times on every folder open, until the stack overflowed
+      // and mould()'s own try/catch swallowed the RangeError — invisible, but
+      // it burned ~1.2s of main thread and pushed the content listing
+      // (media.show_node_by) from ~0.9s to ~2.2s after the click. Write only
+      // when the title actually differs, and never re-enter.
       const name = this.mget(_a.filename) || this.model.get("hub_name");
+      const shown = child && _.isFunction(child.mget) ? child.mget("content") : null;
+      if (name && String(shown) === String(name)) return; // already painted
+      if (this._namingWindow) return;
       if (name && _.isFunction(child.set)) {
-        child.set({ content: name });
+        this._namingWindow = 1;
+        try {
+          child.set({ content: name });
+        } finally {
+          this._namingWindow = 0;
+        }
       } else if (!name && !this.mget(_a.headless)) {
         // Opened without a seeded name (e.g. openFileLocation revealing a hit
         // in a hub/workspace ROOT — media.attributes carries no display name
@@ -1059,7 +1075,9 @@ class __window_folder extends mfsInteract {
     const hub_id = this.mget(_a.hub_id);
     if (!nid || !hub_id) return;
     this._titleResolving = 1;
-    this.fetchService(SERVICE.media.get_path, { nid, hub_id })
+    // Wm.loadWorkspace is very likely asking for this same path right now —
+    // share its request rather than adding a second one (libs/path-request).
+    require("libs/path-request").getPath(this, { nid, hub_id })
       .then((data) => {
         if (this.isDestroyed && this.isDestroyed()) return;
         if (!_.isEmpty(data)) this.refreshBreadcrumbsUI(data);

--- a/src/drumee/libs/path-request.js
+++ b/src/drumee/libs/path-request.js
@@ -1,0 +1,57 @@
+/**
+ * Collapse the duplicate `media.get_path` calls a single window-open fires.
+ *
+ * Opening a folder asks the server for the SAME node path two or three times,
+ * from callers that don't know about each other: `Wm.loadWorkspace` (to feed
+ * `refreshBreadcrumbsUI`), `desk_breadcrumb._updatePath` (to paint the topbar),
+ * and `window_folder._resolveMissingTitle` when the title arrives blank. They
+ * fire within a few milliseconds of each other with identical arguments.
+ *
+ * That is not just wasted work. `mfs_get_path` builds a TEMPORARY table per
+ * call, and two identical calls landing together on the endpoint measured
+ * 173 ms for the first and 404 ms (and, on a cold endpoint, 3013 ms) for its
+ * twin — the duplicate is slower than the original and it delays everything
+ * queued behind it, including the folder's own content listing.
+ *
+ * De-duplication is IN-FLIGHT ONLY: callers that ask while a request for the
+ * same (hub_id, nid) is still open share its promise, and the entry is dropped
+ * as soon as it settles. Nothing is cached across the gap, so a rename, a move
+ * or a permission change is picked up by the next call exactly as before —
+ * this cannot serve stale path data.
+ *
+ * Each caller gets its own copy of the resolved list, so one caller mutating
+ * its result (refreshBreadcrumbsUI reshapes rows) can't corrupt another's.
+ */
+
+const inFlight = new Map();
+
+const keyOf = (hub_id, nid) => `${hub_id || ""}:${nid || ""}`;
+
+/**
+ * @param {Object} view   any widget (supplies fetchService + its auth context)
+ * @param {Object} params { nid, hub_id }
+ * @returns {Promise<Array>} the path rows, newest caller gets its own copy
+ */
+function getPath(view, params = {}) {
+  const { nid, hub_id } = params;
+  // Without both keys the server can only answer for "undefined" — let the
+  // caller's own guard deal with it rather than caching a bad key.
+  if (!nid || !hub_id) return view.fetchService(SERVICE.media.get_path, params);
+
+  const key = keyOf(hub_id, nid);
+  let p = inFlight.get(key);
+  if (!p) {
+    p = view.fetchService(SERVICE.media.get_path, { nid, hub_id });
+    inFlight.set(key, p);
+    const drop = () => {
+      // Only drop OUR entry: a later call for the same node may already have
+      // replaced it.
+      if (inFlight.get(key) === p) inFlight.delete(key);
+    };
+    p.then(drop, drop);
+  }
+  // Copy the array so sharing the promise never means sharing the array.
+  return p.then((data) => (_.isArray(data) ? data.slice() : data));
+}
+
+module.exports = { getPath };

--- a/src/drumee/modules/desk/breadcrumb/index.js
+++ b/src/drumee/modules/desk/breadcrumb/index.js
@@ -3,6 +3,8 @@
  * Listens to RADIO_BROADCAST "breadcrumb:content" emitted by window/core.js
  * whenever the active window navigates, and renders the path.
  * ==================================================================== */
+const { getPath } = require("libs/path-request");
+
 const PROPERTIES = [
   _a.area,
   _a.actual_home_id,
@@ -149,7 +151,9 @@ class __desk_breadcrumb extends LetcBox {
       this.warn("Require node data")
       return;
     }
-    this.fetchService(SERVICE.media.get_path, { nid, hub_id }).then((data) => {
+    // Shared in-flight request: Wm.loadWorkspace asks for this exact path in
+    // the same instant on a folder open (libs/path-request).
+    getPath(this, { nid, hub_id }).then((data) => {
       if (_.isEmpty(data)) return;
       this._buildContent(data)
     })

--- a/src/drumee/modules/desk/wm/index.js
+++ b/src/drumee/modules/desk/wm/index.js
@@ -5,6 +5,9 @@ const push = require("./push");
 // "Open this workspace once signed in" — armed by the welcome module from
 // ?hub_id= (the workspace-invite CTA), consumed on boot below.
 const hubDeepLink = require("libs/hub-deep-link");
+// Shares one in-flight media.get_path with the breadcrumb / folder window when
+// they ask for the same node in the same instant (a folder open does).
+const { getPath } = require("libs/path-request");
 // Same channel the websocket dispatcher triggers on Wm — windows and the
 // sidebar workspace list subscribe to it (window/utils.js, workspace-list).
 const WS_EVENT = "ws:event";
@@ -514,7 +517,7 @@ class __window_manager extends push {
       // path of "undefined" — the same defect as the fetch above, and it left the
       // breadcrumb stuck on the previous screen. openWorkspaceFolder already does
       // it this way (attrs.nid || nid).
-      this.fetchService(SERVICE.media.get_path, { nid: data.nid || nid, hub_id }).then(
+      getPath(this, { nid: data.nid || nid, hub_id }).then(
         (path) => {
           if (_.isEmpty(path)) return;
           cur.refreshBreadcrumbsUI(path);
@@ -738,7 +741,7 @@ class __window_manager extends push {
         // breadcrumb would keep the previous folder's crumbs. Rebuild it from
         // get_path, as loadWorkspace does.
         const deepNid = attrs.nid || nid;
-        this.fetchService(SERVICE.media.get_path, { nid: deepNid, hub_id })
+        getPath(this, { nid: deepNid, hub_id })
           .then((path) => {
             if (_.isEmpty(path)) return;
             if (_.isFunction(currentFolder.refreshBreadcrumbsUI))


### PR DESCRIPTION
## Problem

Opening a folder took **2.5–4s** before content appeared. Worse, the content request (`media.show_node_by`) wasn't even *issued* until **~2.2s after the click** — a long stretch with zero network activity, which is exactly what "click vào folder thì khoảng 2s sau mới thấy gọi load api" describes.

## Root cause — an invisible infinite recursion, 945 deep

`onPartReady("ref-window-name")` restores the window title with `child.set()`. But `set()` re-enters the handler that called it:

```
child.set() → mould() → render() → onBeforeRender → registerPart
           → triggerMethod(part:ready) → onPartReady("ref-window-name") → …
```

Measured live on stage: **945 recursive renders of the same title widget on every folder open**. It terminated only when the JS stack overflowed — and `mould()`'s own `try { … } catch (error) { }` swallowed the `RangeError`, so nothing ever surfaced in the console. Cost: ~1.2s of blocked main thread, which also delayed the window's `feed()` and therefore the content listing behind it.

**Fix**: write only when the title actually differs, plus a re-entrancy guard. Legitimate title changes still paint (verified by navigating into a subfolder: title went `share-thamos` → `docs(2)`, one render).

## Second win — three identical `get_path` calls per open

Three callers ask for the same node path in the same instant without knowing about each other: `Wm.loadWorkspace`, `desk_breadcrumb._updatePath`, `window_folder._resolveMissingTitle`. The duplicates are *slower* than the original (173ms vs 404ms, and **3013ms** on a cold endpoint — `mfs_get_path` builds a TEMPORARY table per call) and they delay whatever is queued behind them.

New `libs/path-request` shares one **in-flight** request per `(hub_id, nid)`. Nothing is cached across the gap, so a rename/move/permission change is still picked up by the next call — this cannot serve stale path data. Each caller gets its own copy of the array.

## Measured on stage (templates folder, window closed before each run)

| | content visible | title renders | get_path calls |
|---|---|---|---|
| before | 2512–3882 ms | **945** | 3 |
| after | **841–1518 ms** | **1** | **1** |

`media.show_node_by` now leaves at **~650ms** instead of ~2170ms.

Verified no regressions: window title correct at workspace root and after navigating into a subfolder, breadcrumb path correct (`share-thamos › docs(2)`), file grid and chat panel render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)