### PR TITLE
Promote test to preview — permission surfaces, reward exit guard, folder-open perf

### DIFF
--- a/docs/superpowers/specs/2026-08-08-reward-flow-exit-and-unload-design.md
+++ b/docs/superpowers/specs/2026-08-08-reward-flow-exit-and-unload-design.md
@@ -1,0 +1,405 @@
+# Reward flow — refresh, Back and tab close
+
+**Date:** 2026-08-08
+**Status:** approved
+**Touches:** ui-team (phase 1), then schemas + server-team + ui-team + analytics-ui (phase 2)
+
+## Problem
+
+Every way out of the reward walkthrough that happens *inside* the app already
+asks "Don't drop now" — the vignette on an active card step, `__guide-scrim`
+during either walkthrough, and the backdrop beside a Step 2 surface
+(2026-07-27-reward-flow-step2-drop-guard-design.md).
+
+Three ways out walk past all of it: **F5**, **Back**, and **closing the tab**.
+The first two are the common ones during a walkthrough that has taken over the
+screen. Neither the flow nor the user gets any say — the run disappears mid-step
+with no acknowledgement.
+
+The funnel has the mirror-image problem. An abandon is only ever recorded when
+the user says so in-app, so a closed tab leaves the row at `started` forever and
+the dashboard cannot tell a user who walked away from one who is still working.
+Those are the two populations the campaign is judged on.
+
+## Prior art
+
+Two unmerged local branches, both dated 2026-08-08, each solving one half:
+
+- `feat/reward-flow-exit-guard` (ui-team only) — intercepts what can be
+  intercepted and shows the flow's own card.
+- `feat/reward-unload-guard` (ui-team + schemas + server-team + analytics-ui) —
+  records the abandon on unload, and reworks the status model to make that safe.
+
+They are not rivals. B is the user-facing layer, A is the funnel layer, and A's
+recoverable `dropped` is precisely what makes recording an uncatchable tab-close
+harmless. This design combines them, shipped in two phases.
+
+## Constraints
+
+**A page cannot render its own UI on unload.** Every engine has ignored custom
+`beforeunload` text since 2016 and shows its own wording; `preventDefault()` is
+the entire dialog. So the branded card can only be raised for gestures caught
+*before* the page starts leaving, and `beforeunload` is a last-resort net.
+
+**`sendBeacon` cannot be used.** Session auth rides on request headers
+(`x-param-keysel` / `x-param-<keysel>`, built by `makeHeaders` in
+`@drumee/ui-essentials`), and `sendBeacon` cannot set them — a beacon would
+arrive unauthenticated with no `uid`. `fetch(..., { keepalive: true })` carries
+headers and is specified to outlive the document.
+
+**Refresh and close are indistinguishable at unload time.** No API separates
+them. This is what forces the status split in phase 2.
+
+---
+
+# Phase 1 — Exit guard (ui-team only)
+
+Self-contained: no schema change, no DB patching, and it degrades to today's
+behaviour if anything is wrong.
+
+## Behaviour
+
+Three signals, one card. The existing "Don't drop now" modal is reused unchanged
+— it asks the same question whether raised by a click on the vignette or by F5,
+and a second variant would be one more string to translate for no new
+information.
+
+| Signal | Caught by | Intent |
+|---|---|---|
+| F5, Ctrl+R, Cmd+R (+Shift for a hard reload) | `keydown`, capture phase, `preventDefault` | `reload` |
+| Back / Forward button | a history sentinel consumed by `popstate` | `navigate` |
+| Tab close, Cmd+W, address bar | `beforeunload` → the browser's own dialog | — |
+
+- **Continue** closes the guard and *cancels* the intent. A refresh the user has
+  thought better of must not still be waiting to happen behind the card. The
+  Back trap is re-armed, since the sentinel was consumed getting here.
+- **Drop anyway** ends the flow as it always has, then **carries out what the
+  user asked for**: a reload actually reloads, a Back actually goes back.
+
+`beforeunload` shows no card and reports nothing. It exists for the paths
+nothing can intercept — Cmd+W, the tab's close box, the address bar — plus the
+browsers that refuse to let Cmd+R be cancelled.
+
+### Not watched: cursor leaving the viewport
+
+The classic exit-intent heuristic was built and then removed. It catches more,
+but it guesses at an intention rather than reading an action, and it fires just
+as readily on someone reaching for a bookmark. A guard that interrupts a
+walkthrough on a guess is worse than one that misses a gesture, and the
+`beforeunload` net still covers the click it was trying to pre-empt. Both
+remaining signals are things the user actually **did**. That is the line this
+module holds.
+
+## When the guard is silent
+
+One predicate, `armed()`, gates all three signals:
+
+- the step is not one of the three card steps — `STEPS.includes(baseStep(step))`.
+  An **allowlist**, not a denylist of terminal states: a step name the flow does
+  not recognise raises no dialog. `baseStep` strips both `_waiting` and
+  `_guide`, so the handoffs are still guarded — they are where users most often
+  wander off, and excluding them would miss the common abandon. `congrats` and
+  `soldout` fall out for free, which matters: a "Leave site?" dialog between a
+  user and their dashboard right after they have won is the worst possible
+  moment for one. It is also what excludes a **capped** run, which mounts
+  straight into `soldout` — offering to talk a user out of leaving a flow they
+  were never given would be nonsense;
+- `_finishing` — the flow is already on its way out;
+- `_dropGuardOpen` — a second F5 while the card is up is swallowed rather than
+  restarting its entry animation and replacing the intent being asked about.
+
+Never armed for a `?reward=1` run, matching `_track`.
+
+## Architecture
+
+A new `exit-guard.js` beside `steps.js` / `storage.js` / `workspace.js`.
+`index.js` is already ~1900 lines, and the directory's convention is that
+anything with a decision worth testing gets its own module, guarded on `typeof
+window` so it stays requirable under bare Node.
+
+```
+exit-guard.js
+  classifyKey(e)      → "reload" | null    pure
+  armed(step, flags)  → boolean            pure
+  class ExitGuard { start() stop() rearm() resumeNavigate() }
+```
+
+`ExitGuard` takes the orchestrator as `ui`, like `RewardGuide` and
+`RewardUploadGuide` do, and calls back into one new method, `ui.onExitIntent()`.
+It never renders: raising the card stays the orchestrator's job, through the
+existing `_openDropGuard()`.
+
+### Why a history sentinel, not a `hashchange` listener
+
+`hashchange` fires *after* the router has navigated, by which point the desk
+module — and the flow inside it — is being torn down. There is nothing left to
+raise a guard on and nothing to restore it to.
+
+So `start()` pushes a duplicate of the current entry. The first Back press pops
+that instead of leaving the desk: the URL never changes, so the router never
+runs, and the flow is intact when the guard goes up. `rearm()` re-pushes it when
+the user stays.
+
+Two states must never be tidied on teardown, both handled by `_isCurrent()`
+(is our marked entry the one the browser is on right now?):
+
+- the flow leaving *through* the sentinel — `resumeNavigate()` owns the history
+  from there;
+- the app having navigated **on top** of it. This is the one that bites:
+  teardown is usually *caused* by a route change, and a blind `history.back()`
+  there would drag the user back to the page they just left.
+
+Every `history` call is feature-detected and wrapped: a guard that cannot
+manipulate history must still leave the keystroke and `beforeunload` nets
+working.
+
+## Funnel in phase 1
+
+Unchanged. "Drop anyway" remains the only abandon gesture and the only writer of
+`dropped`. A tab closed past the native dialog still leaves the row at
+`started`, which is what lets the flow resume from `reward_claim.step` on the
+next login rather than being closed off for a user who only meant to come back
+later.
+
+One change to *how* that post is made: `_track("dropped")` is now **awaited**
+before the exit fires, raced against `DROP_POST_TIMEOUT_MS` (1500 ms). The exit
+can be a reload, and a request still in flight when the page goes is a row the
+funnel never sees. The race is what stops a hung network stranding the user on a
+guard they have already dismissed — past that, losing the row is the cheaper
+failure. A `_leaving` latch makes a double click on "Drop anyway" idempotent.
+
+---
+
+# Phase 2 — Funnel semantics (4 repos)
+
+Ships after phase 1 is deployed and verified.
+
+## `dropped` splits in two
+
+- **`dropped`** — the user left without saying so (an unload we could not
+  intercept). **Recoverable**: it rejoins the set that re-opens the flow, so a
+  stray F5 cannot cost someone a prize they were three clicks from claiming.
+- **`declined`** — the user was asked and said yes ("Drop anyway"). **Terminal.**
+
+Old ladder: `emailed(1) < clicked(2) < started(3) < dropped(4) < missed(5) < done(6)`
+New ladder: `emailed(1) < clicked(2) < dropped(3) < started(4) < declined(5) < missed(6) < done(7)`
+
+`dropped` moves *below* `started` because once a dropped user can return, the old
+ranking freezes their row: their next `started` post is rejected, so someone
+actively working reads as "Dropped" on the dashboard and "In progress"
+undercounts by exactly the returning population.
+
+`declined`, `missed` and `done` all outrank it, so neither a decline, a cap
+refusal nor a completion can be undone by a late abandon.
+
+## One exception to the ladder
+
+**A `dropped` post is accepted onto a row that is `started`.**
+
+Without it `dropped` could never be written at all: the widget posts `started`
+on mount, so every row is already there by the time anyone abandons, and a pure
+rank test rejects the very write that records it.
+
+`started` and `dropped` are the only *reversible* states in the funnel — they
+say where the user is now, and a user may leave and return freely. Every other
+status records a one-time fact (the mail went out, the link was followed, they
+said no, the cap refused them, they finished) and none is takeable back. The
+exception is scoped to that pair **by name**, so it cannot fire against
+`declined`, `missed` or `done`.
+
+## Backfill
+
+Rows already sitting at `dropped` were written under the OLD meaning — people
+who pressed "Drop anyway". Under the new semantics they would become eligible
+again and be re-offered the flow, silently overriding an explicit "no" from
+every one of them.
+
+A one-shot dated patch, `yellow_page/patches/2026-08-08-reward-dropped-to-declined.sql`,
+rewrites them:
+
+```sql
+UPDATE reward_claim SET status = 'declined', mtime = UNIX_TIMESTAMP()
+ WHERE status = 'dropped';
+```
+
+Applied **before** the proc change, and never re-run afterwards — past that
+point a `dropped` row means an accidental exit and converting it would be
+exactly wrong. It is a no-op on this box (`yp.reward_claim` is empty); it exists
+for stage and production.
+
+Measured on stage 2026-08-08 rather than assumed: **1 row** to convert, out of
+173 — emailed 150, failed 17, done 4, dropped 1, started 1, with 4 of the 100
+slots taken. Small, but that one row belongs to a real person who said no.
+
+## Changes
+
+| Repo | Change |
+|---|---|
+| schemas | `reward_claim_track.sql` — re-ranked `FIELD()` lists, exception clause, docblock; `reward_claim_emailed.sql` — `declined` joins the re-armed set and **`dropped` leaves it**; `reward_claim.sql` — status comment; new dated backfill patch; manifest entries in deploy order |
+| server-team | `reward.js` — `OPEN` gains `dropped`, `STATUS` gains `declined` |
+| ui-team | new `reward-flow/beacon.js`; `_syncUnloadGuard` / `_releaseUnloadGuard` / `_beaconDropped` in `index.js`; "Drop anyway" writes `declined` |
+| analytics-ui | `declined` chip, filter option, and colours in **both** skin entries (`app/skin` and `app/user/skin` state the palette twice — keep them in step) |
+
+### `dropped` leaves the re-arm set
+
+Found during implementation; `feat/reward-unload-guard` has this wrong. Its
+`reward_claim_emailed` keeps `dropped` alongside `done`/`declined`/`missed` in
+the set a fresh send re-arms.
+
+That was right while `dropped` was terminal. It is wrong now: re-arming nulls
+`step`, zeroes `clicked_at` and sets the row to `emailed`, which is **not** in
+the gate's OPEN set. So a re-send would take a dropped user who was already
+eligible and already resuming mid-walkthrough, and demote them to someone who
+must go and find the new mail and click it again. **A re-send must never take
+access away from someone who already had it.**
+
+The re-arm set is exactly "statuses not in OPEN, minus `emailed`" —
+`{failed, declined, missed, done}`.
+
+### "Drop anyway" writes two different statuses
+
+Found by testing on stage, after the first combined build was deployed — it
+locked a real tester out of the campaign (row 1213, 2026-08-08 19:07).
+
+Phase 1 gave "Drop anyway" a second job: carry out the reload or Back the user
+asked for. Phase 2 gave it a terminal status. Together, an intercepted F5 —
+which phase 2 exists to protect — ended as `declined`, permanently out of the
+gate's OPEN set.
+
+That inverts the design by information:
+
+| Gesture | What we know | Status | Recoverable |
+|---|---|---|---|
+| Tab close | nothing | `dropped` | yes |
+| F5, intercepted | it is a refresh | `declined` | **no** |
+
+The more we knew the user meant something benign, the harsher the outcome.
+
+So the status follows `_pendingExit`, which is already the exact
+discriminator — set only by `onExitIntent`, cleared by "Continue", null when
+the user raised the card themselves:
+
+- guard raised by the user (vignette, scrim) → `declined`, terminal;
+- guard raised by an intercepted exit → `dropped`, recoverable.
+
+No schema or server change: the proc already accepts `dropped` onto a `started`
+row through the named exception, and `STATUS` already allows both.
+
+### `beforeunload` gets one owner
+
+Both source branches register it: `exit-guard.js` as its last-resort net, and
+the unload half for its dialog. Combining them naively gives one browser prompt
+two owners and puts its arming rules in two places.
+
+It stays with `exit-guard.js`, which owns every signal that ASKS the user
+something. The orchestrator's half only reports, on `pagehide`.
+
+The two arming predicates stay separate, though, and that is deliberate:
+`_shouldReportUnload` shares the step test with `armed()` but not
+`_dropGuardOpen`. That flag exists to stop a second F5 replacing the intent
+already on screen; a user who closes the tab while the card is up has still
+left, and their exit is still worth recording.
+
+## bfcache is not leaving
+
+`pagehide` with `persisted: true` means the page was frozen and may be restored
+intact. Nothing re-posts `started` on restore (`_trackedStep` still holds it), so
+reporting a drop there would leave the row saying "gone" for a user about to be
+looking at the flow again. Skipped.
+
+## Failure mode
+
+Fail-open, and it equals the status quo. If the request never lands — an engine
+that ignores `keepalive`, no network, a UA that kills it — the row stays
+`started`, exactly as before this feature existed. Nothing here is load-bearing
+enough to justify a throw inside a `pagehide` handler, where an exception can
+stall the navigation the user just confirmed.
+
+## Known limitation
+
+Browsers suppress `beforeunload` entirely without prior user interaction (sticky
+activation). A user who lands on the desk, is given the flow, and immediately
+closes the tab without clicking anything gets no dialog. Unfixable, and
+harmless: `pagehide` still fires, so the drop is recorded without a prompt —
+the correct funnel fact, and safe now that `dropped` is recoverable.
+
+## Deployment order
+
+1. backfill patch;
+2. `reward_claim_track` and `reward_claim_emailed` via `bin/patch-from-file`
+   against **every** yellow_page instance — diff the deployed proc first, since
+   hand-applied changes have drifted from the repo before;
+3. server-team;
+4. ui-team;
+5. analytics-ui.
+
+Until the proc is patched a `declined` post silently no-ops — `FIELD()` returns
+NULL for an unknown value, which coalesces to rank 0 and loses every comparison
+— so a half-deployed rollout leaves users at `started` rather than corrupting
+the funnel.
+
+---
+
+# Verification
+
+**Phase 1.** No app-level test runner exists in this repo (only the vendored
+jitsi specs), so the pure decisions are covered by a bare-Node smoke check of
+`classifyKey` and `armed` — including `Cmd+W → null` (not ours), `Ctrl+F5 →
+null` (left to the browser), bare `r → null` (the user is typing), and
+`soldout → false`.
+
+Manual matrix, run with `?reward=1`. For each of `step1`, `step1_guide`,
+`step2_waiting`, `step3_guide`, `soldout`:
+
+1. **F5** → the guard appears, the page does not reload. Continue → still on the
+   same step, nothing lost (the create form still holds its input, the invite
+   popup still holds its typed emails). F5 again → the guard appears again.
+2. **F5 → Drop anyway** → the flow ends *and* the page reloads. The next load
+   does not re-open the flow at the same step.
+3. **Ctrl+R / Cmd+R / Ctrl+Shift+R** → as F5.
+4. **Back** → the guard appears, the desk is still there. Continue → still on
+   the step; Back again → the guard appears again (trap re-armed).
+5. **Back → Drop anyway** → the flow ends and the browser goes back one page.
+6. **Tab close / Cmd+W** → the browser's own dialog. Cancel → still mid-flow.
+7. **Moving the cursor out of the viewport** (any edge) → nothing happens.
+   Regression check: exit-intent detection was deliberately removed.
+8. **`soldout`** → none of 1–7 raises anything, and refresh/close go through
+   untouched.
+
+Also check that finishing normally (congrats → "Go to dashboard") leaves the
+history clean: one Back press from the desk goes where it did before the flow
+ran.
+
+**Phase 2.** Transition matrix against a scratch DB (`utf8mb4_general_ci`,
+stubbed `reward_personal_eligible` / `reward_grant_storage`) covering every
+`(current, posted)` pair — including every terminal-state case, both directions
+of the `started`/`dropped` pair, and `declined` against a later `started`.
+
+Run 2026-08-08: **48 transitions and 12 invariants, 0 failures**, covering the
+exception's named pair, the three refusals it must not fire against, a dropped
+user returning and completing for exactly one slot, the ineligible-user refusal
+consuming no slot, and the cap closing after its last slot.
+
+Two negative controls confirm both changes are load-bearing:
+
+- exception removed → `started + dropped` stays `started`, i.e. `dropped` could
+  never be written at all;
+- old ladder restored → `dropped + started` stays `dropped`, i.e. a returning
+  user reads as "Dropped" forever.
+
+The backfill and the re-arm change are exercised separately against seeded
+rows: the patch converts only the `dropped` row and preserves its `step` and
+`completed_count`, and after it `reward_claim_emailed` re-arms
+`declined`/`done`/`missed` to `emailed` while leaving `dropped` and `started`
+untouched.
+
+**Deployed procs on stage were diffed against the repo before any of this: no
+drift** in `reward_claim_track`, `reward_claim_emailed` or `reward_claim_failed`.
+
+### Still unverified
+
+Nothing has exercised the browser halves for real — the history sentinel, the
+keydown interception, and `fetch(keepalive)` surviving a genuine unload all
+need the manual matrix above, in a browser, on a provisioned account. The
+`?reward=1` path can drive the flow but reports nothing by design, so the
+funnel writes cannot be observed that way.

