### PR TITLE
feat(gtag): report a Google Ads conversion when Checkout comes back paid

### DIFF
--- a/src/drumee/builtins/widget/settings/account/billing/result/index.js
+++ b/src/drumee/builtins/widget/settings/account/billing/result/index.js
@@ -35,8 +35,47 @@ class settings_billing_result extends LetcBox {
       if (ps && ps !== "paid" && ps !== "no_payment_required") {
         this._result = "cancel";
       }
+      this._reportConversion();
     }
     this.feed(require("./skeleton").default(this));
+  }
+
+  /**
+   * Tell Google Ads a purchase happened.
+   *
+   * Here rather than anywhere else because this is the one place in the client
+   * that knows a Checkout session came back PAID: `wm.checkCheckoutReturn`
+   * only sees ?checkout=success in the URL, which says the browser was
+   * redirected, not that Stripe took the money. The receipt fetched above is
+   * what separates the two, and the guard below re-reads `_result` because the
+   * unpaid case has just rewritten it to "cancel".
+   *
+   * The amount is what was CHARGED TODAY. A deferred switch or an MKT promo
+   * bills 0 now and the real amount later, so those report a conversion worth
+   * 0 -- the action is real, the revenue has not happened yet. The later charge
+   * is collected by webhook with no browser in the loop, so it will never
+   * arrive here; if Ads should instead carry the committed amount, that is
+   * `upcoming_amount` on the same receipt, and it is a reporting decision
+   * rather than a bug.
+   *
+   * Client-side reporting misses whoever closes the tab before the redirect
+   * lands, and whoever blocks the tag. Server-side (Ads Conversions API, off
+   * the Stripe webhook that already runs) is the answer to that, and a much
+   * larger change than this one.
+   */
+  _reportConversion() {
+    if (this._result !== "success") return;
+    const receipt = this._receipt || {};
+    const minor = receipt.amount_total;
+    require("libs/gtag").conversion("purchase", {
+      // Stripe reports minor units; Ads wants major.
+      value: Number.isFinite(minor) ? minor / 100 : 0,
+      currency: String(receipt.currency || "usd").toUpperCase(),
+      // The session id, not the invoice number: it is unique per checkout and
+      // always present on this path, while `invoice_number` is null whenever
+      // Stripe issued no invoice.
+      transaction_id: this._sessionId,
+    });
   }
 
   onUiEvent(cmd, args = {}) {

--- a/src/drumee/libs/gtag.js
+++ b/src/drumee/libs/gtag.js
@@ -33,6 +33,38 @@
 const TAG_ID = "AW-18350168481";
 const SRC = `https://www.googletagmanager.com/gtag/js?id=${TAG_ID}`;
 
+/**
+ * Conversion labels, per conversion action.
+ *
+ * A Google Ads conversion is addressed as `AW-18350168481/<label>`, and the
+ * label is minted by the Ads console — Goals > Conversions > the action > Tag
+ * setup > "Install the tag yourself". It is NOT derivable from anything in this
+ * repo, which is why it sits here as data rather than being built at the call
+ * site: one place to fill in, and `conversion()` refuses to guess.
+ *
+ * An empty label means "this action has not been created in Ads yet". That is a
+ * supported state, not a broken one: `conversion()` no-ops and says so in the
+ * console, so this ships and does nothing until the label exists. Nothing
+ * downstream branches on it.
+ */
+const CONVERSION_LABEL = {
+  // Paid Stripe Checkout completed — see billing/result.
+  purchase: "",
+};
+
+// Transactions already reported, so a reload cannot report them twice.
+//
+// The Checkout return URL carries ?checkout=success&session_id=… , and it is an
+// ordinary URL: refresh it, or restore the tab, and the success modal renders
+// again from the same session. Ads dedupes on transaction_id server-side, but
+// only within its own window and only once the hit arrives -- cheaper and more
+// certain to not send the second hit at all.
+//
+// sessionStorage, matching billing-deep-link: the lifetime that matters is the
+// tab that did the checkout. A different tab re-opening the same URL still
+// dedupes on transaction_id at Google's end.
+const SENT_KEY = "drumee_gtagConversions";
+
 // drumee.com and every subdomain of it (workspaces are `<ident>.drumee.com`).
 // Anchored both ends: a lookalike host such as `drumee.com.evil.net` must not
 // match, and neither must `notdrumee.com`.
@@ -137,4 +169,79 @@ function event(name, params = {}) {
   }
 }
 
