### PR TITLE
docs(workspace): mark the workspace-limit UI as legacy and correct why

### DIFF
--- a/src/drumee/builtins/media/form/index.js
+++ b/src/drumee/builtins/media/form/index.js
@@ -176,12 +176,18 @@ class __form_folder extends LetcBox {
         // of rejecting; surface it inline and keep the form open for retry.
         if (hub && (hub.error || hub.error_code)) {
           this._pending = 0;
-          // A quota refusal is not a problem with what the user typed, so it
-          // does not go in the field's error line. check_quota answers
-          // QUOTA_EXCEEDED with a `reason` naming the area
-          // (_private_hub_limit_reached / _share_hub_limit_reached) — a string
-          // that has no translation in ANY locale file, so the old branch
-          // rendered either the generic quota sentence or the raw key.
+          // LEGACY PATH. There is no workspace-count limit: the server's
+          // check_quota preproc was removed on 2026-08-08 because it read the
+          // plan's per-area capability flags ($.private_hub etc.) as counts
+          // and refused a second workspace to everyone, paying customers
+          // included. An updated endpoint never sends this any more.
+          //
+          // Kept while endpoints roll out at their own pace: an old service
+          // still answers QUOTA_EXCEEDED with a `reason` naming the area
+          // (_private_hub_limit_reached / _share_hub_limit_reached), which has
+          // no translation in any locale file, so without this branch the code
+          // itself would land in the name field. Remove once no deployment
+          // runs the old service.
           if (hub.error === "QUOTA_EXCEEDED" || /_hub_limit_reached$/.test(hub.reason || "")) {
             this._setNameError(null);
             this._showQuotaBlock();

--- a/src/drumee/builtins/widget/quota-exceeded/skeleton/index.js
+++ b/src/drumee/builtins/widget/quota-exceeded/skeleton/index.js
@@ -46,12 +46,18 @@ const LIMITS = {
           "You have used all the storage your plan includes.",
     makeRoom: () => LOCALE.QX_ROOM_STORAGE || "Free up space to continue.",
   },
-  /* Deliberately promises NOTHING about upgrading. Team sells the same
-     private_hub: 1 as Free — only Business lifts it — so "upgrade for more
-     workspaces" would be false for the tier most users would land on. The
-     plans page states each tier's workspace count (Free "1", Team "1",
-     Business "Multiple"), so the button lets them see which one helps rather
-     than this sentence claiming it for them. */
+  /* UNREACHABLE since 2026-08-08 — no plan limits how many workspaces you may
+     create, and the server no longer refuses one (server-team removed the
+     create_hub preproc). Kept only so an endpoint still running the old
+     service renders this card instead of a raw "QUOTA_EXCEEDED" in the name
+     field; delete once every deployment is past that point.
+
+     The note that used to sit here — "Team sells the same private_hub: 1 as
+     Free" — was the misreading that caused the outage: $.private_hub /
+     $.share_hub / $.public_hub are per-area capability flags (free 1/0/0,
+     pro 1/1/0, team 1/1/0, business unset), not workspace counts. Read as
+     counts they say a $29 Team may hold exactly one internal workspace.
+     Don't restore a count from them. */
   workspace: {
     title: () => LOCALE.QX_WORKSPACE_TITLE || "Workspace limit reached",
     body: () =>


### PR DESCRIPTION
Comment-only, no behaviour change. Pairs with drumee/server-team#178, which removes the create_hub quota preproc — there is no workspace-count limit in the product.

- The "Workspace limit reached" block can no longer be reached from an updated endpoint. Both call sites now say so.
- The branch **stays** so an endpoint still running the old service renders the card instead of dropping a raw `QUOTA_EXCEEDED` into the workspace-name field (`_private_hub_limit_reached` has no translation in any locale file). Remove once no deployment runs the old service.
- The note that stood on the card — *"Team sells the same private_hub: 1 as Free"* — was the misreading that caused the refusal, so it is replaced rather than left to justify restoring the cap: `private_hub` / `share_hub` / `public_hub` are per-area capability flags (free 1/0/0, pro 1/1/0, team 1/1/0, business unset), not counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)