--- a/src/drumee/builtins/media/core.js
+++ b/src/drumee/builtins/media/core.js
@@ -642,15 +642,39 @@ class __media_core extends DrumeeMFS {
   }
 
   /**
-   * 
-   * @param {*} side 
+   * Debounced shift request. Called on every drag tick, so it dedupes on the
+   * requested (side, bar) pair: the first tick arms the timer and identical
+   * follow-ups leave it alone — the shift fires 120ms after entering the
+   * zone even while the pointer keeps moving. A DIFFERENT request cancels
+   * the pending one and re-arms. The old version cleared the timer inside
+   * the callback — after it had already fired — so every call stacked one
+   * more live timer and shifts landed twice and late during fast drags.
+   * @param {*} side
+   * @param {*} bar 1 when this tile anchors the insertion indicator
    */
-  delaySelect(side) {
-    const f = () => {
-      clearTimeout(this._timer.select);
-      this.shift(side);
-    };
-    this._timer.select = setTimeout(f, 200);
+  delaySelect(side, bar) {
+    const req = `${side || ""}:${bar ? 1 : 0}`;
+    if (this._shiftReq === req) {
+      return;
+    }
+    this._shiftReq = req;
+    clearTimeout(this._timer.select);
+    this._timer.select = setTimeout(() => {
+      // Applied — drop the dedupe key so a later identical request after an
+      // out-of-band reset (resetMotion) re-arms instead of being swallowed.
+      this._shiftReq = null;
+      this.shift(side, bar);
+    }, 120);
+  }
+
+  /**
+   * Drop any pending delaySelect request without touching the tile's current
+   * position. resetMotion goes through this so a shift armed just before the
+   * drop cannot land after the cleanup pass already ran.
+   */
+  cancelShift() {
+    clearTimeout(this._timer.select);
+    this._shiftReq = null;
   }
 
   /**
@@ -659,6 +683,26 @@ class __media_core extends DrumeeMFS {
    */
   index() {
     return this.mget(_a.rank);
+  }
+
+  /**
+   * Position of this tile inside its list collection — the unit
+   * insertMedia's `position` argument speaks (collection.add {at:...}).
+   * Deliberately NOT index(): that returns the stored rank, which only
+   * matches the displayed order while the window is sorted by rank. Under
+   * the default mtime-desc listing the two are unrelated, so deriving an
+   * insertion slot from rank dropped tiles in the wrong place.
+   * @returns {number}
+   */
+  listIndex() {
+    const c =
+      (this.parent && this.parent.collection) ||
+      (this.model && this.model.collection);
+    if (!c || !_.isFunction(c.indexOf)) {
+      return this.index();
+    }
+    const i = c.indexOf(this.model);
+    return i < 0 ? this.index() : i;
   }
 
   /**

--- a/src/drumee/builtins/media/core.js
+++ b/src/drumee/builtins/media/core.js
@@ -194,7 +194,12 @@ class __media_core extends DrumeeMFS {
   _canInviteToHub() {
     const area = this.mget(_a.area);
     if (!["dmz", _a.share, _a.private].includes(area)) return false;
-    return this.mget(_a.privilege) & _K.permission.download;
+    // Inviting is member management: hub.invite / add_contributors /
+    // set_privilege are all `src: admin` server-side, so view, chat AND edit
+    // could only ever meet a 403. This used to test the DOWNLOAD bit, which
+    // offered the action to chat and edit members and made the refusal look
+    // like a bug rather than a permission.
+    return this.mget(_a.privilege) & _K.permission.admin;
   }
 
   contextmenuItemsForHub() {

--- a/src/drumee/builtins/media/file-thread-move-route.js
+++ b/src/drumee/builtins/media/file-thread-move-route.js
@@ -1,0 +1,35 @@
+const FALLBACK_FILE_THREAD_MOVE = "media.move_cross_hub";
+const FALLBACK_WORKSPACE_MOVE = "media.workspace_move";
+
+function mediaServices(services) {
+  return (services && services.media) || {};
+}
+
+function fileThreadMoveService(services) {
+  return mediaServices(services).move_cross_hub || FALLBACK_FILE_THREAD_MOVE;
+}
+
+function workspaceMoveService(services) {
+  return mediaServices(services).workspace_move || FALLBACK_WORKSPACE_MOVE;
+}
+
+function selectCrossWorkspaceMoveService(threadInfo, services) {
+  const info = threadInfo || {};
+  const hasFileThread = Number(info.exists_thread) === 1 &&
+    Boolean(info.file_thread_id);
+
+  return hasFileThread
+    ? fileThreadMoveService(services)
+    : workspaceMoveService(services);
+}
+
+function isMoveResultSuccessful(service, result, services) {
+  if (!result) return false;
+  if (service !== fileThreadMoveService(services)) return true;
+  return result.state === "committed";
+}
+
+module.exports = {
+  isMoveResultSuccessful,
+  selectCrossWorkspaceMoveService,
+};

--- a/src/drumee/builtins/media/grid/index.js
+++ b/src/drumee/builtins/media/grid/index.js
@@ -2,6 +2,14 @@ const { TweenLite, TimelineMax } = require("@drumee/ui-core/vendor");
 
 const Rectangle = require('rectangle-node');
 
+// Half the opening a drop slot leaves between two tiles. Only the two tiles
+// flanking the slot move — the rest of the row stays put — so this has to
+// stay well under a tile width or the opening overruns the neighbours behind
+// it. A tile-sized (120px) opening did exactly that: it visually clipped the
+// tiles further along the row. Keep in sync with the [data-insert] offsets in
+// skin/index.scss.
+const SLOT_SHIFT = 24;
+
 class __media_grid extends DrumeeMediaInteract {
   constructor(...args) {
     super(...args);
@@ -198,29 +206,45 @@ class __media_grid extends DrumeeMediaInteract {
   }
 
   /**
-   * 
-   * @param {*} side 
+   * Slide the tile aside to open an insertion slot (or back to rest).
+   * ±24px on both slot neighbors plus the 16px --grid-gap ≈ a 64px opening —
+   * wide enough to read as "drop here", unlike the old ±15px nudge. No
+   * _animIsActive early-return anymore: dropping a reset request while the
+   * open-tween was still running is exactly how tiles got stuck aside.
+   * overwrite kills the conflicting tween (GSAP defaults to letting both
+   * run, and the stale one's onComplete would re-measure bounds mid-flight).
+   * @param {*} side
+   * @param {*} bar 1 to anchor the insertion indicator on this tile
    */
-  shift(side) {
+  shift(side, bar) {
     let x;
-    if (this._animIsActive) {
-      return;
-    }
     switch (side) {
       case _a.left:
-        x = -15;
+        x = -SLOT_SHIFT;
         break;
 
       case _a.right:
-        x = 15;
+        x = SLOT_SHIFT;
         break;
 
       default:
         x = 0;
     }
+    if (bar && side) {
+      this.el.dataset.insert = side;
+    } else {
+      this.el.removeAttribute("data-insert");
+    }
+    if (this._shiftX === x) {
+      return this;
+    }
     this._shiftX = x;
-    TweenLite.to(this.$el, .2, {
+    const instant =
+      window.matchMedia &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    TweenLite.to(this.$el, instant ? 0 : .2, {
       x,
+      overwrite: "auto",
       onStart: this._onStartShifting,
       onComplete: this._onStopShifting
     });
@@ -228,12 +252,28 @@ class __media_grid extends DrumeeMediaInteract {
   }
 
   /**
-   * 
+   *
    */
   resetMotion() {
     this.el.dataset.over = _a.off;
     this.el.dataset.hover = _a.off;
+    // A shift armed just before the drop must not land after this cleanup.
+    this.cancelShift();
     this.shift();
+  }
+
+  /**
+   * Drop any shift instantly — no tween, no pending request. The re-measure
+   * after a re-render needs the tile at its resting seat RIGHT NOW: mid-tween
+   * $el.offset() still carries part of the ±24px slide, and caching that put
+   * the drag zones beside their tiles (grid re-drags then worked only when
+   * the tween happened to have finished).
+   */
+  snapToRest() {
+    this.cancelShift();
+    this.el.removeAttribute("data-insert");
+    this._shiftX = 0;
+    TweenLite.set(this.$el, { x: 0 });
   }
 
   /**
@@ -245,12 +285,16 @@ class __media_grid extends DrumeeMediaInteract {
   }
 
   /**
-   * 
-   * @param {*} e 
+   *
+   * @param {*} e
    */
   _onStopShifting(e) {
     this._animIsActive = false;
-    this.initBounds();
+    // Re-measure only at rest. $el.offset() reads the TRANSFORMED position,
+    // so re-initing while pushed aside would bake the ±24px offset into the
+    // cached bbox — the insertion zones (seek_insertion computes them from
+    // bbox) would drift under the cursor and flip sides on their own.
+    if (!this._shiftX) this.initBounds();
   }
 
   /**

--- a/src/drumee/builtins/media/grid/skin/effects.scss
+++ b/src/drumee/builtins/media/grid/skin/effects.scss
@@ -58,3 +58,17 @@
   border-radius: 8px;
   animation: media-highlight-flash 1.2s ease-out 2;
 }
+
+// Drag-arrange insertion bar fade-in (bar itself: skin/index.scss
+// [data-insert]).
+@keyframes media-grid-insert-bar {
+  from {
+    opacity: 0;
+    transform: scaleY(0.6);
+  }
+
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}

--- a/src/drumee/builtins/media/grid/skin/index.scss
+++ b/src/drumee/builtins/media/grid/skin/index.scss
@@ -160,6 +160,48 @@
     &:before { @include grid-cell-fill(var(--grid-selected-bg)); }
   }
 
+  // Insertion indicator while arranging by drag: a vertical bar in the slot
+  // opened by the shifted tiles (grid/index.js sets data-insert on the tile
+  // anchoring the slot). Rides the root's ::after — the :before is taken by
+  // grid-cell-fill above — and moves with the tile's shift transform, so it
+  // sits centered in the widened gap without touching layout or the cached
+  // drag geometry.
+  // Insertion indicator: a dashed vertical marker standing in the opening the
+  // two flanking tiles make. A full tile-sized seat was tried and rejected —
+  // only those two tiles move, so a 120px opening ran over the neighbours
+  // behind it and clipped them. This keeps the dashed language at a width the
+  // 64px opening (--grid-gap + 2×24px shift) can hold cleanly.
+  &[data-insert] {
+    &:after {
+      content: " ";
+      position: absolute;
+      top: 4%;
+      width: 0;
+      height: 88%; // spans the card and its meta row, not just the icon
+      box-sizing: border-box;
+      border-left: 3px dashed var(--primary-500);
+      pointer-events: none;
+      z-index: 120;
+      animation: media-grid-insert-bar 0.15s ease-out;
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+  }
+
+  // The opening sits on the tile's trailing edge when it shifted left, on its
+  // leading edge when it shifted right (slot at row start). It spans
+  // --grid-gap + 2×SLOT_SHIFT; half the gap plus one shift lands the marker
+  // on its centre (the ::after rides the tile's own transform, so the shift
+  // itself is already accounted for). 1.5px trims half the border width.
+  &[data-insert="left"]:after {
+    right: calc(-1 * var(--grid-gap) / 2 - 24px + 1.5px);
+  }
+
+  &[data-insert="right"]:after {
+    left: calc(-1 * var(--grid-gap) / 2 - 24px + 1.5px);
+  }
+
   .content-preview {
     height: 100%;
     width: 100%;

--- a/src/drumee/builtins/media/interact.js
+++ b/src/drumee/builtins/media/interact.js
@@ -23,6 +23,10 @@ function _vignetteRemember(url, entry) {
 }
 require("./skin");
 const media_core = require("./core");
+const {
+  isMoveResultSuccessful,
+  selectCrossWorkspaceMoveService,
+} = require("./file-thread-move-route");
 const { copyToClipboard } = require("@drumee/ui-essentials")
 class __media_interact extends media_core {
   constructor(...args) {
@@ -1347,12 +1351,24 @@ class __media_interact extends media_core {
             .catch(() => dest.nid || '0');
         };
 
-        const moveToDestination = (dest) => resolvePid(dest).then((pid) => {
-          const movingAcrossWorkspaces = isCrossHub(dest) && isSingleDestinationMove;
-          const payload = isCrossHub(dest) ? {
-            service: movingAcrossWorkspaces
-              ? ((SERVICE.media && SERVICE.media.workspace_move) || 'media.workspace_move')
-              : SERVICE.media.copy,
+        const moveToDestination = async (dest) => {
+          const pid = await resolvePid(dest);
+          const crossHub = isCrossHub(dest);
+          const movingAcrossWorkspaces = crossHub && isSingleDestinationMove;
+          let service = crossHub ? SERVICE.media.copy : SERVICE.media.move;
+
+          if (movingAcrossWorkspaces) {
+            const infoService = (SERVICE.channel && SERVICE.channel.file_thread_info) ||
+              "channel.file_thread_info";
+            const threadInfo = await this.fetchService(infoService, {
+              hub_id: itemHubId,
+              file_nid: nid,
+            });
+            service = selectCrossWorkspaceMoveService(threadInfo, SERVICE);
+          }
+
+          const payload = crossHub ? {
+            service,
             nid,
             pid,
             action: movingAcrossWorkspaces ? _a.move : _a.copy,
@@ -1371,8 +1387,12 @@ class __media_interact extends media_core {
             notify: 1,
             moved_in: 1,
           };
-          return this.postService(payload).then((data) => data || Promise.reject(data));
-        });
+          const data = await this.postService(payload);
+          if (!isMoveResultSuccessful(service, data, SERVICE)) {
+            return Promise.reject(data);
+          }
+          return data;
+        };
 
         return Promise.all(targetDestinations.map(moveToDestination)).then(() => {
           if (!crossHubDestinations.length || isSingleDestinationMove) return;

--- a/src/drumee/builtins/media/interact.js
+++ b/src/drumee/builtins/media/interact.js
@@ -213,13 +213,20 @@ class __media_interact extends media_core {
       ox = 0;
       oy = 0;
     }
+    // $el.offset() reports the RENDERED position, shift transform included.
+    // Measuring a tile that is still parked in (or sliding back from) an
+    // insertion slot would bake that offset into the cache and leave the
+    // drag zones sitting beside the tiles they belong to. Subtract whatever
+    // shift is currently applied so bbox always describes the resting seat.
+    const sx = this._shiftX || 0;
+    const sy = this._shiftY || 0;
     this.self = null;
     this.left = null;
     this.right = null;
     this.over = null;
     this.bbox = new Rectangle(
-      o.left + ox,
-      o.top + oy,
+      o.left + ox - sx,
+      o.top + oy - sy,
       this.$el.width(),
       this.$el.height()
     );

--- a/src/drumee/builtins/media/row/index.js
+++ b/src/drumee/builtins/media/row/index.js
@@ -1,4 +1,6 @@
 
+const { TweenLite } = require("@drumee/ui-core/vendor");
+
 const MEDIA_TOGGLE = "madia-toggle";
 class __media_row extends DrumeeMediaInteract {
   constructor(...args) {
@@ -118,17 +120,17 @@ class __media_row extends DrumeeMediaInteract {
   // ===========================================================
   shift(side) {
     let y;
-    if (this._animIsActive) {
-      return;
-    }
     switch (side) {
+      // Enough of an opening to read as a gap without overrunning the rows
+      // behind — only these two move. Was ±2px, which barely nudged them and
+      // left nowhere to draw the dashed rule (media/skin/index.scss).
       case _a.left: case _a.top:
-        y = -2;
+        y = -5;
         this.el.dataset.shift = _a.top;
         break;
 
       case _a.right: case _a.bottom:
-        y = 2;
+        y = 5;
         this.el.dataset.shift = _a.bottom;
         break;
 
@@ -137,11 +139,19 @@ class __media_row extends DrumeeMediaInteract {
         y = 0;
     }
     this._shiftY = y;
-    // TweenLite.to(this.$el, .2, {
-    //   y,
-    //   onStart    : this._onStartShifting,
-    //   onComplete : this._onStopShifting
-    // });
+    // The tween was commented out, so data-shift flipped but nothing ever
+    // moved — there was no opening for an insertion seat to sit in. overwrite
+    // kills a conflicting slide instead of letting both run (GSAP default),
+    // which is what strands rows half-shifted.
+    const instant =
+      window.matchMedia &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    TweenLite.to(this.$el, instant ? 0 : .2, {
+      y,
+      overwrite: "auto",
+      onStart: this._onStartShifting,
+      onComplete: this._onStopShifting
+    });
   }
 
   // ===========================================================
@@ -151,7 +161,22 @@ class __media_row extends DrumeeMediaInteract {
     this.el.dataset.over = _a.off;
     this.el.dataset.hover = _a.off;
     this.el.dataset.shift = _a.off;
+    // A shift armed just before the drop must not land after this cleanup.
+    this.cancelShift();
     this.shift();
+  }
+
+  /**
+   * Drop any shift instantly — see the grid counterpart. The re-measure after
+   * a re-render (window/interact syncContent) needs resting positions: mid-
+   * tween $el.offset() still carries part of the slide, and caching that puts
+   * the drag zones beside the rows they belong to.
+   */
+  snapToRest() {
+    this.cancelShift();
+    this.el.dataset.shift = _a.none;
+    this._shiftY = 0;
+    TweenLite.set(this.$el, { y: 0 });
   }
 
   // ===========================================================

--- a/src/drumee/builtins/media/skin/index.scss
+++ b/src/drumee/builtins/media/skin/index.scss
@@ -48,25 +48,35 @@
       height: 12px;
     }
 
-    &[data-shift="top"] {
+    // Row-view insertion indicator: a full-width dashed rule in the opening
+    // the two flanking rows make. Was a 1px hard-coded blue hairline —
+    // effectively invisible while dragging. Dashed to match the grid marker;
+    // a row-height seat was tried and rejected for the same reason as there
+    // (only the two neighbours move, so a full-height opening overran the
+    // rows behind it).
+    &[data-shift="top"],
+    &[data-shift="bottom"] {
       &:after {
         content: " ";
         width: 100%;
-        height: 1px;
-        background-color: blue;
+        height: 0;
+        box-sizing: border-box;
+        border-top: 3px dashed var(--primary-500);
         position: absolute;
-        top: 100%;
+        pointer-events: none;
+        z-index: 120;
+      }
+    }
+
+    &[data-shift="top"] {
+      &:after {
+        top: calc(100% + 2px);
       }
     }
 
     &[data-shift="bottom"] {
       &:after {
-        content: " ";
-        width: 100%;
-        height: 1px;
-        background-color: blue;
-        position: absolute;
-        top: -1px;
+        top: -5px;
       }
     }
   }

--- a/src/drumee/builtins/widget/reward-flow/beacon.js
+++ b/src/drumee/builtins/widget/reward-flow/beacon.js
@@ -1,0 +1,86 @@
+/**
+ * A service POST that survives the page going away.
+ *
+ * The reward flow's unload guard has to report `dropped` from inside a
+ * `pagehide` handler, and a normal postService() cannot do it: the browser
+ * cancels in-flight fetches as soon as the document starts unloading, so the
+ * request is created and then thrown away. The funnel would record nothing and
+ * the user would stay `started` forever.
+ *
+ * WHY NOT navigator.sendBeacon
+ *
+ * The obvious tool, and the wrong one here. Session auth in this app rides on
+ * REQUEST HEADERS -- `x-param-keysel` plus `x-param-<keysel>`, built by
+ * makeHeaders in @drumee/ui-essentials -- and sendBeacon cannot set headers at
+ * all. Its only lever is the Blob's Content-Type. A beacon would therefore
+ * arrive unauthenticated, `this.uid` would be empty, and the row it was meant
+ * to advance belongs to nobody.
+ *
+ * fetch(..., { keepalive: true }) is the same guarantee WITH headers: the spec
+ * requires the request to outlive the document. Its 64 KB body cap is no
+ * constraint on a payload of four short strings.
+ *
+ * FAILING IS SAFE, and that is deliberate. If the request never lands -- an
+ * old browser that ignores `keepalive`, no network, a UA that kills it anyway
+ * -- the row simply stays where it was, which is exactly the behaviour before
+ * the unload guard existed. Nothing here is load-bearing enough to be worth a
+ * throw inside a pagehide handler, where an exception can block the unload.
+ */
+const { makeHeaders } = require("@drumee/ui-essentials");
+
+/**
+ * Post to a service without waiting for it, in a way the unload cannot cancel.
+ *
+ * @param {String} service the SERVICE.* path, e.g. SERVICE.reward.track
+ * @param {Object} [payload] request body; socket_id / device_id are added here
+ *   the way ui-essentials' own defaultPayload() adds them, so a beacon and a
+ *   normal postService carry the same envelope
+ * @returns {Boolean} whether a request was actually dispatched. Only ever used
+ *   for tests and logging -- there is no answer to wait for, and by the time
+ *   one could arrive the document is gone.
+ */
+function beaconPost(service, payload = {}) {
+  // Every one of these is absent in some legitimate context: `fetch` under an
+  // old UA, `bootstrap` before the app has booted, `Visitor` on a page that
+  // never signed in. A guard rather than an optional chain because `bootstrap`
+  // is a bare global -- `bootstrap?.()` still throws ReferenceError when it was
+  // never declared, the same trap libs/campaign documents.
+  if (typeof fetch !== "function") return false;
+  if (typeof bootstrap !== "function") return false;
+  if (!service) return false;
+
+  try {
+    const { svc } = bootstrap() || {};
+    if (!svc) return false;
+
+    const body = { ...payload };
+    if (typeof Visitor === "object" && Visitor) {
+      // Read defensively: this runs while the page is being torn down, and a
+      // Visitor mid-teardown is not worth failing the report over.
+      try {
+        body.socket_id = Visitor.get(_a.socket_id);
+        body.device_id = Visitor.deviceId();
+      } catch (e) { /* envelope only -- the service reads uid from the session */ }
+    }
+
+    fetch(`${svc}${service}`, {
+      method: "POST",
+      // The entire reason this module exists.
+      keepalive: true,
+      mode: "cors",
+      cache: "no-cache",
+      // The real auth headers, not a reimplementation of them. If the session
+      // header scheme ever changes, this changes with it.
+      headers: makeHeaders(),
+      body: JSON.stringify(body),
+    }).catch(() => { /* see the module docblock: failing is the old behaviour */ });
+
+    return true;
+  } catch (e) {
+    // Never propagate. A throw inside a pagehide handler can stall the very
+    // navigation the user just confirmed.
+    return false;
+  }
+}
+
+module.exports = { beaconPost };

--- a/src/drumee/builtins/widget/reward-flow/exit-guard.js
+++ b/src/drumee/builtins/widget/reward-flow/exit-guard.js
@@ -1,0 +1,293 @@
+/**
+ * Reward-flow exit guard.
+ *
+ * Every way out of the flow that happens INSIDE the app already asks "Don't
+ * drop now" — the vignette on a card step, __guide-scrim during a walkthrough,
+ * the backdrop beside a Step 2 surface. Three ways out walked straight past all
+ * of it: pressing F5, pressing Back, and closing the tab. The first two are the
+ * common ones during a walkthrough that has taken over the screen.
+ *
+ * WHAT A BROWSER WILL AND WILL NOT ALLOW.
+ *
+ * A page cannot render its own UI on unload. `beforeunload` can only raise the
+ * browser's NATIVE "Leave site?" dialog, whose wording is the browser's and not
+ * ours. So this module catches what can be caught BEFORE the page starts
+ * leaving, and raises the flow's own guard for those:
+ *
+ *   reload    F5 / Ctrl+R / Cmd+R (+Shift for a hard reload) — a keydown, so it
+ *             is cancellable, unlike Ctrl+W or Cmd+Q which the browser keeps
+ *             for itself.
+ *   navigate  the Back button, trapped with a history sentinel (see _push) so
+ *             the router never runs and the desk is never torn down.
+ *
+ * Both are things the user actually DID, which is the line this module holds.
+ * Watching the cursor leave through the top of the viewport would catch more —
+ * it is the classic exit-intent heuristic — but it guesses at an intention
+ * rather than reading an action, and it fires just as readily on someone
+ * reaching for a bookmark. A guard that interrupts a walkthrough on a guess is
+ * worse than one that misses a gesture.
+ *
+ * `beforeunload` is kept only as the last-resort net for what nothing can
+ * intercept — Cmd+W, the tab's close box, the address bar, and the browsers
+ * that refuse to let Cmd+R be cancelled. It posts nothing and shows no card.
+ *
+ * WHAT IT DOES NOT DO.
+ *
+ * It does not report anything to the funnel. "Drop anyway" remains the only
+ * outright abandon gesture and the only writer of `dropped`; a tab closed past
+ * the native dialog still leaves the row at `started`, which is what lets the
+ * flow resume from reward_claim.step on the next login instead of being closed
+ * off for a user who only meant to come back later.
+ *
+ * Split out of index.js for the same reason as steps.js and storage.js: the
+ * orchestrator extends the `LetcBox` global and cannot be required under bare
+ * Node, so none of the decisions below could be exercised without a browser.
+ * The two that are worth testing — which keystroke is a reload, and whether the
+ * flow is in a state worth guarding — are pure functions, and everything that
+ * touches `window` is guarded so the module loads anywhere.
+ */
+
+const { STEPS, baseStep } = require("./steps");
+
+/**
+ * Is this keystroke a request to reload the page?
+ *
+ * Shift is deliberately allowed through: Ctrl+Shift+R is a hard reload, which
+ * is the same intent and loses the same walkthrough. Alt is not — Alt+R opens a
+ * menu on some platforms and is nobody's refresh.
+ *
+ * @param {KeyboardEvent} e
+ * @returns {"reload"|null}
+ */
+function classifyKey(e) {
+  if (!e || e.altKey) return null;
+  if (e.key === "F5" && !e.ctrlKey && !e.metaKey) return "reload";
+  if (String(e.key || "").toLowerCase() === "r" && (e.ctrlKey || e.metaKey)) {
+    return "reload";
+  }
+  return null;
+}
+
+/**
+ * Is the flow in a state worth guarding?
+ *
+ * One predicate for all four signals, so there is a single place to reason
+ * about when the guard speaks up.
+ *
+ * An ALLOWLIST of the three card steps, not a denylist of terminal ones. The
+ * two differ only for a step name this module does not know about, and there
+ * the answers are opposite: a denylist raises a "Leave site?" dialog on it, an
+ * allowlist stays quiet. Quiet is the right failure — this predicate's whole
+ * job is deciding when to interrupt someone, and a state nobody anticipated is
+ * not evidence that interrupting them is warranted. It also means a fourth step
+ * cannot be added to the flow and silently inherit the guard.
+ *
+ * `baseStep` strips both `_waiting` and `_guide`, so the handoffs stay guarded:
+ * they are where users most often wander off, and excluding them would miss the
+ * common abandon.
+ *
+ * `congrats` and `soldout` fall out of the allowlist for free, which matters
+ * twice over. A "Leave site?" dialog between a user and their dashboard right
+ * after they have won is the worst possible moment for one; and it is what
+ * excludes a CAPPED run, which mounts straight into `soldout` — its vignette
+ * deliberately carries no click service either, because offering to talk a user
+ * out of leaving a flow they were never given would be nonsense.
+ *
+ * @param {String} step the orchestrator's current step
+ * @param {{finishing?: Boolean, guardOpen?: Boolean}} [flags]
+ * @returns {Boolean}
+ */
+function armed(step, { finishing = false, guardOpen = false } = {}) {
+  if (!STEPS.includes(baseStep(step))) return false;
+  // Already on its way out — there is nothing left to talk the user out of.
+  if (finishing) return false;
+  // The guard is already up. A second F5 while it is on screen is swallowed
+  // rather than re-raising it, which would restart its entry animation and
+  // replace the intent the user is currently being asked about.
+  if (guardOpen) return false;
+  return true;
+}
+
+/** Marks the history entry this module pushes, so a popstate can be told from
+ *  any other the app makes. */
+const SENTINEL = "reward-flow-exit-guard";
+
+class ExitGuard {
+  /** @param {Object} ui the reward_flow orchestrator. Must expose
+   *  exitArmed() and onExitIntent(). */
+  constructor(ui) {
+    this._ui = ui;
+    this._on = false;
+    // Our history entry is still the current one, i.e. Back has not been
+    // pressed since it was pushed.
+    this._sentinel = false;
+    // The flow is leaving deliberately (see resumeNavigate), so stop() must not
+    // try to tidy the history out from under it.
+    this._exiting = false;
+    this._onKey = null;
+    this._onPop = null;
+    this._onUnload = null;
+  }
+
+  // ───────── lifecycle ─────────
+
+  /** Begin guarding. No-op (safe) when there is no window. */
+  start() {
+    if (this._on || typeof window === "undefined") return;
+    this._on = true;
+    this._exiting = false;
+
+    // CAPTURE phase, like the Step 2 backdrop guard: the keystroke has to be
+    // cancelled before anything inside the desk acts on it.
+    this._onKey = (e) => {
+      if (classifyKey(e) !== "reload") return;
+      if (!this._armed()) return;
+      e.preventDefault();
+      e.stopPropagation();
+      this._raise({ kind: "reload" });
+    };
+    window.addEventListener("keydown", this._onKey, true);
+
+    // Back / Forward. See _push for why this is a sentinel rather than a
+    // hashchange listener.
+    this._onPop = () => {
+      if (!this._sentinel) return;   // not ours — the app navigated for itself
+      // Landing back ON our own entry means this pop consumed something the
+      // app pushed OVER it, not the sentinel. Leave the trap where it is.
+      if (this._isCurrent()) return;
+      this._sentinel = false;
+      if (!this._armed()) return;
+      this._raise({ kind: "navigate" });
+    };
+    window.addEventListener("popstate", this._onPop);
+
+    // The net under everything above.
+    this._onUnload = (e) => {
+      if (!this._armed()) return;
+      e.preventDefault();
+      // Assigned as well as prevented: the older browsers key their dialog off
+      // returnValue, and nothing else reads it.
+      e.returnValue = "";
+      return "";
+    };
+    window.addEventListener("beforeunload", this._onUnload);
+
+    this._push();
+  }
+
+  /** Unbind everything and give the history entry back. */
+  stop() {
+    if (!this._on) return;
+    this._on = false;
+    if (typeof window !== "undefined") {
+      if (this._onKey) window.removeEventListener("keydown", this._onKey, true);
+      if (this._onPop) window.removeEventListener("popstate", this._onPop);
+      if (this._onUnload) {
+        window.removeEventListener("beforeunload", this._onUnload);
+      }
+    }
+    this._onKey = null;
+    this._onPop = null;
+    this._onUnload = null;
+    // Pop our own entry, so the flow does not cost the user an extra Back press
+    // for the rest of the session. The listeners are already gone, so the
+    // popstate this fires is nobody's, and the URL is unchanged, so the router
+    // does not run.
+    //
+    // Two states must NOT be tidied. The flow leaving THROUGH the sentinel
+    // (resumeNavigate owns the history from here), and — the one that bites —
+    // the app having navigated ON TOP of it: this teardown is usually caused by
+    // exactly that, the desk module being destroyed under a route change, and
+    // a blind back() there would drag the user back to the page they just left.
+    // _isCurrent is what tells the two apart.
+    if (this._sentinel && !this._exiting && this._isCurrent()) {
+      this._sentinel = false;
+      this._history("back");
+    }
+  }
+
+  /** @returns {Boolean} our sentinel is the entry the browser is on right now,
+   *  rather than something the app has since pushed over it. */
+  _isCurrent() {
+    try {
+      return !!(typeof history !== "undefined" && history.state
+        && history.state[SENTINEL]);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // ───────── history sentinel ─────────
+
+  /**
+   * Push a duplicate of the current entry, so the FIRST Back press pops
+   * something of ours instead of leaving the desk.
+   *
+   * A hashchange listener cannot do this job: it fires after the router has
+   * already navigated, by which point the desk module — and the flow with it —
+   * is being torn down, so there is nothing left to raise a guard on and
+   * nothing to restore it to. The sentinel is consumed BEFORE any of that: the
+   * URL never changes, so the router never runs.
+   *
+   * Re-pushed by rearm() when the user chooses to stay, which is what puts the
+   * trap back for the next Back press.
+   */
+  _push() {
+    if (this._sentinel) return;
+    if (this._history("pushState")) this._sentinel = true;
+  }
+
+  /** Put the trap back after a guard the user dismissed with "Continue". */
+  rearm() {
+    if (!this._on) return;
+    this._push();
+  }
+
+  /**
+   * Carry out the Back the user was asking for, now that the flow has finished
+   * with it. The sentinel is already consumed, so one step back is the entry
+   * they were actually trying to reach.
+   */
+  resumeNavigate() {
+    this._exiting = true;
+    this._history("back");
+  }
+
+  /**
+   * Every history call in one guarded place. It is the one API here that can
+   * throw for reasons of its own (a sandboxed frame, a browser that refuses a
+   * same-URL push), and a guard that cannot manipulate history must still leave
+   * the rest of the flow working — the keystroke and beforeunload nets do not
+   * depend on it.
+   *
+   * @returns {Boolean} the call went through
+   */
+  _history(op) {
+    if (typeof history === "undefined") return false;
+    try {
+      if (op === "back") {
+        history.back();
+        return true;
+      }
+      if (typeof history.pushState !== "function") return false;
+      history.pushState({ [SENTINEL]: 1 }, "", location.href);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // ───────── plumbing ─────────
+
+  _armed() {
+    return typeof this._ui?.exitArmed === "function" && this._ui.exitArmed();
+  }
+
+  _raise(intent) {
+    if (typeof this._ui?.onExitIntent === "function") {
+      this._ui.onExitIntent(intent);
+    }
+  }
+}
+
+module.exports = { ExitGuard, classifyKey, armed, SENTINEL };

--- a/src/drumee/builtins/widget/reward-flow/index.js
+++ b/src/drumee/builtins/widget/reward-flow/index.js
@@ -52,6 +52,13 @@ const { visible: onScreen } = require("./guide-core");
 const {
   KEY_WORKSPACE, runGet, runSet, runDel, purgeLegacyKeys,
 } = require("./storage");
+// Refresh and Back — the ways out the flow's own surfaces never saw.
+// See exit-guard.js.
+const { ExitGuard, armed: exitArmed } = require("./exit-guard");
+// A POST that outlives the document, for the exits the guard above cannot
+// intercept — an ordinary postService is cancelled the moment the page starts
+// unloading. See beacon.js.
+const { beaconPost } = require("./beacon");
 
 // Recorded on every funnel post so the row says which campaign it belongs to.
 // Must match the utm_campaign analytics-server puts on the claim-reward email
@@ -81,6 +88,14 @@ const PANEL_OPEN_TIMEOUT_MS = 8000;
 // outlast any settle window, and a fixed one left the hole collapsed and the
 // popup sitting in the dim.
 const TARGET_WAIT_MS = 8000;
+
+// How long "Drop anyway" waits for its status post before leaving anyway.
+// That exit can be a RELOAD, and a request still in flight when the page goes
+// is a request the funnel never sees — so this one post is awaited, alone with
+// the completion claim. Bounded because the cost of waiting is a user staring
+// at a guard they have already dismissed: past this, the funnel losing a row is
+// the cheaper failure.
+const DROP_POST_TIMEOUT_MS = 1500;
 
 // The surfaces Step 2 hands the user to, all fed into the shared wrapper-modal:
 // the internal permission panel Step 1 ends on (onInvitePanel) OR the invite
@@ -154,6 +169,14 @@ class __reward_flow extends LetcBox {
     this._modalOpen = false;
     this._inviteSucceeded = false;
     this._dropGuardOpen = false;
+    // What the user was trying to do when the guard went up — a reload, a Back
+    // press — so "Drop anyway" can carry it out instead of discarding it and
+    // making them ask twice. Null when the guard was raised by a click on the
+    // vignette, which is already where the user meant to be.
+    this._pendingExit = null;
+    // "Drop anyway" is in flight (its status post is awaited before the exit
+    // fires), so a second click is ignored rather than finishing twice.
+    this._leaving = false;
     // Step 2 is being served by the permission panel Step 1 ended on, not by
     // the invite popup — see onInvitePanel. Never restored on resume: the panel
     // is long gone by then, so a reload resumes on the plain Step 2 card.
@@ -195,6 +218,12 @@ class __reward_flow extends LetcBox {
       RADIO_BROADCAST.on("workspace:refresh", this._onWorkspaceRefresh);
       RADIO_BROADCAST.on("invitation:sent", this._onPanelInvitation);
     }
+
+    // Started unconditionally: a capped run is turned away by exitArmed()
+    // below, not by declining to watch, so there is one place that decides when
+    // the guard speaks up.
+    this._exitGuard = new ExitGuard(this);
+    this._exitGuard.start();
   }
 
   onDomRefresh() {
@@ -274,6 +303,14 @@ class __reward_flow extends LetcBox {
       window.removeEventListener("resize", this._onStepResize);
       this._onStepResize = null;
     }
+    // Both unconditionally, not through their arming predicates: by the time
+    // _unbind runs the flow is leaving whatever its step still says, and either
+    // listener outliving the widget would act on a desk that no longer has a
+    // reward flow on it.
+    if (this._exitGuard) {
+      this._exitGuard.stop();
+    }
+    this._releaseUnloadGuard();
     this._stopGuide();
     this._stopUploadGuide();
     this._clearOpenTimer();
@@ -592,7 +629,11 @@ class __reward_flow extends LetcBox {
    * reason (see _finish). Letting it write would put team accounts in the
    * campaign funnel — and would burn a real slot on a test.
    *
-   * @param {String} status "started" | "dropped" | "done" | "missed"
+   * @param {String} status "started" | "left" | "dropped" | "done" |
+   *   "missed". "left" arrives here from an INTERCEPTED exit, where the page
+   *   has not started leaving yet and an ordinary post still works; the
+   *   uncatchable exits report it through _beaconLeft instead, because by
+   *   then nothing but a keepalive request survives.
    * @param {String} [step] defaults to the current card step
    * @returns {Promise<Object|null>} the service's answer, or null when nothing
    *   was posted or the post failed
@@ -630,6 +671,120 @@ class __reward_flow extends LetcBox {
     this._track("started", base);
   }
 
+  // ───────── leaving the page ─────────
+
+  /**
+   * Should an unreported exit be recorded right now?
+   *
+   * Every ACTIVE step, and nothing else. baseStep strips `_waiting` and
+   * `_guide`, so the handoffs count too — being parked in the invite popup or
+   * the uploader is where users most often wander off, and those are exactly
+   * the runs worth catching.
+   *
+   * `congrats` and `soldout` fall out for free: neither survives baseStep into
+   * STEPS. A user who has already won or already been turned away has no
+   * abandon left to record.
+   *
+   * A ?reward=1 run reports nothing, matching _track — letting it write would
+   * put team accounts in the campaign funnel.
+   *
+   * SHARES ITS STEP TEST with exit-guard's `armed()` but not its flags, and the
+   * difference is deliberate. `_dropGuardOpen` disarms the GUARD, so a second
+   * F5 does not replace the intent already on screen; it must not disarm the
+   * REPORT, because a user who closes the tab while the card is up has still
+   * left. `_finishing` is excluded from both: the flow is on its way out under
+   * its own steam, and "Drop anyway" reports for itself.
+   */
+  _shouldReportUnload() {
+    if (this._forced || this._finishing) return false;
+    return STEPS.includes(baseStep(this._step));
+  }
+
+  /**
+   * Arm or disarm the unload REPORT to match the current step.
+   *
+   * Idempotent, because it is called from both _goto and onDomRefresh and most
+   * calls are no-ops: the listener is only touched when the answer changes.
+   *
+   * ONE EVENT, ONE JOB. `beforeunload` — the half that raises the browser's own
+   * "Leave site?" dialog — belongs to exit-guard.js, which owns every signal
+   * that ASKS the user something. This half only reports, on `pagehide`, and
+   * the split across the two events is what makes "if they confirmed" work with
+   * no state of our own: choosing Stay aborts the navigation and pagehide never
+   * fires, so nothing is written. Choosing Leave lets it through and the report
+   * goes out.
+   *
+   * Registering `beforeunload` here as well — which is what the two designs did
+   * separately — would give one dialog two owners and leave the arming rules
+   * for it in two places.
+   */
+  _syncUnloadGuard() {
+    if (typeof window === "undefined") return;
+    const want = this._shouldReportUnload();
+    if (want === !!this._unloadBound) return;
+
+    if (want) {
+      this._onPageHide = (e) => {
+        // BFCACHE IS NOT LEAVING. A page frozen for the back/forward cache
+        // fires pagehide with persisted=true and may be restored intact,
+        // widget and all — and on restore nothing re-posts `started`, because
+        // _trackedStep still holds it. Reporting a drop here would leave the
+        // row saying "gone" for a user who is about to be looking at the flow
+        // again.
+        if (e && e.persisted) return;
+        this._beaconLeft();
+      };
+      window.addEventListener("pagehide", this._onPageHide);
+      this._unloadBound = true;
+      return;
+    }
+
+    this._releaseUnloadGuard();
+  }
+
+  /** Drop the listener. Separate from _syncUnloadGuard so _unbind can call it
+   *  outright on the way out, without reasoning about the current step. */
+  _releaseUnloadGuard() {
+    if (typeof window === "undefined") return;
+    if (this._onPageHide) {
+      window.removeEventListener("pagehide", this._onPageHide);
+      this._onPageHide = null;
+    }
+    this._unloadBound = false;
+  }
+
+  /**
+   * Report the abandon on the way out, through a request the unload cannot
+   * cancel (see beacon.js for why postService cannot do this).
+   *
+   * `left` is NOT terminal. yp.reward_claim_track ranks it below `started` and
+   * reward.get_state counts it as OPEN, so this records that the user went away
+   * without costing them the reward: they come back, resume from `step`, and
+   * their next `started` post clears it by itself. That
+   * matters most for the case this guard exists to catch — a plain refresh,
+   * which is indistinguishable from a close at unload time and must not be
+   * allowed to forfeit a prize the user is three clicks from claiming.
+   *
+   * @returns {Boolean} whether a request went out; for tests, not for callers.
+   */
+  _beaconLeft() {
+    if (this._forced) return false;
+    try {
+      if (typeof SERVICE === "undefined" || !SERVICE.reward || !SERVICE.reward.track) {
+        return false;
+      }
+      return beaconPost(SERVICE.reward.track, {
+        hub_id: Visitor.id,
+        status: "left",
+        step: baseStep(this._step),
+        campaign: CAMPAIGN,
+      });
+    } catch (e) {
+      /* reporting must never obstruct the unload */
+      return false;
+    }
+  }
+
   // ───────── skeleton accessors ─────────
 
   getStep() { return this._step; }
@@ -638,6 +793,13 @@ class __reward_flow extends LetcBox {
 
   _render() {
     this.feed(require("./skeleton")(this));
+    // Here rather than in _goto, because _goto is not the only way the step
+    // moves: _completeStep3 and _openSoldOut both assign this._step directly
+    // and re-render (deliberately — neither "congrats" nor "soldout" may be
+    // persisted as a resumable step). Arming off the render catches all three,
+    // so reaching a terminal screen always lifts the guard and nobody is
+    // prompted with "Leave site?" on their way out of a flow they finished.
+    this._syncUnloadGuard();
     this._positionStepTarget();
   }
 
@@ -1563,6 +1725,62 @@ class __reward_flow extends LetcBox {
     }
   }
 
+  // ───────── leaving the page ─────────
+
+  /**
+   * Is the flow in a state worth guarding? Read by the exit guard before it
+   * acts on ANY of its signals (see exit-guard.js).
+   *
+   * The decision itself is the pure `armed` there, so it can be exercised
+   * without a browser; this only supplies the state it reads.
+   */
+  exitArmed() {
+    if (this.isDestroyed?.()) return false;
+    return exitArmed(this._step, {
+      finishing: this._finishing,
+      guardOpen: this._dropGuardOpen,
+    });
+  }
+
+  /**
+   * The user made a move that would take the page away from the flow — a
+   * refresh keystroke or the Back button. The guard has already stopped it
+   * happening; this is where the flow decides what to say about it.
+   *
+   * Same card as every other abandon gesture, deliberately: "Don't drop now"
+   * asks the same question whether it was raised by a click on the vignette or
+   * by F5, and a second variant would be one more string to translate for no
+   * new information.
+   *
+   * The intent is REMEMBERED so "Drop anyway" can carry it out rather than
+   * discarding it and making the user ask twice.
+   *
+   * @param {{kind: "reload"|"navigate"}} intent
+   */
+  onExitIntent(intent) {
+    if (!this.exitArmed()) return;
+    this._pendingExit = intent || null;
+    this._openDropGuard();
+  }
+
+  /**
+   * Do the thing the user originally asked for, once the flow has finished
+   * getting out of its way.
+   *
+   * Called after _finish, never before: a reload that fired first would take
+   * the page with it while the status post was still in flight and the
+   * handed-off surfaces were still open.
+   */
+  _resumeExit(exit) {
+    if (!exit || typeof window === "undefined") return;
+    try {
+      if (exit.kind === "reload") return location.reload();
+      if (exit.kind === "navigate") return this._exitGuard?.resumeNavigate();
+    } catch (e) {
+      /* the flow is already gone; a failed exit just leaves the user here */
+    }
+  }
+
   // ───────── modals ─────────
 
   /**
@@ -1895,16 +2113,62 @@ class __reward_flow extends LetcBox {
         // back what was underneath: the card, the guide mid-walkthrough, or the
         // invite popup with whatever they had typed. Nothing was torn down, so
         // there is nothing to restore.
+        //
+        // Whatever raised the guard is cancelled with it — "Continue" means
+        // stay, so a refresh the user has thought better of must not still be
+        // waiting to happen behind the card. The Back trap is re-armed for the
+        // next press (the sentinel was consumed getting here).
+        this._pendingExit = null;
+        this._exitGuard?.rearm();
         this._closeDropGuard();
         return;
 
-      case "reward-drop-leave":
-        // "Drop anyway" is the only place the user says outright that they are
-        // abandoning the flow, so it is the only place `dropped` is written.
-        // Closing the tab mid-flow leaves them at `started`, which is the
-        // honest reading: they never told us either way.
-        this._track("dropped");
-        return this._finish();
+      case "reward-drop-leave": {
+        // WHICH STATUS THIS WRITES DEPENDS ON WHO RAISED THE GUARD, and getting
+        // that wrong locked a real tester out of the campaign (row 1213 on
+        // stage, 2026-08-08).
+        //
+        // Three intents reach this one button, and only one of them refuses the
+        // offer:
+        //
+        //   vignette / scrim click  — the user went looking for the way out.
+        //     That is an answer, and it writes `dropped`: TERMINAL, so we stop
+        //     asking at every login.
+        //   intercepted F5 / Back   — the user asked to RELOAD or GO BACK, and
+        //     we interrupted them to ask about it. Pressing "Drop anyway" here
+        //     means "yes, do the thing I asked for", not "I do not want the
+        //     reward". It writes the recoverable `left`.
+        //
+        // Reporting the second as `dropped` inverted the whole design by
+        // information: a closed tab, where we know NOTHING, stayed recoverable,
+        // while an intercepted refresh — where we know exactly what the user
+        // meant, and know it was benign — was terminal. Phase 2 exists to stop
+        // one stray F5 costing someone a prize; routing that same F5 into this
+        // button did it anyway, just with a confirmation on top.
+        //
+        // `_pendingExit` is the discriminator and needs no new state: it is set
+        // only by onExitIntent, cleared by "Continue", and null whenever the
+        // user raised the card themselves.
+        //
+        // The post is AWAITED here, unlike every other tracking call: this exit
+        // can be a RELOAD, and a request still in flight when the page goes is
+        // a row the funnel never sees. Bounded by DROP_POST_TIMEOUT_MS so a
+        // hung network cannot strand the user on a guard they have dismissed.
+        if (this._leaving) return;
+        this._leaving = true;
+        const exit = this._pendingExit;
+        this._pendingExit = null;
+        const post = this._track(exit ? "left" : "dropped");
+        const settled = Promise.race([
+          post,
+          new Promise((r) => setTimeout(r, DROP_POST_TIMEOUT_MS)),
+        ]);
+        settled.then(() => {
+          this._finish();
+          this._resumeExit(exit);
+        });
+        return;
+      }
 
       case "reward-finish":
         // Congrats' "Go to dashboard" — onUploadDone already reported `done`.

--- a/src/drumee/builtins/window/core.js
+++ b/src/drumee/builtins/window/core.js
@@ -859,7 +859,14 @@ class __window_core extends __utils {
       .catch((e) => {
         aw.spinner(0);
         this.warn("newDocument: server error", e);
-        Wm.alert(LOCALE.ERROR_NETWORK);
+        // A refusal is not a network failure. media.save / euroffice.new_doc
+        // answer 403 when the viewer lacks the write bit, and reporting that as
+        // "a network error" sent people looking for a connection problem instead
+        // of telling them they lack the right. Anything else keeps the old
+        // message — a 500 or a dead connection must NOT be reported as a
+        // permission problem (the inverse mistake, see webrtc/room/index.js).
+        const status = e && (e.status || e.error_code);
+        Wm.alert(status == 403 ? LOCALE.WEAK_PRIVILEGE : LOCALE.ERROR_NETWORK);
         if (this.onServerError) this.onServerError(e);
       });
   }

--- a/src/drumee/builtins/window/core.js
+++ b/src/drumee/builtins/window/core.js
@@ -2,10 +2,11 @@ const CHANGE_RADIO = "change:radio";
 const MEDIA_GRID = "media_grid";
 const MEDIA_ROW = "media_row";
 const EOD = "end:of:data";
+// Rows the listing proc returns per page (pageToLimits in the schemas repo).
+// Used to tell a fully-loaded folder from a partially-loaded one before
+// renumbering ranks — see _syncOrder.
+const PAGE_SIZE = 45;
 const __utils = require("./utils");
-const TIMERS = {
-  reorder: null,
-};
 
 const { TweenLite, TimelineMax, TweenMax } = require("@drumee/ui-core/vendor");
 
@@ -167,14 +168,78 @@ class __window_core extends __utils {
    *
    * @param {*} cb
    */
+  /**
+   * localStorage key holding "this folder is manually arranged", so a
+   * reopened window lists by rank instead of falling back to the mtime
+   * default set in initialize(). Without it the ranks were persisted server
+   * side but never asked for again — the arrangement looked lost.
+   * @returns {String|null}
+   */
+  _arrangedSortKey() {
+    const { nid, hub_id } = this.actualNode ? this.actualNode() : {};
+    if (!nid || !hub_id) return null;
+    return `folder-arranged-${hub_id}-${nid}`;
+  }
+
+  /**
+   * Remember that the user arranged this folder by hand.
+   */
+  _rememberArrangedSort() {
+    const key = this._arrangedSortKey();
+    if (!key) return;
+    try {
+      localStorage.setItem(key, "1");
+    } catch (e) {
+      this.warn("could not persist the arranged-sort preference", e);
+    }
+  }
+
+  /**
+   * Forget the manual arrangement — the user picked an explicit sort, which
+   * takes over from here.
+   */
+  _forgetArrangedSort() {
+    const key = this._arrangedSortKey();
+    if (!key) return;
+    try {
+      localStorage.removeItem(key);
+    } catch (e) {
+      this.warn("could not clear the arranged-sort preference", e);
+    }
+  }
+
+  /**
+   * Whether this folder was arranged by hand before (see above).
+   * @returns {Boolean}
+   */
+  _hasArrangedSort() {
+    const key = this._arrangedSortKey();
+    if (!key) return false;
+    try {
+      return localStorage.getItem(key) === "1";
+    } catch (e) {
+      return false;
+    }
+  }
+
   _syncOrder(cb) {
+    // Consume the arrange request up front: every early return below ends
+    // THIS sync, and a flag left set would make some later, unrelated sync
+    // (an upload, a move-in) switch the window to rank order on its behalf.
+    const manual = this._manualArrange;
+    this._manualArrange = 0;
     if (this.iconsList == null || this.iconsList.isDestroyed()) {
       this.iconsList = this.findPart(_a.list);
     }
     if (!this.iconsList || this.iconsList.isDestroyed() || !this.iconsList.collection) {
       return;
     }
-    if (this.getViewMode() === _a.row) {
+    // Row view historically never persisted an order: it could not express
+    // an insertion slot, so every drop appended and renumbering would have
+    // scrambled the folder. It arranges like the grid now, so an explicit
+    // arrange request persists — anything else (upload, move-in) still does
+    // not, exactly as before.
+    if (this.getViewMode() === _a.row && !manual) {
       return;
     }
     if (!(_K.permission.modify & this.mget(_a.privilege))) {
@@ -185,8 +250,32 @@ class __window_core extends __utils {
     // desc) this would overwrite the whole folder's manual arrangement with
     // the current sort order — for every member — after any routine upload
     // or drop.
+    //
+    // The one exception is the user dragging a tile into an insertion slot:
+    // that IS a request for a manual arrangement, so the window adopts rank
+    // order and the drop survives a reload instead of snapping back. The
+    // flag is set by Wm.insert alone — never by an upload, move-in or paste.
     if (this._currentApi && this._currentApi.name !== _a.rank) {
-      return;
+      if (!manual) {
+        return;
+      }
+      // mfs_reorder only writes the nids we send, and the listing is paged
+      // (45 rows, pageToLimits). With a partially loaded folder the unseen
+      // files would keep their old rank — mostly 0 — and jump to the front
+      // the moment the window switched to rank order. Rearranging stays
+      // view-only there; a full page is the case we can renumber honestly.
+      if (this.iconsList.collection.length >= PAGE_SIZE) {
+        return;
+      }
+      this.setCurrentApi({ name: _a.rank, order: _K.order.ascending });
+      this._rememberArrangedSort();
+    }
+    // A comparator left on the collection (sortContent / the folder window's
+    // alphabetical grid sort) makes Backbone re-sort on every add, which
+    // silently undoes the arrangement we are about to persist. Drop it: from
+    // here the displayed order IS the stored order.
+    if (this.iconsList.collection.comparator) {
+      this.iconsList.collection.comparator = null;
     }
     const list = [];
     let i = 0;
@@ -221,18 +310,22 @@ class __window_core extends __utils {
     if (!Visitor.isOnline()) {
       return;
     }
-    let timeout = 1500;
-    if (TIMERS.reorder) {
-      clearTimeout(TIMERS.reorder);
-      TIMERS.reorder = setTimeout(() => {
-        TIMERS.reorder = null;
-        this._syncOrder(cb);
-      }, timeout);
+    // Only an explicit drag-arrange writes ranks now. The old behaviour —
+    // every insert (upload, move-in, paste, WS echo) scheduling a debounced
+    // renumber — is what made a drop look like it had not been saved: a
+    // later insert's sync would re-send the pre-drop order and overwrite it.
+    if (!this._manualArrange) {
       return;
     }
-    TIMERS.reorder = setTimeout(() => {
+    // Per-window timer. This used to be a module-global, so with two folder
+    // windows open a drop in one cancelled the other's pending sync — the
+    // first window then never ran _syncOrder and its _manualArrange flag
+    // survived to fire on some later, unrelated sync.
+    clearTimeout(this._reorderTimer);
+    this._reorderTimer = setTimeout(() => {
+      this._reorderTimer = null;
       this._syncOrder(cb);
-    }, timeout);
+    }, 400);
   }
 
   /**
@@ -715,6 +808,15 @@ class __window_core extends __utils {
     if (!this.iconsList || this.iconsList.isDestroyed() || !this.iconsList.collection) {
       return;
     }
+    // An automatic sort (no cmd — the folder window's alphabetical grid pass)
+    // must never touch a hand-arranged folder: its comparator would re-order
+    // the collection on every add and wipe the arrangement. An explicit sort
+    // from the UI still wins — the user asked for it — and drops the marker
+    // so the folder stops claiming to be hand-arranged.
+    if (!cmd && this._hasArrangedSort && this._hasArrangedSort()) {
+      return;
+    }
+    if (cmd) this._forgetArrangedSort();
     let order, name;
     if (cmd) {
       name = cmd.model.get(_a.name);
@@ -790,19 +892,10 @@ class __window_core extends __utils {
           Wm.alert(LOCALE.ERROR_NETWORK);
           return;
         }
-        // Per design the new file no longer opens by itself: show the small
-        // bottom-right "file created" card and let the user decide — the
-        // card's click handler (Wm.openCreatedFile) runs the same tile /
-        // node_info open route this method used when it still auto-opened.
-        if (window.Wm && _.isFunction(Wm.notifyFileCreated)) {
-          Wm.notifyFileCreated({
-            nid: data.nid,
-            hub_id: data.hub_id || hub_id,
-            filename: data.filename || data.name || name,
-          });
-          return;
-        }
-        // Legacy fallback (wm without the card, e.g. dmz): open the editor
+        // The new file opens in its editor right away: in a busy folder the
+        // grid gives no cue where the created file landed, so waiting for
+        // the user to find it (the "file created" card flow — infra still in
+        // wm/index.js, currently caller-less) left them lost. Open the editor
         // straight from the response (like the DMZ file-share branch)
         // instead of gating it behind the media.new broadcast + a 500ms
         // poll: a delayed or dropped broadcast used to dead-end the whole
@@ -1159,16 +1252,34 @@ class __window_core extends __utils {
           hub_id,
         };
         break;
-      default:
+      default: {
+        // initialize() hard-resets _currentApi to mtime on every open, so a
+        // folder the user had arranged by hand came back in mtime order and
+        // the saved ranks were never asked for. Re-adopt rank here when this
+        // folder carries the arranged marker.
+        let sort = this._currentApi.name;
+        let order = this._currentApi.order;
+        if (sort !== _a.rank && this._hasArrangedSort()) {
+          sort = _a.rank;
+          order = _K.order.ascending;
+          this.setCurrentApi({ name: sort, order });
+        }
+        if (sort === _a.rank && this.iconsList && this.iconsList.collection) {
+          // The server is about to hand back the manual order; a leftover
+          // filename comparator would immediately re-sort it away.
+          this.iconsList.collection.comparator = null;
+        }
         api = {
           service: SERVICE.media.show_node_by,
           page: 1,
           nid,
-          sort: this._currentApi.name,
-          order: this._currentApi.order,
+          sort,
+          order,
           hub_id,
           usePid: this.model.get("usePid"),
         };
+        break;
+      }
     }
     if (this.mget(_a.token)) {
       api.token = this.mget(_a.token);

--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -1448,6 +1448,14 @@ class __window_folder extends mfsInteract {
         return this.openAdvancedSettings(cmd);
 
       case "folder-manage-access":
+        // Belt for the two hidden entry points (topbar icon + overflow menu):
+        // the panel mints secure-share links that can grant can_edit, and
+        // secure_share.create now refuses without the write bit. Refuse here so
+        // a stale DOM or a deep link cannot open a panel that can only fail.
+        if (this.canUpload && !this.canUpload()) {
+          if (window.Butler && Butler.say) Butler.say(LOCALE.WEAK_PRIVILEGE);
+          return;
+        }
         return this.openManageAccess();
 
       case "folder-rename":

--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -520,6 +520,13 @@ class __window_folder extends mfsInteract {
 
   _scheduleAlphabeticalGridSort(list = this.iconsList) {
     if (!this._isFolderGridMode()) return;
+    // A hand-arranged folder must not be re-sorted by filename behind the
+    // user's back. sortContent() installs a filename comparator on the
+    // collection, and Backbone then keeps re-applying it on every add — so
+    // a dropped tile snapped back and the saved ranks were overwritten by
+    // the next sync. This is why arranging worked in row view (which never
+    // schedules this sort) but not in grid.
+    if (this._hasArrangedSort && this._hasArrangedSort()) return;
     if (!list || (list.isDestroyed && list.isDestroyed())) return;
     if (this._folderGridSortTimer) clearTimeout(this._folderGridSortTimer);
     this._folderGridSortTimer = setTimeout(() => {

--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -4015,6 +4015,12 @@ class __window_folder extends mfsInteract {
             return view.append({
               kind: "tasks_panel",
               hub_id: this.mget(_a.hub_id),
+              // Creating a task is an EDIT-tier action (task.create is
+              // `src: write`), and the panel is a LetcBox with no privilege of
+              // its own — so hand it this window's answer, the same
+              // canUpload() the "+ New" gate uses. Only an explicit false
+              // hides the add buttons, so any older/absent value stays as-is.
+              may_write: !!(this.canUpload && this.canUpload()),
               // Upload/destination nid: for a hub-level window the working nid
               // is actual_home_id, not the hub_id itself (else media.upload 403).
               nid: destNid,

--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -1035,9 +1035,25 @@ class __window_folder extends mfsInteract {
       // filename workspace root takes its name from hub_name). Set `child`
       // DIRECTLY — calling ensurePart for this part here would replay
       // onPartReady and loop forever.
+      //
+      // `child.set()` re-enters this handler: set → mould → render →
+      // onBeforeRender → registerPart → triggerMethod(part:ready) → here. That
+      // recursed ~945 times on every folder open, until the stack overflowed
+      // and mould()'s own try/catch swallowed the RangeError — invisible, but
+      // it burned ~1.2s of main thread and pushed the content listing
+      // (media.show_node_by) from ~0.9s to ~2.2s after the click. Write only
+      // when the title actually differs, and never re-enter.
       const name = this.mget(_a.filename) || this.model.get("hub_name");
+      const shown = child && _.isFunction(child.mget) ? child.mget("content") : null;
+      if (name && String(shown) === String(name)) return; // already painted
+      if (this._namingWindow) return;
       if (name && _.isFunction(child.set)) {
-        child.set({ content: name });
+        this._namingWindow = 1;
+        try {
+          child.set({ content: name });
+        } finally {
+          this._namingWindow = 0;
+        }
       } else if (!name && !this.mget(_a.headless)) {
         // Opened without a seeded name (e.g. openFileLocation revealing a hit
         // in a hub/workspace ROOT — media.attributes carries no display name
@@ -1059,7 +1075,9 @@ class __window_folder extends mfsInteract {
     const hub_id = this.mget(_a.hub_id);
     if (!nid || !hub_id) return;
     this._titleResolving = 1;
-    this.fetchService(SERVICE.media.get_path, { nid, hub_id })
+    // Wm.loadWorkspace is very likely asking for this same path right now —
+    // share its request rather than adding a second one (libs/path-request).
+    require("libs/path-request").getPath(this, { nid, hub_id })
       .then((data) => {
         if (this.isDestroyed && this.isDestroyed()) return;
         if (!_.isEmpty(data)) this.refreshBreadcrumbsUI(data);

--- a/src/drumee/builtins/window/folder/skeleton/meeting-schedule.js
+++ b/src/drumee/builtins/window/folder/skeleton/meeting-schedule.js
@@ -529,7 +529,16 @@ module.exports = function meetingSchedule(ui) {
     : active
       ? LOCALE.JOIN_MEETING || "Join meeting"
       : LOCALE.START_A_MEETING;
-  const startBtn = Skeletons.Button.Label({
+  // Starting and scheduling are EDIT-tier actions; JOINING is not. So this
+  // button is dropped only when it would START one — a live meeting (active) or
+  // one we are already in (joined) keeps it, which is exactly what view and chat
+  // are entitled to and mirrors conference_join's own rule (it refuses a start
+  // only when no conference is active for the hub).
+  // canUpload() is the folder window's own write test, the same one
+  // syncNewCtrlVisibility uses; absent → treated as allowed (fail-open).
+  const mayStart =
+    typeof ui.canUpload !== "function" ? true : !!ui.canUpload();
+  const startBtn = (!mayStart && !joined && !active) ? "" : Skeletons.Button.Label({
     className: `${pfx}-sched-start-btn`,
     ico: "meet-camera",
     label: startLabel,
@@ -543,7 +552,9 @@ module.exports = function meetingSchedule(ui) {
   });
 
   // Opens the create modal (skeleton/meeting-modal.js) via open-schedule.
-  const scheduleBtn = Skeletons.Note({
+  // Scheduling always writes a `schedule` node (room.book asks for the write
+  // bit), so unlike Start it has no join-equivalent and simply goes.
+  const scheduleBtn = !mayStart ? "" : Skeletons.Note({
     className: `${pfx}-sched-schedule-btn`,
     content: LOCALE.SCHEDULE,
     service: "open-schedule",

--- a/src/drumee/builtins/window/folder/skeleton/settings-action-panel.js
+++ b/src/drumee/builtins/window/folder/skeleton/settings-action-panel.js
@@ -1,15 +1,45 @@
+// Each row carries the capability it needs, so the panel offers only what the
+// viewer can actually do. The server already refuses the rest — media.download
+// asks for the download bit; rename / move / trash ask for `src: delete` and
+// duplicate for `src: write`, all the same write-tier bit — so this stops the
+// panel presenting five actions that end in a 403 (which is how a view member
+// could rename a column-like action and see it silently not persist).
+//   "download" -> download bit (view ✗, chat ✓)
+//   "write"    -> write bit    (view ✗, chat ✗, edit ✓)
 const actions = [
-  { service: _e.download, label: LOCALE.DOWNLOAD, ico: "file-download" },
-  { service: "folder-rename", label: LOCALE.RENAME, ico: "apps-pencil-simple" },
-  { service: "folder-organize", label: LOCALE.ORGANIZE, ico: "file-organize" },
-  { service: "folder-duplicate", label: LOCALE.DUPLICATE, ico: "file-copy" },
+  { service: _e.download, label: LOCALE.DOWNLOAD, ico: "file-download", need: "download" },
+  { service: "folder-rename", label: LOCALE.RENAME, ico: "apps-pencil-simple", need: "write" },
+  { service: "folder-organize", label: LOCALE.ORGANIZE, ico: "file-organize", need: "write" },
+  { service: "folder-duplicate", label: LOCALE.DUPLICATE, ico: "file-copy", need: "write" },
   {
     service: "folder-delete",
     label: LOCALE.DELETE,
     ico: "trash-action",
     destructive: 1,
+    need: "write",
   },
 ];
+
+/**
+ * Filter the action rows to what this viewer may actually perform.
+ * canUpload() / canDownload() are the window's own tests (the same ones
+ * syncNewCtrlVisibility and the context menus use). If either is missing the
+ * row is KEPT — fail-open, so an unreadable privilege can never strip actions
+ * from a member who has them.
+ */
+function allowedActions(ui) {
+  const may = (need) => {
+    try {
+      if (need === "download") {
+        return typeof ui.canDownload !== "function" ? true : !!ui.canDownload();
+      }
+      return typeof ui.canUpload !== "function" ? true : !!ui.canUpload();
+    } catch (e) {
+      return true;
+    }
+  };
+  return actions.filter((a) => may(a.need));
+}
 
 // Shared 4-level role list (View → Chat → Edit → Admin, weakest first) +
 // bitmask↔role mapping — single source of truth for every role selector.
@@ -304,7 +334,7 @@ module.exports = function settingsActionPanel(ui) {
         kids: [
           Skeletons.Box.Y({
             className: `${pfx}-actions`,
-            kids: actions.map(({ service, label, ico, destructive }) =>
+            kids: allowedActions(ui).map(({ service, label, ico, destructive }) =>
               Skeletons.Box.X({
                 className: `${pfx}-item${destructive ? " destructive" : ""}`,
                 service,

--- a/src/drumee/builtins/window/folder/skeleton/topbar.js
+++ b/src/drumee/builtins/window/folder/skeleton/topbar.js
@@ -84,8 +84,16 @@ const __skl_folder_topbar = function (ui) {
   // topbar icon there is redundant; hide it. isRoot mirrors the window's own
   // root check (folder/index.js curNid / scopeNid logic).
   const isRoot = ui.mget(_a.filetype) === _a.hub && ui.mget(_a.actual_home_id);
+  // Manage Access mints secure-share links, and those links offer can_edit —
+  // so a view or chat member could otherwise share the workspace to themselves
+  // at a higher level than they hold. Gated on the same write bit the server now
+  // enforces in secure_share.create. canUpload() is the window's own test (the
+  // one syncNewCtrlVisibility uses); absent → allowed, so this can only ever
+  // remove the button from someone provably lacking write.
+  const mayManageAccess =
+    typeof ui.canUpload !== "function" ? true : !!ui.canUpload();
   const shareBtn =
-    (!inShare && area === _a.share && isRoot)
+    (!inShare && area === _a.share && isRoot && mayManageAccess)
       ? Skeletons.Button.Svg({
         className: `${cnFolder}__control-icon share`,
         ico: "app-share",

--- a/src/drumee/builtins/window/interact/index.js
+++ b/src/drumee/builtins/window/interact/index.js
@@ -490,6 +490,27 @@ class __window_interact extends windowCore {
       && this.getViewMode && this.getViewMode() !== _a.row) {
       this._partitionFoldersAndFiles(this.__list);
     }
+    // Every tile just moved in the DOM, so the cached bboxes the drag logic
+    // reads (seek_insertion, _rowNeighbor) now describe the OLD layout. Left
+    // stale, the next drag compares the pointer against last-render
+    // coordinates and picks the wrong slot — or none at all.
+    //
+    // initBounds() reads $el.offset(), which includes any active shift
+    // transform, so a tile still sliding back from its ±24px insertion slot
+    // would cache a position 24px off — the grid measured correctly only
+    // when the tween happened to be done, which is what made re-dragging
+    // work intermittently. Clear the transforms first, then measure.
+    _.defer(() => {
+      if (!this.__list || this.__list.isDestroyed()) return;
+      this.__list.children.each((c) => {
+        try {
+          // snapToRest kills the slide instantly; a tween still running here
+          // would leave part of the offset in the measurement below.
+          if (_.isFunction(c.snapToRest)) c.snapToRest();
+          if (_.isFunction(c.initBounds)) c.initBounds();
+        } catch (e) { }
+      });
+    });
   }
 
   /**
@@ -518,6 +539,9 @@ class __window_interact extends windowCore {
    * @returns
    */
   resetShift() {
+    // Everything is back at rest, so the shifted bookkeeping must not leak
+    // into the next drag — _releaseShifted would poke destroyed views.
+    this._shifted = [];
     if (this.__list == null || this.__list.isDestroyed()) {
       return;
     }
@@ -692,6 +716,59 @@ class __window_interact extends windowCore {
   }
 
   /**
+   * Send every tile shifted for a previous insertion slot back to rest,
+   * except the ones staying armed for the current slot. The release goes
+   * through delaySelect too: it cancels a still-pending shift on the same
+   * tile, so a fast drag cannot strand tiles in their pushed-aside position.
+   * @param {*} keep tiles that stay shifted for the current slot
+   */
+  _releaseShifted(keep = []) {
+    if (!this._shifted) this._shifted = [];
+    if (!_.isArray(this._shifted)) this._shifted = [this._shifted];
+    for (const s of this._shifted) {
+      if (keep.indexOf(s) >= 0) continue;
+      if (s.isDestroyed && s.isDestroyed()) continue;
+      if (_.isFunction(s.delaySelect)) s.delaySelect();
+    }
+    this._shifted = [];
+  }
+
+  /**
+   * Nearest tile flanking `ref` on one side within the same visual row.
+   * Geometry-based on purpose: _doPartition (window/utils.js) re-appends
+   * tiles into workspace/folder/file sections, so the collection-adjacent
+   * tile is often somewhere else entirely on screen.
+   * @param {*} ref the tile the slot sits against
+   * @param {*} before true for the slot on ref's leading edge
+   * @param {*} moving the dragged tile, never paired with itself
+   * @returns {*} the flanking tile, or null when the slot ends the row
+   */
+  _rowNeighbor(ref, before, moving, isRow) {
+    if (!ref || !ref.bbox) return null;
+    // Row view is a single vertical column, so the neighbour is the tile
+    // directly above/below and there is no same-line test to apply.
+    const sameLine = (c) =>
+      isRow || Math.abs(c.bbox.y - ref.bbox.y) < (ref.bbox.h || 1) / 2;
+    const gap = (c) => {
+      const d = isRow
+        ? (before ? ref.bbox.y - c.bbox.y : c.bbox.y - ref.bbox.y)
+        : (before ? ref.bbox.x - c.bbox.x : c.bbox.x - ref.bbox.x);
+      return d;
+    };
+    let best = null;
+    let bestGap = Infinity;
+    for (const c of this.__list.children.toArray()) {
+      if (c.cid === ref.cid || c.cid === moving.cid || !c.bbox) continue;
+      if (!sameLine(c)) continue;
+      const d = gap(c);
+      if (d <= 0 || d >= bestGap) continue;
+      best = c;
+      bestGap = d;
+    }
+    return best;
+  }
+
+  /**
    *
    * @param {*} moving
    */
@@ -700,75 +777,100 @@ class __window_interact extends windowCore {
     if (!target) {
       return null;
     }
-    if (this.getViewMode() == _a.row) {
-      this.captured.self = moving;
-      this.captured.self.pos = _e.end;
-      return this
-    }
-    const children = this.__list.children;
-    if (moving.selfOverlapped) {
-      return null;
+    const isRow = this.getViewMode() == _a.row;
+    // Still sitting on its OWN slot — nothing to insert. selfOverlapped is
+    // just the raw intersection with the tile's home rect, which is truthy
+    // from the very first pixel of the drag, so it must be measured: bailing
+    // on any overlap at all made a grid drag unable to ever reach the
+    // insertion logic below. Only a mostly-covering overlap counts as "has
+    // not really left home yet".
+    if (moving.selfOverlapped && moving.bbox) {
+      const home = moving.bbox.area ? moving.bbox.area() : 0;
+      const covered = moving.selfOverlapped.area
+        ? moving.selfOverlapped.area()
+        : 0;
+      if (home > 0 && covered / home > 0.5) {
+        // Tiles shifted for a previous slot must not stay pushed aside here.
+        this._releaseShifted();
+        return null;
+      }
     }
     this.captured = {};
-    let last_y = 0;
-    try {
-      last_y = children.last().$el.offset().top;
-    } catch (e) { }
-    let captured = [];
-    for (var c of this.__list.children.toArray()) {
+    // The tile the drag covers the most is the reference; where the cursor
+    // sits across its width decides the intent. The old rule keyed the
+    // decision on overlap ratio alone (<15% = insert, otherwise drop-into),
+    // which left insertion reachable only on a few-px rim between tiles —
+    // and "drop into" a regular file was a dead end anyway (moveIn only
+    // handles folder/hub destinations).
+    let primary = null;
+    let primaryArea = 0;
+    for (const c of this.__list.children.toArray()) {
+      if (c.cid === moving.cid) continue;
       let area = 0;
       try {
         area = c.overlaps(moving.rectangle);
       } catch (e) {
         return this;
       }
-      if (c.cid !== moving.cid && area > 0) {
-        if (area < 0.15) {
-          // Look for multiple overlaps
-          captured.push(c);
-        } else {
-          if (!this._check_icon_sanity(moving, c)) return null;
-          this.captured.over = c;
-          c.shift();
-          return this;
-        }
+      if (area > primaryArea) {
+        primary = c;
+        primaryArea = area;
       }
     }
-    if (!this._shifted) this._shifted = []
-    if (!_.isArray(this._shifted)) this._shifted = [this._shifted]
-    for (var s of this._shifted) {
-      if (s == this.captured.left) continue;
-      if (s == this.captured.right) continue;
-      s.shift();
+    if (!primary) {
+      this._releaseShifted();
+      this.captured.self = moving;
+      this.captured.self.pos = _e.end;
+      this._intercept(null);
+      return this;
     }
-    switch (captured.length) {
-      case 0:
-        this.captured.self = moving;
-        this.captured.self.pos = _e.end;
-        break;
-      case 1:
-        if (captured[0].mget(_a.rank) == 0) {
-          this.captured.right = captured[0];
-          this.captured.right.delaySelect(_a.right);
-        } else {
-          this.captured.left = captured[0];
-          this.captured.left.delaySelect(_a.left);
-        }
-        this._shifted.push(captured[0]);
-        break;
-      case 2:
-        if (captured[0].mget(_a.rank) < captured[1].mget(_a.rank)) {
-          this.captured.left = captured[0];
-          this.captured.right = captured[1];
-        } else {
-          this.captured.left = captured[1];
-          this.captured.right = captured[0];
-        }
-        this.captured.left.delaySelect(_a.left);
-        this.captured.right.delaySelect(_a.right);
-        this._shifted.push(captured[0]);
-        this._shifted.push(captured[1]);
-      default:
+    // Rows stack vertically, tiles flow horizontally: measure along the axis
+    // the list actually advances on, so the same before/after logic serves
+    // both view modes.
+    const r = moving.rectangle;
+    let t = 0.5;
+    if (isRow) {
+      if (primary.bbox && primary.bbox.h) {
+        t = (r.y + r.h / 2 - primary.bbox.y) / primary.bbox.h;
+      }
+    } else if (primary.bbox && primary.bbox.w) {
+      t = (r.x + r.w / 2 - primary.bbox.x) / primary.bbox.w;
+    }
+    // Folders and hubs keep a wide middle drop-into zone; their edges — and
+    // the whole width of a regular file — read as insertion slots.
+    if (primary.isHubOrFolder && t >= 0.3 && t <= 0.7) {
+      this._releaseShifted();
+      if (!this._check_icon_sanity(moving, primary)) return null;
+      this.captured.over = primary;
+      // Through delaySelect so a still-pending edge-zone shift on this same
+      // tile is cancelled instead of firing over the drop-into highlight.
+      primary.delaySelect();
+      return this;
+    }
+    const before = t < (primary.isHubOrFolder ? 0.3 : 0.5);
+    // Pick the tile that VISUALLY flanks the slot, not the collection
+    // neighbour: the grid is re-partitioned into workspace/folder/file
+    // sections (window/utils.js _doPartition), so collection order and
+    // on-screen order diverge — and even within a section the row wraps.
+    // Nearest tile on the chosen side of the same row, by geometry.
+    const paired = this._rowNeighbor(primary, before, moving, isRow);
+    if (before) {
+      this.captured.right = primary;
+      if (paired) this.captured.left = paired;
+    } else {
+      this.captured.left = primary;
+      if (paired) this.captured.right = paired;
+    }
+    this._releaseShifted([this.captured.left, this.captured.right]);
+    if (this.captured.left) {
+      // The indicator bar rides the left tile's trailing edge when one
+      // exists, otherwise the right tile's leading edge (slot at row start).
+      this.captured.left.delaySelect(_a.left, 1);
+      this._shifted.push(this.captured.left);
+    }
+    if (this.captured.right) {
+      this.captured.right.delaySelect(_a.right, this.captured.left ? 0 : 1);
+      this._shifted.push(this.captured.right);
     }
     this._intercept(null);
     return this;

--- a/src/drumee/builtins/window/manager.js
+++ b/src/drumee/builtins/window/manager.js
@@ -425,11 +425,19 @@ class __window_manager extends mfsInteract {
       target.el.dataset.selected = 1;
       target.el.dataset.over = _a.on;
       if (this._lastTarget == null || this._lastTarget !== target) {
+        // Release the window the drag is LEAVING, then adopt the new one.
+        // This must only run on a target change: selectWindow is called on
+        // every drag tick (Wm.capture), and resetting the current target
+        // here each tick kept cancelling the insertion shift/indicator that
+        // seek_insertion had just armed — tiles could never stay apart.
+        if (
+          this._lastTarget != null &&
+          _.isFunction(this._lastTarget.resetShift)
+        ) {
+          this._lastTarget.resetShift();
+        }
         target.syncBounds();
         this._lastTarget = target;
-      }
-      if (this._lastTarget != null) {
-        this._lastTarget.resetShift();
       }
       if (!target.isDestroyed()) return target;
     }

--- a/src/drumee/builtins/window/meeting/skeleton/index.js
+++ b/src/drumee/builtins/window/meeting/skeleton/index.js
@@ -40,6 +40,24 @@ function meetingSidePanel(_ui_) {
   // desktop it stays open (Figma). The topbar Chat/People buttons still open it.
   const startOpen = !Visitor.isMobile();
 
+  // Chat INSIDE a meeting is the SAME right as workspace chat — this pane posts
+  // through channel.post, which the server now gates on the download bit — so a
+  // view-only member gets the roster without a composer instead of a conversation
+  // every message of which would be refused.
+  //
+  // Scoped to the TEAM-channel case on purpose: a p2p / scheduled room falls back
+  // to the room's own ids (isTeamChannel false) and is not a workspace
+  // conversation, so it is left exactly as it is. DMZ already returned above.
+  //
+  // `permission` is the privilege conference_join resolved for this member
+  // (webrtc/room/index.js msets it from c.user.permission). Absent/unreadable →
+  // treated as allowed, so this can never blank the panel on a missing value.
+  const meetingPriv = Number(_ui_.mget(_a.permission));
+  const mayChat =
+    !isTeamChannel
+    || !Number.isFinite(meetingPriv)
+    || (meetingPriv & _K.permission.download) === _K.permission.download;
+
   const tab = (id, label) =>
     Skeletons.Note({
       className: `${pfx}__chat-tab`,
@@ -64,8 +82,10 @@ function meetingSidePanel(_ui_) {
     // the call stage is what shows first. attrOpt carries the initial data-* to
     // the DOM (bare dataset is dropped at render) — without it the panel mounts
     // with no data-open/data-tab, i.e. closed and tab-less.
-    attrOpt: { "data-open": startOpen ? "1" : "0", "data-tab": "chat" },
-    dataset: { open: startOpen ? 1 : 0, tab: "chat" },
+    // Without the chat right the panel opens on Participants — the only tab
+    // there is — instead of an empty Chat tab.
+    attrOpt: { "data-open": startOpen ? "1" : "0", "data-tab": mayChat ? "chat" : "participants" },
+    dataset: { open: startOpen ? 1 : 0, tab: mayChat ? "chat" : "participants" },
     kids: [
       Skeletons.Box.X({
         className: `${pfx}__chat-header`,
@@ -73,7 +93,7 @@ function meetingSidePanel(_ui_) {
           Skeletons.Box.X({
             className: `${pfx}__chat-tabs`,
             kids: [
-              tab("chat", LOCALE.CHAT),
+              mayChat ? tab("chat", LOCALE.CHAT) : "",
               tab("participants", LOCALE.PARTICIPANTS),
             ],
           }),
@@ -127,8 +147,11 @@ function meetingSidePanel(_ui_) {
           }),
         ],
       }),
-      // Chat pane.
-      Skeletons.Box.Y({
+      // Chat pane. Omitted entirely without the chat right — a mounted composer
+      // whose every send is refused is worse than no composer. Safe to drop:
+      // _bindChatUnread's ensurePart("meeting-chat-widget") simply never
+      // resolves (it has its own .catch), so nothing binds and nothing throws.
+      !mayChat ? "" : Skeletons.Box.Y({
         className: `${pfx}__pane ${pfx}__pane-chat`,
         kids: [
           {

--- a/src/drumee/builtins/window/skeleton/toolkit/index.js
+++ b/src/drumee/builtins/window/skeleton/toolkit/index.js
@@ -1285,12 +1285,15 @@ export function newMenu(ui, opt = {}) {
       area: ui.mget(_a.area) || _a.personal,
       className: `${cnItem}--add-folder ${cnDropdown}__submenu-item`,
     }),
-    row({
-      service: "add-note",
-      ico: "addmenu-note",
-      content: LOCALE.NOTE,
-      className: `${cnItem}--add-note ${cnDropdown}__submenu-item`,
-    }),
+    // Note is temporarily hidden from this create flyout (2026-08). The
+    // add-note handler (window/core.js) and editor_markdown stay wired —
+    // uncomment this row to restore the option.
+    // row({
+    //   service: "add-note",
+    //   ico: "addmenu-note",
+    //   content: LOCALE.NOTE,
+    //   className: `${cnItem}--add-note ${cnDropdown}__submenu-item`,
+    // }),
     row({
       service: "new-document",
       name: "document.docx",

--- a/src/drumee/builtins/window/skeleton/toolkit/index.js
+++ b/src/drumee/builtins/window/skeleton/toolkit/index.js
@@ -1605,7 +1605,12 @@ export function topbarMoreMenu(ui) {
   // only (filetype === hub). Sub-folders already share via their right-click
   // "Share" menu, so this entry is redundant there — keep in sync with topbar.js.
   const isRoot = ui.mget(_a.filetype) === _a.hub && ui.mget(_a.actual_home_id);
-  if (!inShare && area === _a.share && isRoot) {
+  // Same write gate as the inline share icon in folder/skeleton/topbar.js: a
+  // secure-share link can grant can_edit, so a view/chat member must not be able
+  // to mint one for a workspace they only read. Keep the two in sync.
+  const mayManageAccess =
+    typeof ui.canUpload !== "function" ? true : !!ui.canUpload();
+  if (!inShare && area === _a.share && isRoot && mayManageAccess) {
     items.push({
       service: "folder-manage-access",
       ico: "app-share",

--- a/src/drumee/builtins/window/tasks/index.js
+++ b/src/drumee/builtins/window/tasks/index.js
@@ -308,6 +308,9 @@ class __tasks_panel extends LetcBox {
   }
 
   async onDomRefresh() {
+    // Before any wiring: refuse task writes this viewer cannot perform, so an
+    // edit says why instead of silently reverting on reopen.
+    this._guardTaskWrites();
     this._installDnd();
     this._installBoardPan();
     this._installMediaDroppable();
@@ -405,9 +408,84 @@ class __tasks_panel extends LetcBox {
     }
   }
 
+  /**
+   * May this viewer change tasks? The folder window hands the panel `may_write`
+   * at mount, derived from its own canUpload(). Shared with the skeleton so the
+   * board's buttons and this guard can never disagree.
+   */
+  _mayWriteTasks() {
+    return require("./skeleton/helpers").mayCreateTask(this);
+  }
+
+  /**
+   * Task mutations, as declared `src: "write"` in acl/task.json. A view (3) or
+   * chat (7) member is refused server-side, so every one of these was a silent
+   * revert: the card moved, the field accepted text, and reopening showed the
+   * old value — which is exactly what Duy reported from the Task tab.
+   *
+   * Guarded at postService rather than per control: there are 43 mutating call
+   * sites across 86 onUiEvent cases, and gating them one by one would certainly
+   * miss some. This is the single point they all pass through.
+   *
+   * Anything NOT listed here (list, comment_list, activity, column_list, the
+   * column_watch_* notification toggles, and every non-task service) is
+   * untouched — fail-open, consistent with the rest of this batch. The server
+   * stays the real gate; this only stops offering a write that cannot land.
+   */
+  static get TASK_MUTATIONS() {
+    return [
+      "task.create", "task.update", "task.update_status", "task.update_assignee",
+      "task.delete", "task.link_file", "task.unlink_file", "task.link_label",
+      "task.unlink_label", "task.comment_create", "task.comment_update",
+      "task.comment_delete", "task.comment_react", "task.column_create",
+      "task.column_update", "task.column_delete", "task.column_reorder",
+    ];
+  }
+
+  /**
+   * Install the mutation guard.
+   *
+   * postService is an OWN INSTANCE PROPERTY, bound in ui-core's box constructor
+   * (`this.postService = postService.bind(this)`) — NOT a prototype method. A
+   * subclass `postService(){}` would therefore be shadowed and never run, and
+   * `super.postService` does not exist at all. So wrap the bound instance
+   * function instead, after super.initialize() has created it.
+   */
+  _guardTaskWrites() {
+    if (this._taskWriteGuardInstalled) return;
+    const original = this.postService;
+    if (typeof original !== "function") return; // nothing to wrap: leave as-is
+    this._taskWriteGuardInstalled = 1;
+    this.postService = (...args) => {
+      try {
+        const a0 = args[0];
+        const name = typeof a0 === "string" ? a0 : (a0 && a0.service) || "";
+        if (
+          this.constructor.TASK_MUTATIONS.includes(`${name}`)
+          && !this._mayWriteTasks()
+        ) {
+          if (typeof Butler !== "undefined" && Butler.say) Butler.say(LOCALE.WEAK_PRIVILEGE);
+          // postService resolves UNDEFINED when a call does not complete, and
+          // every caller here already tolerates that — so refusing this way
+          // reproduces a shape they handle rather than adding a rejection path.
+          return Promise.resolve(undefined);
+        }
+      } catch (e) {
+        /* never let the guard break a legitimate call */
+      }
+      return original(...args);
+    };
+  }
+
   // Delegated drag-and-drop on this.el — survives every _render()'s feed() rebuild.
   _installDnd() {
     if (!this.el || this._dndInstalled) return;
+    // Dragging a card between columns is task.update_status, and reordering a
+    // column header is task.column_reorder — both `src: write`, so the server
+    // refuses them for a view or chat member and the board snapped back. Don't
+    // wire the drag at all rather than let them move a card that cannot land.
+    // One guard here covers dragstart, dragover AND drop together.
+    if (!this._mayWriteTasks()) return;
     this._dndInstalled = true;
     const root = this.el;
 

--- a/src/drumee/builtins/window/tasks/skeleton/gantt.js
+++ b/src/drumee/builtins/window/tasks/skeleton/gantt.js
@@ -5,7 +5,7 @@
 // A purple "today" line and a shaded current-period band sit behind the bars.
 //   Figma: 2057-32279 (weeks), 2065-90472 (months), 2365-137835 (body detail).
 // Globals Skeletons/LOCALE/Dayjs are injected at runtime.
-const { priorityMeta } = require("./helpers");
+const { priorityMeta, mayCreateTask } = require("./helpers");
 
 const ASIDE_W = 300; // left task-list width
 const ROW_H = 56; // task row height (aside + track share it)
@@ -283,7 +283,7 @@ module.exports = function (ui) {
         className: `${pfx}__gantt-aside-head`,
         styleOpt: { height: `${HEAD_H}px` },
         kids: [
-          Skeletons.Box.X({
+          !mayCreateTask(ui) ? "" : Skeletons.Box.X({
             className: `${pfx}__gantt-work`,
             bubble: 0,
             service: "add-task",

--- a/src/drumee/builtins/window/tasks/skeleton/helpers.js
+++ b/src/drumee/builtins/window/tasks/skeleton/helpers.js
@@ -75,7 +75,29 @@ function statusMeta(ui, key) {
   );
 }
 
+/**
+ * May this viewer create tasks / boards here?
+ *
+ * The tasks panel is a LetcBox with no privilege of its own, so the folder
+ * window hands it `may_write` at mount (folder/index.js), derived from the same
+ * canUpload() its "+ New" gate uses. task.create / task.column_create are
+ * `src: write` server-side, so view and chat members are refused there anyway —
+ * this only stops the button being offered.
+ *
+ * Deliberately `!== false`: an absent or unrecognised value behaves exactly as
+ * before, so this can never hide the button from someone whose privilege simply
+ * was not passed down.
+ */
+function mayCreateTask(ui) {
+  try {
+    return ui.mget("may_write") !== false;
+  } catch (e) {
+    return true;
+  }
+}
+
 module.exports = {
+  mayCreateTask,
   PRIORITY_RANK,
   fullName,
   assigneeUids,

--- a/src/drumee/builtins/window/tasks/skeleton/index.js
+++ b/src/drumee/builtins/window/tasks/skeleton/index.js
@@ -71,6 +71,7 @@ function buildFileSearchDropdownContent(ui, scope, ctx = {}) {
 }
 
 const { stripMarkers: stripMentionMarkers } = require("../mention-markers");
+const { mayCreateTask } = require("./helpers");
 
 const make = function (ui) {
   const pfx = ui.fig.family;
@@ -357,6 +358,7 @@ const make = function (ui) {
   };
 
   const addButton = (colKey) =>
+    !mayCreateTask(ui) ? "" :
     Skeletons.Box.X({
       className: `${pfx}__add-btn`,
       bubble: 0,
@@ -1851,14 +1853,14 @@ const make = function (ui) {
 
   // Right-side controls (Figma 2040-53814): calendar/gantt granularity when
   // those views are active, then the create buttons, then the shared Filter.
-  const newTaskBtn = Skeletons.Note({
+  const newTaskBtn = !mayCreateTask(ui) ? "" : Skeletons.Note({
     className: `${pfx}__viewbar-new`,
     content: `+ ${LOCALE.NEW_TASK}`,
     bubble: 0,
     service: "add-task",
     uiHandler: [ui],
   });
-  const newBoardBtn = Skeletons.Box.X({
+  const newBoardBtn = !mayCreateTask(ui) ? "" : Skeletons.Box.X({
     className: `${pfx}__viewbar-board`,
     bubble: 0,
     service: "add-board",

--- a/src/drumee/builtins/window/tasks/skeleton/index.js
+++ b/src/drumee/builtins/window/tasks/skeleton/index.js
@@ -506,7 +506,13 @@ const make = function (ui) {
                         "data-active": ui.isColumnWatched(col.key) ? "1" : "0",
                       },
                     }),
-                    col.custom
+                    // The "⋮" popover renames and deletes the column
+                    // (task.column_update / column_delete, both `src: write`),
+                    // so a view or chat member could open it and type a new name
+                    // that silently never persisted. Same right as creating a
+                    // task; hiding the trigger closes the popover too, since it
+                    // only renders while getColMenuFor() matches.
+                    col.custom && mayCreateTask(ui)
                       ? Skeletons.Note({
                           className: `${pfx}__col-menu-btn`,
                           content: "⋮",
@@ -520,7 +526,10 @@ const make = function (ui) {
                 }),
               ].filter(Boolean),
             }),
-            col.custom && ui.getColMenuFor() === col.key
+            // Belt: the trigger above is already hidden, but a stale
+            // getColMenuFor() (set before a live role change) must not leave the
+            // rename popover mounted.
+            col.custom && mayCreateTask(ui) && ui.getColMenuFor() === col.key
               ? columnMenu(col)
               : null,
             ...(state[col.key] || []).map((t) => taskCard(col.key, t)),

--- a/src/drumee/builtins/window/utils.js
+++ b/src/drumee/builtins/window/utils.js
@@ -221,6 +221,8 @@ class __window_mfs extends DrumeeMFS {
     if (this._responsive) RADIO_BROADCAST.off(_e.responsive, this._responsive);
     if (this._kbHandler) RADIO_KBD.off(_e.keyup, this._kbHandler);
     Wm.off(WS_EVENT, this.handleWsEvent);
+    // Pending rank sync (window/core.js syncOrder) would run on a dead view.
+    if (this._reorderTimer) clearTimeout(this._reorderTimer);
     if (
       this._partitionObserver ||
       this._partitionDebounce ||
@@ -635,15 +637,40 @@ class __window_mfs extends DrumeeMFS {
       scrollEl.appendChild(fileWrap);
     }
 
+    // Where a tile belongs inside its section is the COLLECTION order.
+    // appendChild alone always dropped a freshly (re)inserted tile at the
+    // end of its section, so a drag-arrange visibly snapped back to the
+    // bottom even though the reorder had already been persisted.
+    // Element → collection position. Ranked by the COLLECTION (the model
+    // order insertMedia wrote into), not by the children container: the
+    // latter iterates in view-creation order, which is exactly what
+    // diverges after an insert-in-the-middle.
+    const rankOf = new Map();
+    const collection = listPart.collection;
+    if (collection && listPart.children && _.isFunction(listPart.children.each)) {
+      listPart.children.each((view) => {
+        if (!view || !view.el || !view.model) return;
+        const i = collection.indexOf(view.model);
+        if (i >= 0) rankOf.set(view.el, i);
+      });
+    }
+    const rank = (el) => {
+      const r = rankOf.get(el);
+      return r == null ? Number.MAX_SAFE_INTEGER : r;
+    };
     items.forEach((item) => {
       const ft = item.dataset?.filetype;
-      if (ft === _a.hub) {
-        workspaceWrap.appendChild(item);
-      } else if (ft === _a.folder) {
-        folderWrap.appendChild(item);
-      } else {
-        fileWrap.appendChild(item);
+      const wrap =
+        ft === _a.hub ? workspaceWrap : ft === _a.folder ? folderWrap : fileWrap;
+      const target = rank(item);
+      let before = null;
+      for (const sibling of wrap.children) {
+        if (rank(sibling) > target) {
+          before = sibling;
+          break;
+        }
       }
+      wrap.insertBefore(item, before);
     });
 
     scrollEl.style.display = "flex";

--- a/src/drumee/libs/path-request.js
+++ b/src/drumee/libs/path-request.js
@@ -1,0 +1,57 @@
+/**
+ * Collapse the duplicate `media.get_path` calls a single window-open fires.
+ *
+ * Opening a folder asks the server for the SAME node path two or three times,
+ * from callers that don't know about each other: `Wm.loadWorkspace` (to feed
+ * `refreshBreadcrumbsUI`), `desk_breadcrumb._updatePath` (to paint the topbar),
+ * and `window_folder._resolveMissingTitle` when the title arrives blank. They
+ * fire within a few milliseconds of each other with identical arguments.
+ *
+ * That is not just wasted work. `mfs_get_path` builds a TEMPORARY table per
+ * call, and two identical calls landing together on the endpoint measured
+ * 173 ms for the first and 404 ms (and, on a cold endpoint, 3013 ms) for its
+ * twin — the duplicate is slower than the original and it delays everything
+ * queued behind it, including the folder's own content listing.
+ *
+ * De-duplication is IN-FLIGHT ONLY: callers that ask while a request for the
+ * same (hub_id, nid) is still open share its promise, and the entry is dropped
+ * as soon as it settles. Nothing is cached across the gap, so a rename, a move
+ * or a permission change is picked up by the next call exactly as before —
+ * this cannot serve stale path data.
+ *
+ * Each caller gets its own copy of the resolved list, so one caller mutating
+ * its result (refreshBreadcrumbsUI reshapes rows) can't corrupt another's.
+ */
+
+const inFlight = new Map();
+
+const keyOf = (hub_id, nid) => `${hub_id || ""}:${nid || ""}`;
+
+/**
+ * @param {Object} view   any widget (supplies fetchService + its auth context)
+ * @param {Object} params { nid, hub_id }
+ * @returns {Promise<Array>} the path rows, newest caller gets its own copy
+ */
+function getPath(view, params = {}) {
+  const { nid, hub_id } = params;
+  // Without both keys the server can only answer for "undefined" — let the
+  // caller's own guard deal with it rather than caching a bad key.
+  if (!nid || !hub_id) return view.fetchService(SERVICE.media.get_path, params);
+
+  const key = keyOf(hub_id, nid);
+  let p = inFlight.get(key);
+  if (!p) {
+    p = view.fetchService(SERVICE.media.get_path, { nid, hub_id });
+    inFlight.set(key, p);
+    const drop = () => {
+      // Only drop OUR entry: a later call for the same node may already have
+      // replaced it.
+      if (inFlight.get(key) === p) inFlight.delete(key);
+    };
+    p.then(drop, drop);
+  }
+  // Copy the array so sharing the promise never means sharing the array.
+  return p.then((data) => (_.isArray(data) ? data.slice() : data));
+}
+
+module.exports = { getPath };

--- a/src/drumee/modules/desk/breadcrumb/index.js
+++ b/src/drumee/modules/desk/breadcrumb/index.js
@@ -3,6 +3,8 @@
  * Listens to RADIO_BROADCAST "breadcrumb:content" emitted by window/core.js
  * whenever the active window navigates, and renders the path.
  * ==================================================================== */
+const { getPath } = require("libs/path-request");
+
 const PROPERTIES = [
   _a.area,
   _a.actual_home_id,
@@ -149,7 +151,9 @@ class __desk_breadcrumb extends LetcBox {
       this.warn("Require node data")
       return;
     }
-    this.fetchService(SERVICE.media.get_path, { nid, hub_id }).then((data) => {
+    // Shared in-flight request: Wm.loadWorkspace asks for this exact path in
+    // the same instant on a folder open (libs/path-request).
+    getPath(this, { nid, hub_id }).then((data) => {
       if (_.isEmpty(data)) return;
       this._buildContent(data)
     })

--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -1379,9 +1379,102 @@ class desk_module extends LetcBox {
   }
 
   /** Keep the topbar actions enabled when the breadcrumb context changes. */
+  /**
+   * May the viewer create things in the workspace they are currently in?
+   *
+   * The desk topbar's "+ New" writes into the CURRENT workspace, but the desk
+   * itself holds no privilege — the open workspace window does, and it already
+   * keeps it live (folder/index.js: change:privilege, _applyLivePrivilege,
+   * _healChatPrivilege). So ask that window, which is the same source its own
+   * "+ New" gate (syncNewCtrlVisibility) trusts, instead of caching a second copy.
+   *
+   * FAIL-OPEN in every unknown case — no workspace context (desk home / the
+   * user's own space), no window yet, or an unexpected shape — so this can only
+   * ever remove an option from someone provably lacking write, never block a
+   * member whose privilege we simply could not read.
+   */
+  _curWorkspaceCanWrite() {
+    try {
+      const ws = (window.Wm && Wm._curWorkspace) || null;
+      if (!ws || !ws.hub_id) return true;
+      const win = Wm._findWorkspaceWindow && Wm._findWorkspaceWindow(ws.hub_id);
+      if (!win || typeof win.canUpload !== "function") return true;
+      return !!win.canUpload();
+    } catch (e) {
+      return true;
+    }
+  }
+
+  /**
+   * May the viewer manage the members of the workspace they are currently in?
+   * Same resolution and same fail-open posture as _curWorkspaceCanWrite; the
+   * server asks for the ADMIN bit on hub.invite / set_privilege / delete_contributor,
+   * so view, chat and edit would only ever meet a refusal.
+   *
+   * canAdmin() (the bare admin bit) rather than canManageAccess(), which also
+   * requires area === private and would therefore hide Invite from the owner of
+   * a SHARED workspace.
+   */
+  _curWorkspaceCanManage() {
+    try {
+      const ws = (window.Wm && Wm._curWorkspace) || null;
+      if (!ws || !ws.hub_id) return true;
+      const win = Wm._findWorkspaceWindow && Wm._findWorkspaceWindow(ws.hub_id);
+      if (!win || typeof win.canAdmin !== "function") return true;
+      return !!win.canAdmin();
+    } catch (e) {
+      return true;
+    }
+  }
+
+  /**
+   * Refuse a create/upload the current workspace privilege does not allow, with
+   * words, BEFORE the file picker or editor opens. Returns true when the caller
+   * must stop — same contract as over-limit's guardWrite, so the two read alike
+   * at every call site.
+   *
+   * The server already refuses these (media.upload / make_dir / save ask for the
+   * write bit), so this is not the enforcement — it exists so a view/chat member
+   * is never offered a picker whose result can only be a 403.
+   */
+  _guardWorkspaceWrite() {
+    if (this._curWorkspaceCanWrite()) return false;
+    this._sayWeakPrivilege();
+    return true;
+  }
+
+  /**
+   * The one place this batch says "you don't have the right for that".
+   * Mirrors over-limit's notifyBlocked: Butler first, Wm.alert as the fallback,
+   * and never allowed to throw into the caller's own path.
+   * LOCALE.WEAK_PRIVILEGE already exists in all six locales — no new key.
+   */
+  _sayWeakPrivilege() {
+    try {
+      if (typeof Butler !== "undefined" && Butler.say) Butler.say(LOCALE.WEAK_PRIVILEGE);
+      else if (typeof Wm !== "undefined" && Wm.alert) Wm.alert(LOCALE.WEAK_PRIVILEGE);
+    } catch (e) {
+      /* a toast must never break the caller's own path */
+    }
+  }
+
   _updateAddmenu() {
     this.ensurePart("action-cluster").then((p) => {
       p.setState(1);
+    });
+    // Navigating into (or out of) a workspace can change whether the create /
+    // upload rows apply at all. Re-feed the topbar only when the answer actually
+    // flips, so ordinary folder-to-folder navigation inside one workspace costs
+    // nothing. Same re-feed mechanism _onOverLimitChanged already uses.
+    const may = this._curWorkspaceCanWrite();
+    const manage = this._curWorkspaceCanManage();
+    if (this._addmenuMayWrite === may && this._addmenuMayManage === manage) return;
+    this._addmenuMayWrite = may;
+    this._addmenuMayManage = manage;
+    this.ensurePart("top-bar").then((part) => {
+      if (part && !(part.isDestroyed && part.isDestroyed())) {
+        part.feed(require("./skeleton/topbar")(this));
+      }
     });
   }
 
@@ -2861,6 +2954,10 @@ class desk_module extends LetcBox {
         // Refuse before the file picker opens — a picker that can only
         // produce OVER_LIMIT_READ_ONLY is worse than no picker.
         if (require("libs/over-limit").guardWrite("write")) return;
+        // Same reason, different cause: a view/chat member of the CURRENT
+        // workspace cannot upload into it, and a picker that can only end in a
+        // 403 is worse than no picker.
+        if (this._guardWorkspaceWrite()) return;
         return Wm.handleUpload();
       }
 
@@ -2869,6 +2966,9 @@ class desk_module extends LetcBox {
 
       case "launch-gdrive-migration": {
         this.closeDeskNewMenu(cmd);
+        // A Drive import writes into the current workspace (it lands on the same
+        // upload path), so it needs the same right as "From device".
+        if (this._guardWorkspaceWrite()) return;
         const workspace = (Wm && Wm._curWorkspace) || {};
         return Kind.waitFor("migrate_gdrive_popup").then(() => {
           Wm.launch(
@@ -3085,6 +3185,9 @@ class desk_module extends LetcBox {
         // never sees it. Gate here so hard-lock / over_limit don't leave
         // a writable markdown window on a read-only desk.
         if (require("libs/over-limit").guardWrite("write")) return;
+        // A note is saved into the current workspace (media.save asks for the
+        // write bit), so refuse here rather than open an editor that cannot save.
+        if (this._guardWorkspaceWrite()) return;
         Wm.windowsLayer.append({
           kind: "editor_markdown",
           uiHandler: [this],
@@ -3098,6 +3201,8 @@ class desk_module extends LetcBox {
         // Office create hits euroffice.new_doc; refuse before the spinner /
         // "network error" path that the plugin's own error handler shows.
         if (require("libs/over-limit").guardWrite("write")) return;
+        // Same for a viewer who simply lacks write in this workspace.
+        if (this._guardWorkspaceWrite()) return;
         Wm.newDocument(cmd);
         return;
       }
@@ -3108,6 +3213,12 @@ class desk_module extends LetcBox {
         // panels, workspace menus) still land here. Answer with words, not a
         // popup whose submit can only be refused.
         if (require("libs/over-limit").guardWrite("invite")) return;
+        // Managing members needs the ADMIN bit (hub.invite is `src: admin`), so
+        // refuse with words rather than open a popup whose submit can only 403.
+        if (!this._curWorkspaceCanManage()) {
+          this._sayWeakPrivilege();
+          return;
+        }
         return this._openInvitePopup(cmd);
       }
 

--- a/src/drumee/modules/desk/skeleton/topbar.js
+++ b/src/drumee/modules/desk/skeleton/topbar.js
@@ -14,12 +14,17 @@ const addMenuItem = (pfx, ui, ico, label, service, name, opts = {}) =>
     uiHandler: [ui],
   });
 
-const addItems = (pfx, ui) => [
+// The tablet "more" menu splices these in. Same rule as the "+ New" dropdown:
+// only "Workspace" is account-level and always stays; the four file entries
+// write into the CURRENT workspace and follow its privilege.
+const addItems = (pfx, ui, mayWrite) => [
   addMenuItem(pfx, ui, "addmenu-folder", LOCALE.WORKSPACE || "Workspace", "new-workspace", "", { highlight: 1, iconClass: "ico-workspace" }),
+  ...(!mayWrite ? [] : [
   addMenuItem(pfx, ui, "addmenu-note", LOCALE.NOTE || "Note", "new-note", "", { iconClass: "ico-note" }),
   addMenuItem(pfx, ui, "addmenu-document", LOCALE.DOCUMENT || "Document", "new-document", "document.docx", { iconClass: "ico-document" }),
   addMenuItem(pfx, ui, "addmenu-spreadsheet", LOCALE.SPREADSHEET || "Spreadsheet", "new-spreadsheet", "spreadsheet.xlsx", { iconClass: "ico-spreadsheet" }),
   addMenuItem(pfx, ui, "addmenu-presentation", LOCALE.PRESENTATION || "Presentation", "new-presentation", "presentation.pptx", { iconClass: "ico-presentation" }),
+  ]),
 ];
 
 const newMenuRow = (pfx, ui, {
@@ -50,7 +55,17 @@ const newMenuRow = (pfx, ui, {
   ],
 });
 
-const deskNewMenu = (pfx, ui) => {
+// Everything in this menu EXCEPT "Workspace" writes into the workspace the user
+// is currently in, so it follows their privilege there: view and chat members
+// cannot upload, import, or create files. Creating a NEW WORKSPACE belongs to
+// their own account, not to the workspace they happen to be visiting, so it
+// always stays.
+//
+// `mayWrite` is resolved ONCE per render by the caller and threaded in, so every
+// surface of this topbar necessarily agrees. Desk._updateAddmenu re-feeds the
+// topbar when the answer flips, so the menu follows navigation into and out of a
+// workspace.
+const deskNewMenu = (pfx, ui, mayWrite) => {
   const createItems = [
     newMenuRow(pfx, ui, {
       ico: "addmenu-folder",
@@ -58,6 +73,7 @@ const deskNewMenu = (pfx, ui) => {
       service: "new-workspace",
       className: `${pfx}__add-menu-item ${pfx}__new-menu-submenu-item ico-workspace`,
     }),
+    ...(!mayWrite ? [] : [
     newMenuRow(pfx, ui, {
       ico: "addmenu-note",
       label: LOCALE.NOTE || "Note",
@@ -85,6 +101,7 @@ const deskNewMenu = (pfx, ui) => {
       name: "presentation.pptx",
       className: `${pfx}__add-menu-item ${pfx}__new-menu-submenu-item ico-presentation`,
     }),
+    ]),
   ];
 
   const createGroup = Skeletons.Box.X({
@@ -134,13 +151,16 @@ const deskNewMenu = (pfx, ui) => {
     items: Skeletons.Box.Y({
       className: `${pfx}__new-menu-items`,
       kids: [
-        newMenuRow(pfx, ui, {
+        // Both import rows land on the upload path, so they need write in the
+        // current workspace. "" is dropped by ui-core's validChild, the same
+        // idiom the tab bar uses to blank a tab.
+        !mayWrite ? "" : newMenuRow(pfx, ui, {
           ico: "app-upload",
           label: LOCALE.FROM_DEVICE || "From device",
           service: _e.upload,
           className: `${pfx}__new-menu-item--from-device`,
         }),
-        newMenuRow(pfx, ui, {
+        !mayWrite ? "" : newMenuRow(pfx, ui, {
           ico: "logo-google",
           label: LOCALE.MIGRATE_GDRIVE_TITLE || "Migrate from Google Drive",
           service: "launch-gdrive-migration",
@@ -154,6 +174,14 @@ const deskNewMenu = (pfx, ui) => {
 
 module.exports = function (ui) {
   const pfx = `${ui.fig.family}-topbar`;
+  // Same two questions the "+ New" dropdown asks, resolved once for the whole
+  // topbar: may this viewer create things in the workspace they are in, and may
+  // they manage its members? Both fail open when there is no workspace context
+  // (the user's own desk) or the privilege cannot be read.
+  const mayWrite =
+    typeof ui._curWorkspaceCanWrite === "function" ? ui._curWorkspaceCanWrite() : true;
+  const mayManage =
+    typeof ui._curWorkspaceCanManage === "function" ? ui._curWorkspaceCanManage() : true;
 
   return Skeletons.Box.X({
     debug: __filename,
@@ -188,7 +216,7 @@ module.exports = function (ui) {
           // offering five entries that each end in a server refusal. The
           // desk re-feeds this part on over-limit:changed, so it comes back
           // the moment the org is within limits again.
-          ...(require("libs/over-limit").isLocked() ? [] : [deskNewMenu(pfx, ui)]),
+          ...(require("libs/over-limit").isLocked() ? [] : [deskNewMenu(pfx, ui, mayWrite)]),
 
           // Search bar + suggestions
           Skeletons.Box.Y({
@@ -255,7 +283,10 @@ module.exports = function (ui) {
           // limits: invites are paused (the seat guard and the REST clamp
           // both refuse them), and a button that only ever answers with a
           // refusal toast should not be offered. Same re-feed as "+ New".
-          ...(require("libs/over-limit").isLocked() ? [] : [Skeletons.Button.Label({
+          // Also gone for a member who cannot manage this workspace's members:
+          // hub.invite / set_privilege ask for the ADMIN bit server-side, so
+          // view / chat / edit would only ever meet a refusal.
+          ...(require("libs/over-limit").isLocked() || !mayManage ? [] : [Skeletons.Button.Label({
             ico: "topbar-invite",
             className: `${pfx}__invite-btn`,
             label: LOCALE.INVITE || "Invite",
@@ -283,15 +314,15 @@ module.exports = function (ui) {
               // the consolidated tablet menu keeps nothing actionable.
               ? []
               : [
-                ...addItems(pfx, ui),
-                Skeletons.Button.Label({
+                ...addItems(pfx, ui, mayWrite),
+                !mayWrite ? "" : Skeletons.Button.Label({
                   ico: "app-upload",
                   className: `${pfx}__more-menu-item`,
                   label: LOCALE.UPLOAD,
                   service: _e.upload,
                   uiHandler: [ui],
                 }),
-                Skeletons.Button.Label({
+                !mayManage ? "" : Skeletons.Button.Label({
                   ico: "topbar-invite",
                   className: `${pfx}__more-menu-item`,
                   label: LOCALE.INVITE || "Invite",

--- a/src/drumee/modules/desk/wm/index.js
+++ b/src/drumee/modules/desk/wm/index.js
@@ -1238,7 +1238,13 @@ class __window_manager extends push {
       return;
     }
     if (this._lastTaget && this._lastTaget != this._target) {
-      if (_.isFunction(this._lastTaget)) this._lastTaget.clearShift();
+      // _lastTaget is a window widget, so the old _.isFunction guard never
+      // passed and tiles in the previous window stayed pushed aside when the
+      // drag crossed into another window. resetShift is the per-window
+      // release (interact/index.js).
+      if (_.isFunction(this._lastTaget.resetShift)) {
+        this._lastTaget.resetShift();
+      }
     }
     this._lastTaget = this._target;
     this.moveAllowed(moving);
@@ -1283,24 +1289,42 @@ class __window_manager extends push {
       return true;
     }
 
+    // Slot positions are collection indexes (insertMedia hands them to
+    // collection.add {at:...}), so they must be read with listIndex() —
+    // index() returns the stored rank, which only tracks the display order
+    // while the window is sorted by rank.
+    //
+    // Rearranging means moving a tile WITHIN its own window. Dragging one in
+    // from elsewhere is a move: it lands in the slot, but it must not flip
+    // the destination to rank order behind the user's back.
+    // getLogicalParent() rather than the raw property: the latter is only
+    // populated lazily by that getter, so it is often still undefined here.
+    const rearranging =
+      _.isFunction(moving.getLogicalParent) &&
+      moving.getLogicalParent() === this._target;
     if (c.left) {
       this.verbose("insert:after", c.left);
       if (this._target.mget(_a.privilege) & _K.permission.modify) {
-        if (moving.index() < c.left.index()) {
-          position = c.left.index();
+        // Dropping a tile that sits BEFORE the slot shifts everything after
+        // it one step left once it is pulled out, so the target index is the
+        // left neighbour's own index rather than the one past it.
+        if (moving.listIndex() < c.left.listIndex()) {
+          position = c.left.listIndex();
         } else {
-          position = c.left.index() + 1;
+          position = c.left.listIndex() + 1;
         }
+        if (rearranging) this._target._manualArrange = 1;
       } else {
         this._target.warning(LOCALE.WEAK_PRIVILEGE);
         return false;
       }
     } else if (c.right) {
-      this.verbose("insert:before", c.right, c.right.index());
-      position = c.right.index();
+      this.verbose("insert:before", c.right, c.right.listIndex());
+      position = c.right.listIndex();
       if (position === 0) {
         position = -1;
       }
+      if (rearranging) this._target._manualArrange = 1;
     } else if (c.self && c.self.intersect(this._target)) {
       if (this._target.cid !== this.cid) {
         this.verbose("insert:another window", c, this._target, this);

--- a/src/drumee/modules/desk/wm/index.js
+++ b/src/drumee/modules/desk/wm/index.js
@@ -5,6 +5,9 @@ const push = require("./push");
 // "Open this workspace once signed in" — armed by the welcome module from
 // ?hub_id= (the workspace-invite CTA), consumed on boot below.
 const hubDeepLink = require("libs/hub-deep-link");
+// Shares one in-flight media.get_path with the breadcrumb / folder window when
+// they ask for the same node in the same instant (a folder open does).
+const { getPath } = require("libs/path-request");
 // Same channel the websocket dispatcher triggers on Wm — windows and the
 // sidebar workspace list subscribe to it (window/utils.js, workspace-list).
 const WS_EVENT = "ws:event";
@@ -514,7 +517,7 @@ class __window_manager extends push {
       // path of "undefined" — the same defect as the fetch above, and it left the
       // breadcrumb stuck on the previous screen. openWorkspaceFolder already does
       // it this way (attrs.nid || nid).
-      this.fetchService(SERVICE.media.get_path, { nid: data.nid || nid, hub_id }).then(
+      getPath(this, { nid: data.nid || nid, hub_id }).then(
         (path) => {
           if (_.isEmpty(path)) return;
           cur.refreshBreadcrumbsUI(path);
@@ -738,7 +741,7 @@ class __window_manager extends push {
         // breadcrumb would keep the previous folder's crumbs. Rebuild it from
         // get_path, as loadWorkspace does.
         const deepNid = attrs.nid || nid;
-        this.fetchService(SERVICE.media.get_path, { nid: deepNid, hub_id })
+        getPath(this, { nid: deepNid, hub_id })
           .then((path) => {
             if (_.isEmpty(path)) return;
             if (_.isFunction(currentFolder.refreshBreadcrumbsUI))

--- a/tests/file-thread-move-route.test.js
+++ b/tests/file-thread-move-route.test.js
@@ -1,0 +1,85 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  isMoveResultSuccessful,
+  selectCrossWorkspaceMoveService,
+} = require("../src/drumee/builtins/media/file-thread-move-route");
+
+const services = {
+  media: {
+    move_cross_hub: "media.move_cross_hub",
+    workspace_move: "media.workspace_move",
+  },
+};
+
+test("file threads use the durable cross-hub move coordinator", () => {
+  const service = selectCrossWorkspaceMoveService(
+    { exists_thread: 1, file_thread_id: "thread-1" },
+    services,
+  );
+
+  assert.equal(service, "media.move_cross_hub");
+});
+
+test("files without a thread keep the generic workspace move", () => {
+  const service = selectCrossWorkspaceMoveService(
+    { exists_thread: 0 },
+    services,
+  );
+
+  assert.equal(service, "media.workspace_move");
+});
+
+test("an incomplete thread probe does not enter the thread saga", () => {
+  const service = selectCrossWorkspaceMoveService(
+    { exists_thread: 1 },
+    services,
+  );
+
+  assert.equal(service, "media.workspace_move");
+});
+
+test("an empty thread probe keeps the generic workspace move", () => {
+  assert.equal(
+    selectCrossWorkspaceMoveService(null, services),
+    "media.workspace_move",
+  );
+});
+
+test("service fallbacks work before the runtime registry is hydrated", () => {
+  assert.equal(
+    selectCrossWorkspaceMoveService({ exists_thread: 0 }),
+    "media.workspace_move",
+  );
+  assert.equal(
+    selectCrossWorkspaceMoveService({ exists_thread: 1, file_thread_id: "thread-1" }),
+    "media.move_cross_hub",
+  );
+});
+
+test("only a committed thread saga is treated as a completed move", () => {
+  assert.equal(
+    isMoveResultSuccessful("media.move_cross_hub", { state: "committed" }, services),
+    true,
+  );
+  assert.equal(
+    isMoveResultSuccessful("media.move_cross_hub", { state: "compensated" }, services),
+    false,
+  );
+  assert.equal(
+    isMoveResultSuccessful("media.move_cross_hub", { state: "failed" }, services),
+    false,
+  );
+});
+
+test("legacy move responses remain truthy-compatible", () => {
+  assert.equal(
+    isMoveResultSuccessful("media.workspace_move", { nid: "file-1" }, services),
+    true,
+  );
+  assert.equal(
+    isMoveResultSuccessful("media.workspace_move", null, services),
+    false,
+  );
+});


### PR DESCRIPTION
Promotes the whole `test` branch to `preview`, at Huân's request.

### What rides along
- `fix(permission)` ×3: stop offering view/chat members actions they cannot perform; close three more surfaces (Manage Access ×2, folder-setting actions, task column ⋮); and the **task board** — view/chat could drag cards and edit task details with nothing persisting
- `feat(reward)`: exit and unload guard for the reward flow (`beacon.js`, `exit-guard.js`) — pairs with the new `left` status on the server side
- `fix(media)`: drag-to-arrange lands and persists in both view modes; threaded cross-workspace moves routed through the file-thread saga
- `perf(folder)`: stop the window-title render loop that delayed every folder open
- `feat(window)`: hide the Note entry from the folder create menu

### Prod DB
Applied first — see drumee/schemas#131.

`preview` had **zero content commits** ahead of `test`, the merge is conflict-free, and the merged tree is byte-identical to `test`'s — no backmerge was needed.

⚠️ The `Code Quality` job is expected red on the `sourceType: module` parsing errors — a pre-existing CI config limitation, red on `preview`'s head too. `CD - deploy ui-team` is the job that matters.
