### PR TITLE
feat(gtag): send the app's page_views explicitly instead of relying on a property toggle

### DIFF
--- a/src/drumee/libs/gtag.js
+++ b/src/drumee/libs/gtag.js
@@ -43,9 +43,14 @@ const TAG_ID = "AW-18350168481";
 // Analytics only; TAG_ID above remains the Ads/conversion tag. The gtag.js
 // loader below is shared — one script serves every configured tag.
 //
-// The app routes by location.hash, and GA4 only counts in-app navigation
-// when the property's Enhanced measurement has hash-based page changes
-// enabled — a property-side toggle, not something this file can set.
+// The app routes by location.hash, so the automatic page_view — which fires
+// once per DOCUMENT — would have counted the screen someone landed on and
+// nothing they did afterwards, with the hash counting or not depending on
+// the property's Enhanced measurement toggle for history-based page changes.
+// That is a setting this file cannot see, let alone guarantee, and an app
+// property that cannot see in-app navigation has very little to report. So
+// the automatic hit is off (send_page_view:false below) and the screens are
+// sent explicitly instead — see pageView().
 const GA4_ID = "G-9123HGZ86W";
 const SRC = `https://www.googletagmanager.com/gtag/js?id=${TAG_ID}`;
 
@@ -114,7 +119,13 @@ function install() {
   // A real Date — gtag stamps the load time from it; Dayjs is not a substitute.
   window.gtag("js", new Date());
   window.gtag("config", TAG_ID);
-  window.gtag("config", GA4_ID);
+  window.gtag("config", GA4_ID, { send_page_view: false });
+  // send_page_view:false suppresses the automatic hit, so the FIRST screen has
+  // to be sent by hand or the property never sees a session at all. Everything
+  // after it comes from the router; this is the one the router cannot emit,
+  // because install() runs from module scope of index.web.js, long before a
+  // router exists.
+  pageView();
 
   const el = document.createElement("script");
   el.async = true;
@@ -154,4 +165,38 @@ function event(name, params = {}) {
   }
 }
 
-module.exports = { install, event, isEnabled, TAG_ID };
+// The last screen reported, so the same one is not counted twice.
+let lastPath = null;
+
+/**
+ * Report a screen to GA4.
+ *
+ * `send_page_view: false` on its own measures NOTHING — no page views, no
+ * sessions, no users — so the two belong together and this is the other half.
+ * `router/route()` calls it. drumee.com does the same thing for the same
+ * reason: its config carries send_page_view:false and its router emits a
+ * page_view per route (drumee-landingpage src/lib/analytics.ts). Same param
+ * shape here, so the two implementations read alike even though they now
+ * report to different properties.
+ *
+ * What this buys the app property: "welcome/signin", "welcome/signup", "desk"
+ * and "desk/billing" arrive as distinct screens however the property is
+ * configured, instead of one hit per document plus whatever an Enhanced
+ * measurement toggle happens to be set to.
+ *
+ * @param {String} [path] defaults to the current pathname + hash
+ * @param {String} [title] defaults to document.title
+ * @returns {Boolean} true when a hit was sent
+ */
+function pageView(path, title) {
+  if (typeof window === "undefined" || typeof window.gtag !== "function") return false;
+  const p = path || `${window.location.pathname}${window.location.hash}`;
+  // route() runs on boot AND on every hashchange, and a few flows call it again
+  // for a URL that has not moved.
+  if (p === lastPath) return false;
+  lastPath = p;
+  event("page_view", { page_path: p, page_title: title || document.title });
+  return true;
+}
+
+module.exports = { install, event, pageView, isEnabled, TAG_ID, GA4_ID };

--- a/src/drumee/router/index.js
+++ b/src/drumee/router/index.js
@@ -397,6 +397,13 @@ class drumee_router extends LetcBox {
         return;
       }
     }
