### PR TITLE
fix(folder): close the role menu instantly instead of flying it upward

### DIFF
--- a/src/drumee/builtins/window/folder/index.js
+++ b/src/drumee/builtins/window/folder/index.js
@@ -4301,10 +4301,24 @@ class __window_folder extends mfsInteract {
 
     // The option fires its pick straight at this window via uiHandler, so the
     // click never bubbles back to the menu_topic for it to auto-close. Close
-    // it explicitly (animated, widget kept alive) so the dropdown dismisses on
-    // every pick and stays reusable for the next change.
+    // it explicitly, so the dropdown dismisses on every pick and stays
+    // reusable for the next change.
+    //
+    // Instantly, though — NOT changeState(0). That routes into ui-core's
+    // _closeItems, which tweens the items by (items_width + trigger_width)
+    // before _onClosed hides them; for a `down` menu the tween is negative y,
+    // so the box visibly flies UP the screen and only then vanishes. Reported
+    // as "box permission bị bay lên trên hơi khó hiểu" — and it is, because
+    // the motion points away from the row the choice belongs to.
+    //
+    // _onClosed IS the end state that tween is animating towards: it flips the
+    // dataset/state flags and gsap.set()s the transform back to 0. Calling it
+    // directly lands there in one frame, and the menu stays reusable — same
+    // final state, no journey. changeState remains the fallback in case a
+    // future ui-core drops the hook.
     const menu = cmd.getParentByKind?.(KIND.menu.topic);
-    if (menu?.changeState) menu.changeState(0);
+    if (_.isFunction(menu?._onClosed)) menu._onClosed();
+    else if (_.isFunction(menu?.changeState)) menu.changeState(0);
   }
 
   // Menu pick from a member-row role dropdown — confirm and persist the


### PR DESCRIPTION
Chọn permission trong **Folder Setting → Invite Member** thì box trượt **lên trên** rồi mới biến mất — hướng chuyển động đi ngược khỏi hàng mà lựa chọn đó thuộc về, nên nhìn khó hiểu.

## Nguyên nhân

Menu **đã** được đóng khi pick rồi — option bắn thẳng vào window qua `uiHandler` nên click không bubble ngược lại cho menu tự đóng, code phải gọi tay. Nhưng nó gọi `changeState(0)`, thứ dẫn vào `_closeItems` của ui-core:

```js
// @drumee/ui-core/letc/widgets/menu/index.js
case _a.down:
  gsap.to(items.el, { y: -y, duration: d, ...opt });   // y = items_width + trigger_width
```

Role dropdown có `direction: "down"` → tween `y` **âm** → box bay lên. `_onClosed` chỉ chạy ở `onComplete`, tức chỉ ẩn **sau khi** bay xong.

## Đo trên stage, đúng dropdown đó

Lấy transform của phần tử items mỗi 55ms:

| | translateY qua từng frame | đỉnh dịch lên |
|---|---|---|
| `changeState(0)` — cũ | `0, 0, 0, -3, -25, -172, -211, -218, -218, 0` | **−218px** |
| `_onClosed()` — mới | `0, 0, 0, 0, 0, 0, 0, 0, 0, 0` | **0** |

**218px đi lên** rồi mới biến mất.

## Sửa

`_onClosed` **chính là trạng thái cuối** mà tween kia đang hướng tới: nó lật cờ `dataset`/`state` và `gsap.set()` transform về 0. Gọi thẳng nó thì tới đích trong một frame — cùng kết quả, bỏ đoạn đường.

Cả hai đường đều kết thúc với `isOpen === false` và transform `0`, nên menu vẫn dùng lại được cho lần chọn sau — đã xác nhận trong cùng lượt đo.

`changeState` giữ làm fallback phòng khi ui-core sau này bỏ hook.

## Phạm vi

Chỉ dropdown ở **hàng invite**. Dropdown ở **hàng member** (`setFolderMemberRole`) không gọi đường đóng có animation — nó mở confirm dialog rồi để `_refeedFolderMembersPanel` dựng lại panel — nên không dính lỗi này.

Nó **có** một chuyện khác: nếu bấm Cancel ở confirm thì menu vẫn nằm đó. Đó là câu hỏi riêng, PR này không đụng vào — nói ra để anh biết chứ không tiện tay sửa kèm.
