### PR TITLE
fix(promo): open the Admin Console in place instead of reloading the page

### DIFF
--- a/src/drumee/builtins/widget/promo-launch30/index.js
+++ b/src/drumee/builtins/widget/promo-launch30/index.js
@@ -45,6 +45,7 @@ class __promo_launch30 extends LetcBox {
   onDomRefresh() {
     this._portalToBody();
     this._render();
+    this._warmAdminConsole();
     // Show-once: mark the surface seen as soon as the modal actually
     // renders, not only on an explicit X-dismiss (tester feedback
     // 2026-07-31 #3 — the full modal must never re-appear once shown,
@@ -70,6 +71,36 @@ class __promo_launch30 extends LetcBox {
 
   _render() {
     this.feed(require("./skeleton")(this));
+  }
+
+  /**
+   * Fetch the Admin Console bundle while the user is still reading Modal B.
+   *
+   * "Start exploring now" is a click on a button whose destination is a plugin
+   * this document has never loaded — a brand-new org domain, first session.
+   * Measured end to end on stage with a real new account: 3786ms from click to
+   * a visible console, of which 3202ms was ONE chunk,
+   * src_widgets_apps-main_index_js at 1.58 MB (24 chunks, 2.9 MB, fetched 23
+   * at a time, so the concurrency was never the problem — that one file was).
+   *
+   * Nobody clicks instantly: Modal B is four paragraphs and a trial end date.
+   * Spending those seconds on the download turns the click into a cache hit.
+   * The same warm-up is why the second open in a session is already fast.
+   *
+   * Welcome surface only. On the OFFER modal the user has not claimed
+   * anything, may never claim, and on Free has no Admin Console to open —
+   * downloading 2.9 MB at them there would be a cost with no destination.
+   *
+   * Entirely best-effort: no await, failures swallowed. If the bundle is not
+   * there when the click comes, _exploreAfterClaim's broadcast loads it the
+   * normal way, exactly as before.
+   */
+  _warmAdminConsole() {
+    if (this._state !== "welcome") return;
+    try {
+      if (Kind.get("apps_main")) return;
+      Kind.loadPlugin({ name: "admin-console", kind: "apps_main" }).catch(() => {});
+    } catch (e) { /* never let a prefetch break the modal */ }
   }
 
   // ───────── skeleton accessors ─────────

--- a/src/drumee/builtins/widget/promo-launch30/index.js
+++ b/src/drumee/builtins/widget/promo-launch30/index.js
@@ -191,27 +191,61 @@ class __promo_launch30 extends LetcBox {
       });
   }
 
+  /**
+   * Remove THIS modal, and nothing else.
+   *
+   * `parent.clear()` was wrong: launched with {explicit:1}, this widget is
+   * appended to Wm.getWindowsPool(), which is a SHARED layer — windowsLayer,
+   * or headlessLayer whenever a workspace is open. Measured on stage: with the
+   * Account window open, the promo modal's parent reports children
+   * ["window_account", "promo_launch30"], so clearing the parent took the
+   * user's Account window down with the promo.
+   *
+   * Nothing noticed while "Start exploring now" reloaded the page a moment
+   * later, but "Maybe later" and the X have always closed straight into it.
+   */
   _close() {
-    if (this.parent && _.isFunction(this.parent.clear)) this.parent.clear();
-    else this.softDestroy();
+    this.goodbye();
   }
 
   /**
-   * D2: land on Admin Console → Members with Invite open. org_provision
-   * rewrote domain/vhost — same stale-bootstrap problem billing solves with
-   * a full reload on payment.org_provisioned. Flags survive the reload;
-   * Desk opens Admin, apps-main opens Invite.
+   * D2: land on Admin Console → Members with Invite open.
    *
-   * triggerHandlers(toggle-apps) is a no-op here: Wm.launch does not wire
-   * uiHandler to Desk, so the service never reached the sidebar handler.
+   * This used to set two flags and call location.reload(), on the reasoning
+   * that org_provision had rewritten domain/vhost and the bootstrap globals
+   * were stale. They are not stale by the time anyone can click this button:
+   * Modal B is only ever launched by Desk._maybeShowPromoLaunch30 on a HOME
+   * MOUNT, from promo.get_state reporting claimed_active — i.e. in a document
+   * that booted AFTER the claim, with a get_env that already reflects the new
+   * org. (And a reload could not have fixed a domain move anyway: it re-loads
+   * the same URL, it does not move origin.)
+   *
+   * So the reload bought nothing and cost a full app boot. Measured on stage,
+   * with everything warm in cache, the chain that has to complete before the
+   * console can even begin to open is yp.get_env 305-600ms, bootstrap.authn
+   * 680-827ms, desk.get_env 841-976ms, bootstrap.plugin 1179-1304ms — ~1.3s,
+   * plus the 400ms timer the reload path then waits out in
+   * Desk._maybeOpenPromoAdminAfterClaim, plus the desk skeleton and a restore
+   * pass that sleeps 300ms of its own. Reported by a tester as ~5s to reach
+   * the console.
+   *
+   * The same door the over-limit popup uses is already open and costs none of
+   * that: the broadcast lands on Desk._openAdminConsole -> _toggleAppsShim,
+   * the exact command the sidebar item sends. A broadcast rather than
+   * triggerHandlers because Wm.launch does not wire uiHandler to Desk, which
+   * is what defeated the first attempt at this.
+   *
+   * The invite flag stays — admin-console's apps-main is a separate bundle
+   * with no reference to this widget, and a one-shot key is how it is told to
+   * open the panel. It is read and cleared in _loadMembersTab, which the
+   * "member" tab below guarantees will run.
    */
   _exploreAfterClaim() {
     try {
       sessionStorage.setItem("drumee_promo_open_invite", "1");
-      sessionStorage.setItem("drumee_promo_open_admin", "1");
     } catch (e) { /* private mode */ }
     this._close();
-    window.location.reload();
+    RADIO_BROADCAST.trigger("desk:open-admin-console", { tab: "member" });
   }
 
   // ───────── event routing ─────────

--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -685,8 +685,15 @@ class desk_module extends LetcBox {
   }
 
   /**
-   * After promo-launch30 explore → location.reload(), open Admin Console.
-   * Invite panel is opened by apps-main from drumee_promo_open_invite.
+   * Legacy path for promo-launch30's "Start exploring now".
+   *
+   * That button no longer reloads — it broadcasts desk:open-admin-console and
+   * the console opens in place, which is ~1.7s cheaper (see the note on
+   * _exploreAfterClaim). Nothing sets drumee_promo_open_admin any more.
+   *
+   * Kept for one case only: a tab that clicked the button on the previous
+   * build, set the flag, and reloaded into this one. sessionStorage dies with
+   * that tab, so this can be deleted after a deploy cycle.
    */
   _maybeOpenPromoAdminAfterClaim() {
     let open = false;


### PR DESCRIPTION
## Tester báo

Click **"Start exploring now"** trên modal LAUNCH30 → mất ~**5s** mới thấy Admin Console.

## Nguyên nhân

Nút đó đang **reload cả app** chỉ để trao 2 flag `sessionStorage` cho code chạy trong **chính document đó**.

```js
sessionStorage.setItem("drumee_promo_open_invite", "1");
sessionStorage.setItem("drumee_promo_open_admin", "1");
this._close();
window.location.reload();          // ← toàn bộ chi phí nằm ở đây
```

Lý do ghi trong comment là "org_provision đã đổi domain/vhost nên bootstrap globals bị cũ". **Không cũ** tại thời điểm người dùng bấm được nút này: Modal B chỉ được `Desk._maybeShowPromoLaunch30` bật ở **home mount**, khi `promo.get_state` trả `claimed_active` — tức document đang chạy đã boot **sau** khi claim, `get_env` đã phản ánh org mới rồi.

Mà reload cũng **không thể** sửa được chuyện đổi domain: nó load lại **đúng URL cũ**, không chuyển origin.

## Chi phí đo được (stage, cache đã ấm)

Chuỗi bắt buộc phải xong trước khi console *bắt đầu* mở được:

| Request | |
|---|---|
| `yp.get_env` | 305 → 600ms |
| `bootstrap.authn` | 680 → 827ms |
| `desk.get_env` | 841 → 976ms |
| `bootstrap.plugin` | 1179 → 1304ms |

**~1.3s** — cộng thêm `setTimeout(400)` mà đường reload phải đợi trong `_maybeOpenPromoAdminAfterClaim`, cộng desk skeleton, cộng một lượt restore tự ngủ 300ms.

## Sửa

Broadcast `desk:open-admin-console` — đúng cánh cửa over-limit popup đang dùng, rơi vào cùng `_toggleAppsShim` mà sidebar gửi.

Dùng broadcast chứ không `triggerHandlers` vì `Wm.launch` không nối `uiHandler` tới Desk — chính chỗ đó làm lần thử trước thất bại.

**Đo end-to-end trên stage: `106–122ms`** tới lúc console hiện và panel Invite đã mở, so với ~5s.

## Kèm một bug reload đang che

`_close()` gọi `this.parent.clear()`. Widget này launch bằng `{explicit:1}` nên nằm trong `Wm.getWindowsPool()` — một **layer dùng chung** (`windowsLayer`, hoặc `headlessLayer` khi có workspace mở). Nên `parent.clear()` **kéo theo hàng xóm**.

Tái hiện trên stage — mở cửa sổ Account rồi bật popup promo:

```json
{"parentIsWindowsLayer": true,
 "siblingsThatClearWouldDestroy": ["window_account", "promo_launch30"]}
```

"Start exploring now" reload ngay sau đó nên không ai thấy — nhưng **"Maybe later" và nút X thì đâm thẳng vào nó**, không reload gì cả. Đổi sang `goodbye()`.

Kiểm lại sau khi sửa:

```json
{"poolBefore": ["window_account"], "poolAfter": ["window_account"],
 "accountSurvived": true, "promoRemoved": true,
 "t_console_visible_ms": 106, "invitePopupOpen": true}
```

## Ghi chú

`Desk._maybeOpenPromoAdminAfterClaim` được **giữ lại** nhưng đánh dấu legacy: chỉ còn phục vụ tab nào bấm nút trên build cũ, set flag, rồi reload vào build này. `sessionStorage` chết theo tab nên xoá được sau một chu kỳ deploy.