### PR TITLE
feat(gtag): measure the app in GA4, on the marketing site's property

### DIFF
--- a/src/drumee/libs/gtag.js
+++ b/src/drumee/libs/gtag.js
@@ -1,5 +1,6 @@
 /**
- * Google tag (gtag.js) — the Google Ads tag AW-18350168481.
+ * Google tag (gtag.js) — the Google Ads tag AW-18350168481 and the GA4
+ * property G-JWRXMF6HDP.
  *
  * The document itself is not ours to edit: the app boots into a shell served
  * by the backend, and this repo builds bundles, not HTML (there is no
@@ -22,15 +23,46 @@
  * queue provably exists before the library can run, whatever the network does.
  *
  * WHERE IT RUNS — Drumee-operated hosts only, see `TRACKED_HOST`. This is AGPL
- * software that other people deploy on their own domains, and an ad tag
- * compiled into the bundle would otherwise report every one of those
- * deployments to Google under OUR conversion ID: their visitors' traffic
- * leaves their instance, and our Ads reporting fills with conversions no
- * campaign of ours produced. Stage (drumee.in) is excluded by the same rule,
- * which is the point — test signups are not conversions.
+ * software that other people deploy on their own domains, and a tag compiled
+ * into the bundle would otherwise report every one of those deployments to
+ * Google under OUR ids: their visitors' traffic leaves their instance, and our
+ * reporting fills with activity no campaign of ours produced. That guard
+ * matters more with GA4 in the picture than it did with Ads alone — Ads only
+ * hears about conversions, GA4 measures ordinary use of a product whose whole
+ * promise is that your data stays yours. Stage (drumee.in) is excluded by the
+ * same rule, which is the point — test signups are not conversions.
  */
 
 const TAG_ID = "AW-18350168481";
+
+/**
+ * GA4 — the SAME property the marketing site runs, deliberately.
+ *
+ * Until now the app carried the Ads tag and nothing else, so GA4 could see a
+ * visitor arrive on drumee.com and then went blind the moment they crossed to
+ * app.drumee.com: everything after sign-in was unmeasured, and the journey
+ * that ends in a signup was cut in half.
+ *
+ * Nothing extra is needed to stitch that journey back together, because it was
+ * never a cross-domain problem. drumee.com, app.drumee.com and the workspace
+ * hosts <ident>.drumee.com share one registrable domain, and GA4's default
+ * cookie_domain 'auto' resolves to `.drumee.com` — so the cookie, and with it
+ * the session, already spans all three. Confirmed against the live marketing
+ * site, which configures no `linker` and does not need one. A second property
+ * here, or an explicit cookie_domain, would only break that.
+ *
+ * NOTE on page_view. Left at its default (on), so the boot hit exists and the
+ * session is real. drumee.com passes send_page_view:false because its router
+ * emits its own page_view per route (src/lib/analytics.ts); no equivalent
+ * route→page mapping exists for a desk, and inventing one is a separate piece
+ * of work. If the property's Enhanced Measurement "page changes based on
+ * browser history events" turns out to make noise from hash routes, that is a
+ * switch in the GA4 property, not a code change here.
+ */
+const GA4_ID = "G-JWRXMF6HDP";
+
+// One <script> serves every configured id, which is also what keeps this page
+// compliant with Google's "no more than one Google tag per page".
 const SRC = `https://www.googletagmanager.com/gtag/js?id=${TAG_ID}`;
 
 // drumee.com and every subdomain of it (workspaces are `<ident>.drumee.com`).
@@ -98,6 +130,7 @@ function install() {
   // A real Date — gtag stamps the load time from it; Dayjs is not a substitute.
   window.gtag("js", new Date());
   window.gtag("config", TAG_ID);
+  window.gtag("config", GA4_ID);
 
   const el = document.createElement("script");
   el.async = true;
@@ -137,4 +170,4 @@ function event(name, params = {}) {
   }
 }
 
-module.exports = { install, event, isEnabled, TAG_ID };
+module.exports = { install, event, isEnabled, TAG_ID, GA4_ID };

--- a/src/drumee/libs/gtag.js
+++ b/src/drumee/libs/gtag.js
@@ -62,8 +62,11 @@ const TAG_ID = "AW-18350168481";
 const GA4_ID = "G-JWRXMF6HDP";
 
 // One <script> serves every configured id, which is also what keeps this page
-// compliant with Google's "no more than one Google tag per page".
-const SRC = `https://www.googletagmanager.com/gtag/js?id=${TAG_ID}`;
+// compliant with Google's "no more than one Google tag per page". Loaded under
+// the GA4 id, matching drumee.com's own snippet — either id works, and being
+// able to diff the two implementations line for line is worth more than the
+// choice itself.
+const SRC = `https://www.googletagmanager.com/gtag/js?id=${GA4_ID}`;
 
 // drumee.com and every subdomain of it (workspaces are `<ident>.drumee.com`).
 // Anchored both ends: a lookalike host such as `drumee.com.evil.net` must not