+    // GA4 screen, reported here rather than automatically: the tag is
+    // configured send_page_view:false, and this is a hash router, so nothing
+    // after the first screen would be counted otherwise. Below the two
+    // redirect branches above on purpose — a bootstrap page or a changeHost is
+    // a URL we are leaving, not one anybody looked at. Deduped and
+    // self-gating; off a drumee.com host it does nothing. See libs/gtag.
+    require('libs/gtag').pageView();
     let name = moduleName();
     const cm = this.currentModule;
     if (cm && !cm.isDestroyed() && cm.mget(_a.name) == name) {


### PR DESCRIPTION
Rebase lên `main` mới (`fa23a683` — app dùng property riêng `G-9123HGZ86W`). Xung đột đã hết. **1 commit, 2 file, +57/−5.**

## PR này KHÔNG đụng vào quyết định property

`GA4_ID` và `SRC` giữ nguyên như `fa23a683`. Thay đổi ở đây chạy y hệt nhau dù app báo về property nào.

## Nó đóng đúng cái caveat mà `fa23a683` tự ghi

> *The app routes by location.hash, and GA4 only counts in-app navigation when the property's Enhanced measurement has hash-based page changes enabled — a property-side toggle, not something this file can set.*

Nhận xét đó đúng, và giờ **quan trọng hơn** so với hồi app báo về property marketing: page_view tự động bắn **một lần mỗi document**, tức chỉ ghi được màn hình người ta đáp xuống rồi thôi. Một property dành riêng cho app mà không thấy được điều hướng trong app thì gần như không có gì để báo cáo — và có thấy hay không lại phụ thuộc một công tắc mà file này không đọc được, nói gì đến bảo đảm.

Nên: tắt hit tự động, bắn tay.

| | |
|---|---|
| `gtag('config', GA4_ID, { send_page_view: false })` | tắt hit tự động |
| `install()` | bắn màn đầu (chạy trước khi có router) |
| `router/route()` | bắn mọi màn sau |

`welcome/signin`, `welcome/signup`, `desk`, `desk/billing` giờ là các màn riêng biệt **bất kể property cấu hình thế nào**.

## Giống hệt cách drumee.com làm

Landing page cũng `send_page_view:false` + router tự bắn `trackPageView` mỗi route (`drumee-landingpage src/lib/analytics.ts`). Param shape ở đây khớp với nó, nên hai bản đọc giống nhau dù báo về hai property khác nhau.

⚠️ Chép mỗi cái cờ mà không chép phần bắn thì **tệ hơn không chép gì**: tự nó không đo được gì cả — không page view, không session, không user.

## Nối vào `route()`, vì sao chỗ đó

Là **điểm hội tụ duy nhất** cho cả cold boot lẫn mọi `hashchange` (`window.onhashchange = this._boundRoute`), và đã chứa `captureCampaignArrival` + billing deep-link capture vì cùng lý do.

Đặt **dưới** hai nhánh bootstrap-page và `changeHost` — đó là URL đang rời đi, không phải URL ai xem. Dedupe theo path cuối vì `route()` cũng chạy cho URL không đổi.

## Verify trên stage (bundle đã build lại sau rebase)

Guard chặn đúng: không có `script[data-drumee-gtag]`, `gtag` undefined. Stub thẻ rồi đổi route 4 lần, một lần lặp:

```json
[{"name":"page_view","page_path":"/-/vudangnt/#/desk/billing"},
 {"name":"page_view","page_path":"/-/vudangnt/#/desk"},
 {"name":"page_view","page_path":"/-/vudangnt/#/desk/billing"}]
```

**4 lần đổi → 3 hit**, lần lặp bị nuốt.

Thẻ thật chỉ chạy trên host `drumee.com` nên chỉ kiểm được sau khi lên prod:

```js
(window.dataLayer||[]).map(a=>Array.from(a)).filter(a=>a[0]==="config")
// mong đợi: ["AW-18350168481"] và ["G-9123HGZ86W",{send_page_view:false}]
```

---

## ⚠️ Ba việc cần người quyết, nằm ngoài PR này

**1. Property nào cho app — cần thống nhất.** Yêu cầu ban đầu là gắn `G-JWRXMF6HDP` (chung với landing page, để một property nhìn trọn funnel). `fa23a683` đổi sang `G-9123HGZ86W` với lý do sản phẩm rõ ràng (product analytics tách khỏi marketing, chấp nhận funnel bị cắt). Hai hướng đều hợp lý nhưng **mâu thuẫn nhau** — PR này cố ý không chọn hộ.

**2. `preview` chưa có GA4 dòng nào.** Cả `db26fdb4` lẫn `fa23a683` đều commit thẳng vào `main`. `preview` đang đi trước `main` 47 commit và không có GA4 — lần release `preview → main` tới sẽ **xoá mất hoặc xung đột** với tất cả. Cần port ngược.

**3. #488 giờ là bản trùng và đã lỗi thời** (nó dùng `G-JWRXMF6HDP`). Nên đóng.
