### PR TITLE
fix(gdrive): show the imported files in the folder the user is already in

### DIFF
--- a/src/drumee/builtins/widget/migrate-gdrive-popup/index.js
+++ b/src/drumee/builtins/widget/migrate-gdrive-popup/index.js
@@ -611,6 +611,11 @@ class __migrate_gdrive_popup extends LetcBox {
           this._stopPolling();
           this._state = r.status;
           this._cancelRequested = 0;
+          // The files exist now, so show them where the user already is —
+          // without waiting for a click on "Open in Drumee". A cancelled or
+          // failed run can still have imported part of the set, so those
+          // refresh too; there is nothing to gain from leaving a stale grid.
+          this._refreshDestination();
         }
         // Re-feeding identical content every 2s replaced the Cancel button
         // element for nothing, eating clicks. Only paint real changes.
@@ -774,6 +779,77 @@ class __migrate_gdrive_popup extends LetcBox {
       this.warn('[migrate-gdrive] dismiss_post_onboarding failed', e);
     }
     this._close();
+  }
+
+  /**
+   * Where the import landed, as a nid.
+   *
+   * With direct_into=1 the worker reports the destination folder ITSELF
+   * (importer.js: `_destNidOut = (rootFolder && rootFolder.nid) || nid`), so
+   * this is the folder the user was standing in when they hit "+ New →
+   * Migrate from Google Drive". Without it, it is the GoogleDriveMigration
+   * wrapper the worker created underneath.
+   */
+  _destNid() {
+    const snap = this._jobSnap || {};
+    return snap.dest_nid || this._nid;
+  }
+
+  /**
+   * The open folder window already showing that folder, or null.
+   *
+   * Same predicate as window/utils `_findFolderWindow`, rewritten here because
+   * that one lives on the window base class and this popup is a LetcBox.
+   * getItemsByKind walks the whole Wm tree, so it finds the workspace folder in
+   * headlessLayer as well as a floating one in windowsLayer.
+   */
+  _openFolderWindow(nid) {
+    if (typeof Wm === 'undefined' || !_.isFunction(Wm.getItemsByKind)) return null;
+    try {
+      return (Wm.getItemsByKind('window_folder') || []).find(
+        (w) => w
+          && !(w.isDestroyed && w.isDestroyed())
+          && `${w.mget(_a.hub_id)}` === `${this._hub_id}`
+          && `${w.mget(_a.nid)}` === `${nid}`,
+      ) || null;
+    } catch (e) {
+      this.warn('[migrate-gdrive] folder window lookup failed', e);
+      return null;
+    }
+  }
+
+  /**
+   * Show the imported files where the user already is.
+   *
+   * The direct_into flow exists so nobody has to move files out of a
+   * GoogleDriveMigration folder afterwards — but the folder they were standing
+   * in was rendered BEFORE the import, so it kept showing the old contents and
+   * the migration read as having done nothing. The only way to see the files
+   * was "Open in Drumee", which opened a SECOND window on the very folder
+   * already on screen: the destination nid is that folder's own nid, and
+   * openFileLocation's reuse path only matches a rendered media node, not the
+   * window. Two windows on one folder, to see something that should simply
+   * have appeared.
+   *
+   * refreshContent re-runs loadContent in place, which is what an upload into
+   * an open folder already does.
+   *
+   * @param {Object} [opt]
+   * @param {Boolean} [opt.raise] bring the window forward as well
+   * @returns {Boolean} true when a window was found and refreshed
+   */
+  _refreshDestination(opt = {}) {
+    const win = this._openFolderWindow(this._destNid());
+    if (!win) return false;
+    if (opt.raise && _.isFunction(win.raise)) win.raise();
+    if (!_.isFunction(win.refreshContent)) return false;
+    try {
+      win.refreshContent({});
+    } catch (e) {
+      this.warn('[migrate-gdrive] destination refresh failed', e);
+      return false;
+    }
+    return true;
   }
 
   _close() {
@@ -956,18 +1032,24 @@ class __migrate_gdrive_popup extends LetcBox {
       // destination is usually the HOME the user is already looking at, so
       // opening it reads as "nothing happened".
       case 'gdrive-open-dest': {
-        const snap = this._jobSnap || {};
-        const nid = snap.dest_nid || this._nid;
-        // The popup is launched FROM Settings — its overlay sits above the
-        // desk, so the revealed folder would open BEHIND it. Close the main
-        // panels first (same guard pattern as desk/wm).
+        // Already open — which is the NORMAL case for the direct_into launch,
+        // where the destination is the folder the user started from. Raise and
+        // refresh it instead of opening a second window on the same folder:
+        // openFileLocation would launch one, because its reuse path matches a
+        // rendered media node rather than the folder's own window.
+        if (this._refreshDestination({ raise: true })) return this._close();
+
+        // Not open: the popup was launched from Settings / Home / onboarding,
+        // where the destination is somewhere the user is not. Its overlay sits
+        // above the desk, so the revealed folder would open BEHIND it — close
+        // the main panels first (same guard pattern as desk/wm).
         try {
           if (window.Desk && typeof window.Desk.closeMainPanels === 'function') {
             window.Desk.closeMainPanels();
           }
         } catch (e) { /* non-fatal */ }
         try {
-          Wm.openFileLocation({ nid, hub_id: this._hub_id, filetype: _a.folder });
+          Wm.openFileLocation({ nid: this._destNid(), hub_id: this._hub_id, filetype: _a.folder });
         } catch (e) { /* non-fatal — still close */ }
         return this._close();
       }

--- a/src/drumee/libs/gtag.js
+++ b/src/drumee/libs/gtag.js
@@ -1,5 +1,6 @@
 /**
- * Google tag (gtag.js) — the Google Ads tag AW-18350168481.
+ * Google tag (gtag.js) — the Google Ads tag AW-18350168481 and the GA4
+ * property G-JWRXMF6HDP.
  *
  * The document itself is not ours to edit: the app boots into a shell served
  * by the backend, and this repo builds bundles, not HTML (there is no
@@ -22,15 +23,46 @@
  * queue provably exists before the library can run, whatever the network does.
  *
  * WHERE IT RUNS — Drumee-operated hosts only, see `TRACKED_HOST`. This is AGPL
- * software that other people deploy on their own domains, and an ad tag
- * compiled into the bundle would otherwise report every one of those
- * deployments to Google under OUR conversion ID: their visitors' traffic
- * leaves their instance, and our Ads reporting fills with conversions no
- * campaign of ours produced. Stage (drumee.in) is excluded by the same rule,
- * which is the point — test signups are not conversions.
+ * software that other people deploy on their own domains, and a tag compiled
+ * into the bundle would otherwise report every one of those deployments to
+ * Google under OUR ids: their visitors' traffic leaves their instance, and our
+ * reporting fills with activity no campaign of ours produced. That guard
+ * matters more with GA4 in the picture than it did with Ads alone — Ads only
+ * hears about conversions, GA4 measures ordinary use of a product whose whole
+ * promise is that your data stays yours. Stage (drumee.in) is excluded by the
+ * same rule, which is the point — test signups are not conversions.
  */
 
 const TAG_ID = "AW-18350168481";
+
+/**
+ * GA4 — the SAME property the marketing site runs, deliberately.
+ *
+ * Until now the app carried the Ads tag and nothing else, so GA4 could see a
+ * visitor arrive on drumee.com and then went blind the moment they crossed to
+ * app.drumee.com: everything after sign-in was unmeasured, and the journey
+ * that ends in a signup was cut in half.
+ *
+ * Nothing extra is needed to stitch that journey back together, because it was
+ * never a cross-domain problem. drumee.com, app.drumee.com and the workspace
+ * hosts <ident>.drumee.com share one registrable domain, and GA4's default
+ * cookie_domain 'auto' resolves to `.drumee.com` — so the cookie, and with it
+ * the session, already spans all three. Confirmed against the live marketing
+ * site, which configures no `linker` and does not need one. A second property
+ * here, or an explicit cookie_domain, would only break that.
+ *
+ * NOTE on page_view. Left at its default (on), so the boot hit exists and the
+ * session is real. drumee.com passes send_page_view:false because its router
+ * emits its own page_view per route (src/lib/analytics.ts); no equivalent
+ * route→page mapping exists for a desk, and inventing one is a separate piece
+ * of work. If the property's Enhanced Measurement "page changes based on
+ * browser history events" turns out to make noise from hash routes, that is a
+ * switch in the GA4 property, not a code change here.
+ */
+const GA4_ID = "G-JWRXMF6HDP";
+
+// One <script> serves every configured id, which is also what keeps this page
+// compliant with Google's "no more than one Google tag per page".
 const SRC = `https://www.googletagmanager.com/gtag/js?id=${TAG_ID}`;
 
 // drumee.com and every subdomain of it (workspaces are `<ident>.drumee.com`).
@@ -98,6 +130,7 @@ function install() {
   // A real Date — gtag stamps the load time from it; Dayjs is not a substitute.
   window.gtag("js", new Date());
   window.gtag("config", TAG_ID);
+  window.gtag("config", GA4_ID);
 
   const el = document.createElement("script");
   el.async = true;
@@ -137,4 +170,4 @@ function event(name, params = {}) {
   }
 }
 
-module.exports = { install, event, isEnabled, TAG_ID };
+module.exports = { install, event, isEnabled, TAG_ID, GA4_ID };

--- a/src/drumee/libs/gtag.js
+++ b/src/drumee/libs/gtag.js
@@ -1,6 +1,6 @@
 /**
  * Google tag (gtag.js) — the Google Ads tag AW-18350168481 and the GA4
- * property G-JWRXMF6HDP.
+ * property G-9123HGZ86W.
  *
  * The document itself is not ours to edit: the app boots into a shell served
  * by the backend, and this repo builds bundles, not HTML (there is no
@@ -36,30 +36,23 @@
 const TAG_ID = "AW-18350168481";
 
 /**
- * GA4 — the SAME property the marketing site runs, deliberately.
+ * GA4 — the app's OWN property ("app.drumee.com", G-9123HGZ86W), not the
+ * marketing site's G-JWRXMF6HDP. The split is deliberate: the landing page
+ * is marketing, the app is product, and each team reads its own property
+ * without the other's noise.
  *
- * Until now the app carried the Ads tag and nothing else, so GA4 could see a
- * visitor arrive on drumee.com and then went blind the moment they crossed to
- * app.drumee.com: everything after sign-in was unmeasured, and the journey
- * that ends in a signup was cut in half.
+ * What the split costs: a session cannot span two properties, so GA4 shows
+ * no single funnel from ad click to signup — the visitor "ends" on the
+ * marketing property and "starts" here, even though the `.drumee.com`
+ * cookie itself spans both hosts. Cross-site campaign attribution is
+ * measured where it survives that cut: Google Ads (the AW tag + gclid) and
+ * the backend's profile.utm.
  *
- * Nothing extra is needed to stitch that journey back together, because it was
- * never a cross-domain problem. drumee.com, app.drumee.com and the workspace
- * hosts <ident>.drumee.com share one registrable domain, and GA4's default
- * cookie_domain 'auto' resolves to `.drumee.com` — so the cookie, and with it
- * the session, already spans all three. Confirmed against the live marketing
- * site, which configures no `linker` and does not need one. A second property
- * here, or an explicit cookie_domain, would only break that.
- *
- * NOTE on page_view. Left at its default (on), so the boot hit exists and the
- * session is real. drumee.com passes send_page_view:false because its router
- * emits its own page_view per route (src/lib/analytics.ts); no equivalent
- * route→page mapping exists for a desk, and inventing one is a separate piece
- * of work. If the property's Enhanced Measurement "page changes based on
- * browser history events" turns out to make noise from hash routes, that is a
- * switch in the GA4 property, not a code change here.
+ * page_view is not left to the property: install() passes
+ * send_page_view:false and the router emits explicit screens via pageView()
+ * below — see its comment for why a hash router needs that.
  */
-const GA4_ID = "G-JWRXMF6HDP";
+const GA4_ID = "G-9123HGZ86W";
 
 // One <script> serves every configured id, which is also what keeps this page
 // compliant with Google's "no more than one Google tag per page". Loaded under

--- a/src/drumee/libs/gtag.js
+++ b/src/drumee/libs/gtag.js
@@ -62,8 +62,11 @@ const TAG_ID = "AW-18350168481";
 const GA4_ID = "G-JWRXMF6HDP";
 
 // One <script> serves every configured id, which is also what keeps this page
-// compliant with Google's "no more than one Google tag per page".
-const SRC = `https://www.googletagmanager.com/gtag/js?id=${TAG_ID}`;
+// compliant with Google's "no more than one Google tag per page". Loaded under
+// the GA4 id, matching drumee.com's own snippet — either id works, and being
+// able to diff the two implementations line for line is worth more than the
+// choice itself.
+const SRC = `https://www.googletagmanager.com/gtag/js?id=${GA4_ID}`;
 
 // drumee.com and every subdomain of it (workspaces are `<ident>.drumee.com`).
 // Anchored both ends: a lookalike host such as `drumee.com.evil.net` must not
@@ -129,8 +132,14 @@ function install() {
 
   // A real Date — gtag stamps the load time from it; Dayjs is not a substitute.
   window.gtag("js", new Date());
+  // Same order and same options as drumee.com's snippet.
+  window.gtag("config", GA4_ID, { send_page_view: false });
   window.gtag("config", TAG_ID);
-  window.gtag("config", GA4_ID);
+  // send_page_view:false suppresses the automatic hit, so the FIRST screen has
+  // to be sent by hand or the session never begins. Everything after it comes
+  // from the router; this is the one the router cannot emit, because install()
+  // runs from module scope of index.web.js, long before a router exists.
+  pageView();
 
   const el = document.createElement("script");
   el.async = true;
@@ -170,4 +179,41 @@ function event(name, params = {}) {
   }
 }
 
-module.exports = { install, event, isEnabled, TAG_ID, GA4_ID };
+// The last screen reported, so the same one is not counted twice.
+let lastPath = null;
+
+/**
+ * Report a screen to GA4.
+ *
+ * `send_page_view: false` is copied from drumee.com deliberately, but it is
+ * only half of what that site does: its router calls trackPageView on every
+ * route (src/lib/analytics.ts). Copying the flag WITHOUT copying the emitter
+ * would mean GA4 receives nothing at all from the app — no page views, no
+ * sessions, no users — which is the opposite of the point. So this exists, and
+ * `router/route()` calls it.
+ *
+ * Why not just leave the automatic hit on: this is a hash router. The
+ * automatic page_view fires once per document, so every screen after the first
+ * would be invisible, and whether the hash counts at all then depends on an
+ * Enhanced Measurement switch in the property rather than on anything in this
+ * repo. Sending them explicitly makes "welcome/signin", "welcome/signup",
+ * "desk" and "desk/billing" distinct screens, which is what a funnel needs.
+ *
+ * Same param shape as the marketing site, so the two feed one report.
+ *
+ * @param {String} [path] defaults to the current pathname + hash
+ * @param {String} [title] defaults to document.title
+ * @returns {Boolean} true when a hit was sent
+ */
+function pageView(path, title) {
+  if (typeof window === "undefined" || typeof window.gtag !== "function") return false;
+  const p = path || `${window.location.pathname}${window.location.hash}`;
+  // route() runs on boot AND on every hashchange, and a few flows call it again
+  // for a URL that has not moved.
+  if (p === lastPath) return false;
+  lastPath = p;
+  event("page_view", { page_path: p, page_title: title || document.title });
+  return true;
+}
+
+module.exports = { install, event, pageView, isEnabled, TAG_ID, GA4_ID };

--- a/src/drumee/router/index.js
+++ b/src/drumee/router/index.js
@@ -397,6 +397,13 @@ class drumee_router extends LetcBox {
         return;
       }
     }
+    // GA4 screen, reported here rather than automatically: the tag is
+    // configured send_page_view:false to match drumee.com, and this is a hash
+    // router, so nothing after the first screen would be counted otherwise.
+    // Below the two redirect branches above on purpose — a bootstrap page or a
+    // changeHost is a URL we are leaving, not one anybody looked at. Deduped
+    // and self-gating; off a drumee.com host it does nothing. See libs/gtag.
+    require('libs/gtag').pageView();
     let name = moduleName();
     const cm = this.currentModule;
     if (cm && !cm.isDestroyed() && cm.mget(_a.name) == name) {


### PR DESCRIPTION
Reopen của issue "migrate thẳng vào folder đích": migrate xong **không hiện gì trong workspace đó**, phải bấm "Open in Drumee" thì nó mới mở workspace lần nữa.

## Nguyên nhân

`direct_into=1` cho worker đặt `_destNidOut = nid` ([importer.js:288](https://github.com/drumee/server-team/blob/preview/offline/workers/gdrive/importer.js#L288)) — tức **destination chính là folder người dùng đang đứng**.

Nhưng folder window đó đã render **trước khi** import chạy, và **không ai bảo nó nạp lại**. Popup chỉ đổi `_state = 'done'` rồi dừng. Grid giữ nguyên nội dung cũ ⇒ một lần migrate thành công trông như chẳng có gì xảy ra, và cách duy nhất để thấy file là bấm nút.

## Sửa

**1. Popup tự refresh destination khi job dừng.**

`refreshContent` chạy lại `loadContent` tại chỗ — đo trên stage: `media.show_node_by` + `media.get_path` được gọi lại và grid render lại, đúng như khi upload vào một folder đang mở. Job `cancelled`/`failed` cũng refresh: cả hai đều có thể đã import được một phần, để lại grid cũ chẳng lợi gì.

**2. Tìm cửa sổ đang mở.**

`window/utils` đã có `_findFolderWindow`, nhưng nó nằm trên window base class còn popup này là `LetcBox` — nên cùng phép so khớp (cùng hub, cùng nid) được viết lại ở đây. `getItemsByKind` duyệt toàn bộ cây Wm nên bắt được **cả workspace ở `headlessLayer`** lẫn cửa sổ nổi ở `windowsLayer` — đã verify với workspace headless thật.

**3. "Open in Drumee" tái dùng cửa sổ đó** khi nó đang mở: `raise` → `refresh` → đóng popup.

Đường cũ giữ nguyên cho các launch mà destination thật sự ở nơi khác (Settings / Home / onboarding) — ở đó `closeMainPanels()` là thứ ngăn folder mở **phía sau** overlay của popup. Còn với `direct_into` thì destination chính là folder đang trên màn hình, nên đóng panel rồi vào lại khiến workspace **hiện ra lần nữa** một cách vô nghĩa.

## Verify trên stage

Dựng đúng bối cảnh của tester — workspace mở ở headless layer:

```json
{"newCodeShipped": true,
 "foundOpenFolderWindow": true,
 "refreshReturned": true,
 "countBefore": 1, "countAfter": 1, "noExtraWindow": true}
```

Và refresh có gọi server thật:

```json
{"serviceCallsTriggered": ["media.get_path", "media.show_node_by"]}
```

## ⚠️ Điều em KHÔNG tái hiện được

Báo cáo mô tả cú click "mở workspace đó lần nữa (duplicated)", và `openFileLocation` trông rất giống thủ phạm — đường tái dùng cửa sổ của nó chỉ chạy cho tab deep link, còn lại chỉ khớp một media node đã render chứ không khớp cửa sổ folder.

Nhưng khi gọi thẳng nó trên stage, nó **không** tạo cửa sổ thứ hai — cả với cửa sổ folder nổi lẫn với workspace headless: **1 cửa sổ trước, 1 cửa sổ sau**, cả hai lần.

```json
{"label":"OLD — openFileLocation while the workspace is open headless",
 "countBefore":1,"countAfter":1,"DUPLICATED":false}
```

Nên PR này **không nhận** là sửa lỗi nhân đôi cửa sổ. Cái nó sửa là **grid không cập nhật** (tái hiện được từ code path) và **việc vào lại một folder chưa từng rời khỏi**. Nếu tester vẫn thấy hai workspace sau bản này, cần một repro cụ thể hơn — nhiều khả năng destination lúc đó khác nid với cái đang mở.

## Ghi chú ngoài lề

Trong lúc verify, desk trên stage crash với `Cannot find module 'libs/hotkeys'`. File đó **chỉ tồn tại trên nhánh `test`**, không có trên `preview` lẫn `main` — đây là webpack cache còn giữ chunk từ lần build nhánh `test`, không phải lỗi code. Xoá `build/` + `node_modules/.cache` rồi build lại là hết.