@@ -129,8 +132,14 @@ function install() {
 
   // A real Date — gtag stamps the load time from it; Dayjs is not a substitute.
   window.gtag("js", new Date());
+  // Same order and same options as drumee.com's snippet.
+  window.gtag("config", GA4_ID, { send_page_view: false });
   window.gtag("config", TAG_ID);
-  window.gtag("config", GA4_ID);
+  // send_page_view:false suppresses the automatic hit, so the FIRST screen has
+  // to be sent by hand or the session never begins. Everything after it comes
+  // from the router; this is the one the router cannot emit, because install()
+  // runs from module scope of index.web.js, long before a router exists.
+  pageView();
 
   const el = document.createElement("script");
   el.async = true;
@@ -170,4 +179,41 @@ function event(name, params = {}) {
   }
 }
 
-module.exports = { install, event, isEnabled, TAG_ID, GA4_ID };
+// The last screen reported, so the same one is not counted twice.
+let lastPath = null;
+
+/**
+ * Report a screen to GA4.
+ *
+ * `send_page_view: false` is copied from drumee.com deliberately, but it is
+ * only half of what that site does: its router calls trackPageView on every
+ * route (src/lib/analytics.ts). Copying the flag WITHOUT copying the emitter
+ * would mean GA4 receives nothing at all from the app — no page views, no
+ * sessions, no users — which is the opposite of the point. So this exists, and
+ * `router/route()` calls it.
+ *
+ * Why not just leave the automatic hit on: this is a hash router. The
+ * automatic page_view fires once per document, so every screen after the first
+ * would be invisible, and whether the hash counts at all then depends on an
+ * Enhanced Measurement switch in the property rather than on anything in this
+ * repo. Sending them explicitly makes "welcome/signin", "welcome/signup",
+ * "desk" and "desk/billing" distinct screens, which is what a funnel needs.
+ *
+ * Same param shape as the marketing site, so the two feed one report.
+ *
+ * @param {String} [path] defaults to the current pathname + hash
+ * @param {String} [title] defaults to document.title
+ * @returns {Boolean} true when a hit was sent
+ */
+function pageView(path, title) {
+  if (typeof window === "undefined" || typeof window.gtag !== "function") return false;
+  const p = path || `${window.location.pathname}${window.location.hash}`;
+  // route() runs on boot AND on every hashchange, and a few flows call it again
+  // for a URL that has not moved.
+  if (p === lastPath) return false;
+  lastPath = p;
+  event("page_view", { page_path: p, page_title: title || document.title });
+  return true;
+}
+
+module.exports = { install, event, pageView, isEnabled, TAG_ID, GA4_ID };

--- a/src/drumee/router/index.js
+++ b/src/drumee/router/index.js
@@ -397,6 +397,13 @@ class drumee_router extends LetcBox {
         return;
       }
     }