-module.exports = { install, event, isEnabled, TAG_ID };
+/**
+ * Has this transaction already been reported from this tab?
+ *
+ * Storage itself is the thing most likely to fail here — private mode and
+ * blocked storage both throw on access — and the honest answer to a storage we
+ * cannot read is "not sent". Reporting a conversion twice is a smaller harm
+ * than dropping one, so the failure leans towards sending.
+ *
+ * @param {String} key transaction identity
+ * @returns {Boolean}
+ */
+function alreadySent(key) {
+  try {
+    const raw = window.sessionStorage.getItem(SENT_KEY);
+    return !!raw && JSON.parse(raw).includes(key);
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Record a transaction as reported. Best effort, by the same reasoning.
+ *
+ * @param {String} key transaction identity
+ */
+function markSent(key) {
+  try {
+    const raw = window.sessionStorage.getItem(SENT_KEY);
+    const seen = raw ? JSON.parse(raw) : [];
+    if (!seen.includes(key)) {
+      seen.push(key);
+      window.sessionStorage.setItem(SENT_KEY, JSON.stringify(seen));
+    }
+  } catch (e) {
+    // Nothing to do: the next reload may re-report, and Ads dedupes on
+    // transaction_id. Never let bookkeeping break the flow being measured.
+  }
+}
+
+/**
+ * Report a Google Ads conversion.
+ *
+ * @param {String} name key into CONVERSION_LABEL, e.g. "purchase"
+ * @param {Object} [params]
+ * @param {Number} [params.value] amount in MAJOR units (dollars, not cents)
+ * @param {String} [params.currency] ISO 4217, upper case
+ * @param {String} [params.transaction_id] unique per transaction; enables the
+ *   dedupe above and Google's own
+ * @returns {Boolean} true when a hit was sent
+ */
+function conversion(name, params = {}) {
+  // Absence of the tag is checked FIRST, and answered in silence. Off a
+  // drumee.com host there is deliberately no tag at all, and someone running
+  // this AGPL software on their own domain should not be told about the state
+  // of our Ads account on every purchase they take.
+  if (typeof window === "undefined" || typeof window.gtag !== "function") return false;
+
+  const label = CONVERSION_LABEL[name];
+  if (!label) {
+    // Loud here, because reaching this line means the tag IS in force and a
+    // real conversion just went unreported -- a configuration gap someone has
+    // to close, not an expected runtime state.
+    console.warn(`[gtag] no Ads label for "${name}" — conversion not reported`);
+    return false;
+  }
+
+  const { transaction_id } = params;
+  const dedupeKey = transaction_id && `${name}:${transaction_id}`;
+  if (dedupeKey && alreadySent(dedupeKey)) return false;
+
+  event("conversion", { send_to: `${TAG_ID}/${label}`, ...params });
+  if (dedupeKey) markSent(dedupeKey);
+  return true;
+}
+
+module.exports = { install, event, conversion, isEnabled, TAG_ID };


### PR DESCRIPTION
## Bối cảnh

Thẻ Ads `AW-18350168481` đã chạy trên mọi trang `drumee.com` (landing page qua `index.html`, app qua [libs/gtag.js](src/drumee/libs/gtag.js)) — nhưng **chưa có conversion nào được báo về**. Ads thấy được traffic chiến dịch mang lại, không thấy được nó tạo ra cái gì. Chính comment trong file đã ghi: *"No conversion is wired up yet — this is the door for the first one."*

PR này mở cánh cửa đó.

## Bắn ở đâu, và vì sao ở đó

Ở modal kết quả sau Checkout ([billing/result/index.js](src/drumee/builtins/widget/settings/account/billing/result/index.js)) — chỗ **duy nhất** trong client biết một session Stripe thật sự đã **PAID**.

`wm.checkCheckoutReturn` chỉ thấy `?checkout=success` trên URL, tức là *trình duyệt đã được redirect*, không phải *Stripe đã thu tiền*. Cái tách hai chuyện đó ra là receipt mà widget này vốn đã fetch (`payment.checkout_result`). Guard đọc lại `_result` vì nhánh unpaid vừa ghi đè nó thành `"cancel"` ngay phía trên.

## ⚠️ Cần anh điền label trước khi nó chạy

```js
const CONVERSION_LABEL = {
  purchase: "",   // ← lấy từ Google Ads
};
```

Label do **Ads console** cấp, không suy ra được từ repo: *Goals → Conversions → chọn action → Tag setup → "Install the tag yourself"*, lấy phần sau dấu `/` trong `send_to: "AW-18350168481/XXXXXXX"`.

Ship với label rỗng là **trạng thái hợp lệ, không phải hỏng**: `conversion()` no-op và cảnh báo console thay vì gửi `send_to` méo. Điền vào là sửa một dòng, một chỗ.

## Các quyết định trong này

| | |
|---|---|
| **Số tiền** | Là tiền **thu hôm nay**, đổi sang đơn vị lớn (`amount_total / 100`). Deferred switch hoặc promo MKT thu 0 hôm nay → conversion value 0: hành động là thật, doanh thu thì chưa. Lần charge sau đi qua webhook, không có trình duyệt nào trong vòng lặp nên sẽ không bao giờ tới đây. Nếu muốn Ads nhận số đã cam kết thì đó là `upcoming_amount` trên cùng receipt — **quyết định về cách báo cáo, không phải bug**. |
| **Chống bắn trùng** | URL trả về là URL bình thường: refresh hoặc khôi phục tab là modal render lại từ đúng session đó. Dedupe bằng `sessionStorage` theo `session_id` — duy nhất mỗi lần checkout và luôn có ở nhánh này, khác `invoice_number` (null khi Stripe không phát hành invoice). Ads cũng dedupe theo `transaction_id`, cái này chỉ để không gửi hit thứ hai. |
| **Self-hosted** | Kiểm tra thiếu tag **trước** khi kiểm tra label, và im lặng. Người chạy bản AGPL trên domain riêng không cần bị báo về tình trạng tài khoản Ads của mình trên mỗi giao dịch họ nhận. |
| **Storage lỗi** | Private mode / storage bị chặn đều throw. `alreadySent` trả `false` — báo trùng một lần nhẹ hơn là mất hẳn một conversion. |

## Giới hạn đã biết

Đo phía client sẽ **sót** người đóng tab trước khi redirect kịp về, và người chặn tag. Câu trả lời cho chuyện đó là đo phía server (Ads Conversions API, gắn vào chính webhook Stripe đang chạy) — thay đổi lớn hơn nhiều so với PR này.

## Chưa verify chạy thật

Stage `drumee.in` bị `TRACKED_HOST` (`/(^|\.)drumee\.com$/i`) loại nên tag không bao giờ cài ở đó — đúng thiết kế, signup test không phải conversion. Em đã dừng bước verify theo yêu cầu. Sau khi có label, cách kiểm nhanh nhất là chạy một checkout thật trên prod rồi xem Google Tag Assistant, hoặc xem `dataLayer` có `conversion` với đúng `send_to`.

## Phạm vi

Chỉ **purchase**. Conversion signup nằm ở plugin `@drumee/signup` (repo khác, cùng document) — nếu cần thì làm PR riêng.