+    // GA4 screen, reported here rather than automatically: the tag is
+    // configured send_page_view:false to match drumee.com, and this is a hash
+    // router, so nothing after the first screen would be counted otherwise.
+    // Below the two redirect branches above on purpose — a bootstrap page or a
+    // changeHost is a URL we are leaving, not one anybody looked at. Deduped
+    // and self-gating; off a drumee.com host it does nothing. See libs/gtag.
+    require('libs/gtag').pageView();
     let name = moduleName();
     const cm = this.currentModule;
     if (cm && !cm.isDestroyed() && cm.mget(_a.name) == name) {


### PR DESCRIPTION
## Vấn đề

App chỉ có thẻ **Google Ads**, không có GA4. Đo trên prod:

```json
// app.drumee.com
{"configIds":["AW-18350168481"], "hasGA4":false, "hasAds":true}

// drumee.com
{"configs":[{"id":"G-JWRXMF6HDP","opts":{"send_page_view":false}},
            {"id":"AW-18350168481","opts":null}]}
```

GA4 thấy khách tới `drumee.com` rồi **mù hẳn** khi họ sang `app.drumee.com`. Mọi thứ sau đăng nhập không được đo.

## Sửa — bám sát đúng snippet của `drumee-landingpage/index.html`

```js
window.gtag("js", new Date());
window.gtag("config", GA4_ID, { send_page_view: false });   // G-JWRXMF6HDP
window.gtag("config", TAG_ID);                              // AW-18350168481
```

Loader nạp dưới **id GA4** (`gtag/js?id=G-JWRXMF6HDP`), y như landing page. Id nào trong URL cũng chạy được — nhưng để hai bản diff được từng dòng thì đáng hơn.

Một `<script>` phục vụ mọi id đã config → vẫn đúng **một thẻ Google mỗi trang**.

## ⚠️ `send_page_view:false` mới là nửa đầu — chép mỗi cờ đó thì tệ hơn không chép

Landing page tắt page_view tự động **vì router của nó tự bắn** `trackPageView` mỗi route (`src/lib/analytics.ts`). Chép mỗi cái cờ mà không chép phần bắn thì GA4 **không nhận được gì từ app** — không page view, không session, không user.

Nên `libs/gtag` có thêm `pageView()`, và `router/route()` gọi nó.

Đó là đúng chỗ nối: `route()` là **điểm hội tụ duy nhất** cho cả cold boot lẫn mọi `hashchange` (`window.onhashchange = this._boundRoute`), và nó đã chứa `captureCampaignArrival` + billing deep-link capture vì cùng lý do. Đặt **dưới** hai nhánh bootstrap-page và `changeHost` — đó là URL đang rời đi, không phải URL ai đó xem.

Bắn tay cũng tốt hơn để tự động: đây là **hash router**, page_view tự động chỉ bắn một lần mỗi document nên mọi màn hình sau màn đầu sẽ vô hình, và hash có được tính hay không lại phụ thuộc một công tắc Enhanced Measurement trong property chứ không phải code trong repo. Giờ `welcome/signin`, `welcome/signup`, `desk`, `desk/billing` là các màn riêng biệt — đúng thứ một funnel cần.

`install()` tự bắn màn đầu, vì nó chạy ở module scope của `index.web.js`, rất lâu trước khi có router.

Dedupe theo path cuối: `route()` chạy lúc boot và mỗi hashchange, vài luồng gọi lại cho URL không đổi.

## Verify trên stage

Guard chặn đúng — không có `script[data-drumee-gtag]`, `gtag` undefined. Stub thẻ rồi đổi route 4 lần (một lần lặp lại):

```json
[{"name":"page_view","page_path":"/-/vudangnt/#/desk/billing"},
 {"name":"page_view","page_path":"/-/vudangnt/#/desk"},
 {"name":"page_view","page_path":"/-/vudangnt/#/desk/billing"}]
```

**4 lần đổi → 3 hit**, lần lặp bị nuốt đúng.

## Không cần linker — chứng minh không ghi gì vào GA4 prod

`drumee.com`, `app.drumee.com` và workspace `<ident>.drumee.com` **cùng registrable domain**, nên `cookie_domain:'auto'` giải ra `.drumee.com`.

Cookie do `drumee.com` đặt, đọc từ `app.drumee.com`:

| | drumee.com | app.drumee.com |
|---|---|---|
| `_ga` | `GA1.1.615314983.178645…` | `GA1.1.615314983.178645…` |
| `_ga_JWRXMF6HDP` | `GS2.1.s1786455874$o1$g…` | `GS2.1.s1786455874$o1$g…` |

**Cùng client id, cùng session** ⇒ phiên nối liền từ landing sang app. Landing page không cấu hình `linker` và cũng không cần; property thứ hai hoặc `cookie_domain` tường minh chỉ làm hỏng cái đang đúng.

## Quyền riêng tư

Guard `TRACKED_HOST` giờ quan trọng hơn hồi chỉ có Ads: Ads chỉ nghe conversion, **GA4 đo việc sử dụng thông thường** của một sản phẩm mà lời hứa cốt lõi là dữ liệu thuộc về bạn — và đây là phần mềm AGPL người khác tự cài. Ngoài `drumee.com` không cài gì, kể cả stage.

Phần người dùng Drumee trên `drumee.com` thì vẫn cần soát consent banner / privacy policy — nằm ngoài code.

## Chưa verify được thẻ thật chạy ở đâu

Stage `drumee.in` bị `TRACKED_HOST` loại — đúng thiết kế. Sau khi lên UAT/prod, kiểm bằng:

```js
(window.dataLayer||[]).map(a=>Array.from(a)).filter(a=>a[0]==="config")
// mong đợi: ["G-JWRXMF6HDP",{send_page_view:false}] và ["AW-18350168481"]
```

## ⚠️ Đụng độ với #486

PR này và **#486** (Ads purchase conversion) cùng sửa `libs/gtag.js`, cùng nhánh từ `preview`. Cái nào merge trước thì cái sau rebase — xung đột nhỏ, khác vùng trong file (#486 thêm `CONVERSION_LABEL` + `conversion()`; PR này thêm `GA4_ID`, `pageView()` và hai dòng `config`).