### PR TITLE
feat(signin): wire up Google / Apple sign-in in welcome/signin

### DIFF
--- a/docs/superpowers/specs/2026-08-11-welcome-signin-oauth-design.md
+++ b/docs/superpowers/specs/2026-08-11-welcome-signin-oauth-design.md
@@ -1,0 +1,170 @@
+# OAuth sign-in (Google / Apple) in the built-in welcome/signin module
+
+**Date:** 2026-08-11
+**Status:** approved
+**Touches:** ui-team (client), loby (callback error handling), schemas (oauth_state.ref)
+
+## Problem
+
+`welcome/signin` already renders "Continue with Google" and "Continue with
+Apple" — `skeleton/content.js` draws both — but the click handler was a stub:
+
+```js
+// ---- Social sign-in (no initiate service on this server yet) ----
+case "use-google":
+case "use-apple":
+  return this.renderMessage(LOCALE.COMING_SOON || "Coming soon");
+```
+
+The server side has existed for a while in the `loby` plugin
+(`google.initiate` / `google.callback`, `apple.*`, `oauth.verify_otp` /
+`resend_otp` / `cancel_otp`), and the standalone **signin plugin**
+(`@drumee/signin`) drives it. The built-in module — which is what
+`welcome/index.js -> loadSignin()` falls back to whenever
+`Platform.get('plugins').signin` is absent — never learned how.
+
+## What the flow already does without us
+
+Worth stating, because it bounds the work: the non-2FA return leg needs no client
+code at all. `google.callback` finishes by serving `account-created.html`, which
+either redirects to the desk (existing sign-in) or shows the welcome card whose
+CTA continues there (new account). The browser is handed a finalized session
+cookie by `sendHtml`. So the client is responsible for exactly three things:
+
+1. starting the flow (`initiate` → provider redirect),
+2. the 2FA return leg, which loby cannot finish on its own,
+3. the failure return leg.
+
+## Two things that make this non-obvious
+
+### 1. The OAuth return collides with the password-2FA branch
+
+`session_check_cookie` derives `connection` from the **otp table**, not from
+`cookie.status`:
+
+```sql
+SELECT o.secret, IF(unix_timestamp() < (o.ctime + 600), 0, 1) expired
+  FROM otp o INNER JOIN cookie c ON c.uid=o.uid
+  WHERE c.id=_sid ... INTO _secret, _expired;
+IF _secret IS NULL THEN SELECT 'ok' INTO _connection;
+ELSE ... SELECT 'otp' INTO _connection;
+```
+
+After `google.callback` hits the 2FA gate it has done both things that satisfy
+that query: `session_login_with_oauth` set `cookie.uid` and left
+`status='otp_pending'`, and `_send2faOtp` minted an `otp` row. So the page the
+user lands on reports **`connection: 'otp'`** — the same value a
+password-plus-2FA sign-in produces.
+
+`onDomRefresh` switches on exactly that value, and its `case "otp"` calls
+`prompt_otp({secret: Visitor.get("otp_key")})`, which posts to `yp.authenticate`
+with a client-side secret. On the OAuth path there is no client-side secret by
+design. So the OAuth hand-off **must** be tested before the switch. (The signin
+plugin's router orders it the same way, which is why it works there.)
+
+### 2. `dtk_otp` does not recognise `verify_otp`'s failure shape
+
+`oauth.verify_otp` answers `{status:'success'}` or `{status:'error'}`. The
+widget classifies responses with:
+
+```js
+const errStatus = ['wrong-code', 'no-user', 'no-socket', 'expired', 'invalid',
+                   'INVALID_CODE', 'INVALID_SECRET'];
+```
+
+`'error'` is not on it, and the response carries no `error` key — so a mistyped
+code reads as **success**, fires the host's success service and reloads. The user
+gets a blank OTP screen back with no explanation.
+
+Fixed by wrapping the instance's `postService` and normalizing the response
+before the widget inspects it. Wrapping rather than patching `dtk_otp` keeps the
+change off the reconnect and password-reset screens, whose APIs already answer in
+shapes it understands. `builtins/widget/otp-gate` wraps the same method for its
+own submit spinner, so this is an established idiom here.
+
+## Design
+
+### ui-team
+
+**`skeleton/content.js`** — gate the divider and the social block on
+`SERVICE.google.initiate` / `SERVICE.apple.initiate`, per provider. These
+services reach the client through `Platform.get('services')`, so an install
+without loby simply has none, and a button that cannot start a flow should not be
+drawn. Empty-string kids are the file's existing idiom for a conditional child
+(`forgotRow`, `signupPrompt`).
+
+**`index.js`**
+
+| Piece | Behaviour |
+|---|---|
+| `startOauth(provider)` | POST `<provider>.initiate`; on `{status:'prompt', authUrl}` set `location.href`. The URL must come from `initiate` — it also writes the single-use `oauth_state` row carrying this session id, which is how the cross-site callback finds its way back to this visitor. Spinner stays up through the navigation so a second click cannot mint a second state row. |
+| `_oauthMfaParams()` | `oauth_mfa=1` + decoded `email`, via `Visitor.parseModuleArgs()` (splits on `[#/&?]`, does **not** decode). Returns null — and warns — when `oauth.verify_otp` is unregistered; the sign-in form beats a screen that cannot submit. |
+| `_oauthErrorParam()` / `_oauthErrorMessage()` | Map loby's reasons to lexicon copy. `default` collapses to a generic line so no internal token can reach the screen. |
+| `onDomRefresh` | `oauth_mfa` first (see above), then `oauth_error`, then the existing switch untouched. |
+| `_promptOtpOauth(email)` | Registers `dtk_otp` on demand and feeds `skeleton/otp-oauth.js` — mirrors `_promptOtpReconnect`, since this bundle does not run the widget's `loadSeeds()`. |
+| `_armOauthOtp(otp)` | The response normalization above. Idempotent. |
+| `_resendOauthOtp()` | Host-driven (`resendService`): the widget assigns its resend *response* over `payload`, and `resend_otp` answers `{status:'ok'}`, which would wipe the email the copy is built from. Clears the digit boxes, per the `otp-gate` resend contract. |
+| `back-to-signin` | In the OAuth screen, POST `oauth.cancel_otp` first. Nothing else can clear that cookie: `session_logout` matches by uid, which a never-authenticated session lacks, so a plain reload lands straight back on the OTP screen. Best-effort — we return to the form either way. |
+| `oauth-otp-verified` | Scrub the hand-off params, then reload. `verify_otp` returns only a status, so there is no payload to feed `gotSignedIn`; and reloading with `oauth_mfa=1` still set would re-enter the OTP screen against a session that is already finalized. |
+
+**`skeleton/otp-oauth.js`** (new) — `dtk_otp` (6 numeric boxes, `api:
+SERVICE.oauth.verify_otp`, `service: 'oauth-otp-verified'`) plus a "Back to sign
+in" row. The payload deliberately carries **no secret**: on this path it never
+leaves the server, and `verify_otp` resolves it from the pending session. The
+back link sits beside the widget rather than inside it because leaving needs a
+server round-trip the widget knows nothing about.
+
+**`skin/index.scss`** — the existing `&__items.reconnect` block already reshapes
+`dtk_otp` from its full-page default (52×72 cells, 180px top offset) into the
+`otp-gate` card. The OAuth screen occupies the same content slot, so it joins
+that selector rather than re-deriving it. Adds `&__backlink-row` / `&__backlink`.
+
+Note for anyone extending that block: `drumee.typo()` maps `$weight` to a
+*font-family* and only handles 300/400/500/700, so `$weight: 600` emits nothing —
+the semibold face has to be named explicitly, as `__social-label` already does.
+
+### loby
+
+- `apple.callback` had no error handling whatsoever: no try/catch, and
+  `if (!res.error)` with no `else`. `oauth_not_linked`, a failed token exchange
+  or a JWKS failure therefore returned **nothing at all** to the browser. Brought
+  to parity with `google.callback` (`sendOauthError`), which is also what makes
+  the new client-side `oauth_error` handling reachable on the Apple path.
+- Stripped the `AAA:` / `AAAA:` debug logs — including `apple.js:152`, which
+  dumped the whole verified ID-token payload (email, `sub`) into the server log
+  on every Apple sign-in — and the dead `handleAppleResponse`.
+
+### schemas
+
+`initiate` writes `oauth_state (state, session_id, ref, ctime)` for referral
+attribution, with a try/catch falling back to a 3-column insert "on a DB without
+the optional ref column". No schema in the repo has that column — not
+`tables/oauth_state.sql`, not `templates/factory/seed/yp.sql` — so on a freshly
+seeded database the fallback fires on **every** OAuth sign-in and referral
+attribution is silently lost. Adds the patch, the column, and a manifest entry.
+
+## Testing
+
+The flow cannot be exercised on this box: `yp` here has no `oauth_accounts` or
+`oauth_state` tables, so `initiate` fails before it can redirect. (The locally
+deployed `session_login_with_oauth` is also older than the repo's — it has the
+`otp_pending` branch but not the STEP 1b Drive-pollution guard.) So no live
+provider round-trip was performed, and none of the claims below rest on one.
+
+- `tests/welcome-signin-oauth.test.js` — 33 `node:test` cases driving the real
+  module, with only the bundle surroundings stubbed. Covers the ordering
+  guarantee in both directions, the error-shape normalization, the
+  no-secret-in-payload invariant, initiate success/refusal/rejection, resend,
+  cancel-on-leave, and per-provider button gating.
+- `sass` compile of `skin/index.scss` against the webpack load paths.
+
+## Not done
+
+- No lexicon keys were added. New copy uses the `LOCALE.X || "fallback"` pattern
+  already used throughout this module, so the screens read correctly in English
+  before translation and pick the keys up when they land:
+  `BACK_TO_SIGN_IN`, `SIGNIN_CANCELLED`, `OAUTH_NOT_LINKED`.
+- `oauth_not_linked` gets explanatory copy but no action. The productive version
+  offers "sign in with your password and link it in settings" as a flow rather
+  than as a sentence; that needs a linking surface in account settings, which is
+  out of scope here.

--- a/src/drumee/modules/welcome/signin/index.js
+++ b/src/drumee/modules/welcome/signin/index.js
@@ -43,6 +43,21 @@ class __welcome_signin extends __welcome_interact {
    *
    */
   onDomRefresh() {
+    // OAuth 2FA hand-off. This MUST be tested before the connection switch
+    // below, and the ordering is not cosmetic: session_check_cookie derives
+    // `connection` from the otp TABLE, not from cookie.status, so the pending
+    // cookie plus the code loby just minted make this load report
+    // connection == 'otp'. Left to the switch, an OAuth return would be
+    // hijacked by the password-2FA branch and posted to yp.authenticate with a
+    // client-side secret — which this path deliberately does not have.
+    const mfa = this._oauthMfaParams();
+    if (mfa) {
+      return this._promptOtpOauth(mfa.email);
+    }
+    // Provider callback gave up (user cancelled on the consent screen, expired
+    // state, unlinked address, token exchange failed). loby has already bounced
+    // us back here with the reason; surface it once the form is rendered.
+    const oauthError = this._oauthErrorParam();
     let opt = {};
     switch (bootstrap().connection) {
       case "otp":
@@ -86,6 +101,64 @@ class __welcome_signin extends __welcome_interact {
       //     this.feed(this._skeleton(this, opt));
       // }
     }
+    if (oauthError) {
+      this._renderOauthError(oauthError);
+    }
+  }
+
+  /**
+   * Read the query the provider hand-off appends to the sign-in route. It rides
+   * INSIDE the hash fragment (#/welcome/signin?oauth_mfa=1&email=…), which is
+   * what parseModuleArgs already parses — it splits on [#/&?] and does NOT
+   * percent-decode, so any value read here needs decoding.
+   * @returns {object}
+   */
+  _oauthArgs() {
+    return Visitor.parseModuleArgs() || {};
+  }
+
+  /**
+   * Decode one value out of the hash query, tolerating a malformed escape
+   * sequence (decodeURIComponent throws on a bare '%').
+   * @param {string} raw
+   * @returns {string}
+   */
+  _decodeArg(raw) {
+    const s = String(raw == null ? "" : raw);
+    try {
+      return decodeURIComponent(s);
+    } catch (e) {
+      return s;
+    }
+  }
+
+  /**
+   * An OAuth sign-in that stopped at the 2FA gate. loby's provider callback
+   * leaves the session pending and bounces the browser to
+   * #/welcome/signin?oauth_mfa=1&email=…
+   * @returns {{email:string}|null} null when this is not an OAuth 2FA return.
+   */
+  _oauthMfaParams() {
+    const args = this._oauthArgs();
+    if (args.oauth_mfa !== "1") {
+      return null;
+    }
+    // Guard the whole feature on the finalize service being reachable: without
+    // oauth.verify_otp the OTP screen could take a code and never submit it,
+    // which is a worse dead end than the sign-in form.
+    if (!(SERVICE.oauth && SERVICE.oauth.verify_otp)) {
+      this.warn("oauth_mfa hand-off but oauth.verify_otp is not registered");
+      return null;
+    }
+    return { email: this._decodeArg(args.email) };
+  }
+
+  /**
+   * Reason a provider callback aborted, as set by loby's sendOauthError.
+   * @returns {string} '' when the return was not an error.
+   */
+  _oauthErrorParam() {
+    return this._decodeArg(this._oauthArgs().oauth_error);
   }
 
   /**
@@ -244,6 +317,13 @@ class __welcome_signin extends __welcome_interact {
       case "back-to-signin":
         clearInterval(this._tick);
         this._counting = false;
+        // Abandoning the OAuth 2FA screen needs server-side cleanup first: the
+        // otp_pending cookie outlives a plain reload and would land us straight
+        // back on this screen. Checked before the reconnect branch because the
+        // OAuth screen can also be reached from the reconnect popup.
+        if (this._inOauthMfa) {
+          return this._cancelOauthMfa();
+        }
         if (this.mget(RECONNECT)) {
           // Reconnect popup: re-rendering in place leaves the modal over the
           // desk. Navigate to the real sign-in page so the screen matches the
@@ -270,10 +350,22 @@ class __welcome_signin extends __welcome_interact {
         location.hash = "#/welcome/terms";
         return;
 
-      // ---- Social sign-in (no initiate service on this server yet) ----
+      // ---- Social sign-in (Google / Apple, served by the loby plugin) ----
       case "use-google":
+        return this.startOauth("google");
+
       case "use-apple":
-        return this.renderMessage(LOCALE.COMING_SOON || "Coming soon");
+        return this.startOauth("apple");
+
+      case "resend-oauth-otp":
+        return this._resendOauthOtp();
+
+      case "oauth-otp-verified":
+        // oauth.verify_otp promoted the pending cookie to 'ok'. It returns only
+        // a status — no user/hub/organization payload — so there is nothing to
+        // feed gotSignedIn with; re-boot instead and let bootstrap resolve the
+        // now-authenticated session.
+        return this._reloadClean();
 
       default:
         return super.onUiEvent(cmd, args);
@@ -428,6 +520,246 @@ class __welcome_signin extends __welcome_interact {
       return this.feed(this._skeleton(this, { content: skel }));
     }
     this.__content.feed(skel);
+  }
+
+  /**
+   * Start a provider sign-in: ask loby for the authorization URL, then hand the
+   * browser to the provider.
+   *
+   * `initiate` does more than build a URL — it persists a single-use `state` row
+   * carrying THIS visitor's session id, because the provider's callback comes
+   * back as a cross-site request (Apple's is a cross-site POST) whose cookies
+   * are not reliably sent. So the redirect must be driven by what initiate
+   * returns; a hand-built provider URL would come back with no session to
+   * resume.
+   *
+   * @param {'google'|'apple'} provider
+   */
+  startOauth(provider) {
+    const api = SERVICE[provider] && SERVICE[provider].initiate;
+    if (!api) {
+      // The buttons are gated on this same condition (skeleton/content.js), so
+      // reaching here means the services map changed under a rendered form.
+      return this.renderMessage(LOCALE.COMING_SOON || "Coming soon");
+    }
+    this.setButtonLoading(true);
+    this.postService(api, {}).then((data) => {
+      data = data || {};
+      if (data.status === "prompt" && data.authUrl) {
+        // Leaving the app entirely — keep the spinner up so the button cannot be
+        // clicked twice while the navigation is being scheduled. A second click
+        // would mint a second state row and orphan the first.
+        location.href = data.authUrl;
+        return;
+      }
+      this.setButtonLoading(false);
+      this.warn(`${provider}.initiate refused`, data);
+      this.renderMessage(this._oauthErrorMessage(data.error));
+    }).catch((e) => {
+      this.setButtonLoading(false);
+      this.warn(`${provider}.initiate failed`, e);
+      this.renderMessage(LOCALE.TRY_AGAIN_LATER || "Please try again later");
+    });
+  }
+
+  /**
+   * Human-readable copy for a provider failure. The reasons come from loby
+   * (sendOauthError / initiate) and are stable strings, so they are mapped to
+   * lexicon keys where we have them and collapsed to one generic line where we
+   * do not — an untranslated internal token must never reach the screen.
+   * @param {string} error
+   * @returns {string}
+   */
+  _oauthErrorMessage(error) {
+    switch (error) {
+      case "access_denied":
+        // The user backed out on the provider's consent screen. Not a fault.
+        return LOCALE.SIGNIN_CANCELLED || "Sign-in was cancelled";
+      case "oauth_not_linked":
+        return LOCALE.OAUTH_NOT_LINKED ||
+          "This email already has a Drumee account. Sign in with your password, then link the provider from your account settings.";
+      case "credentials_missing":
+      case "oauth_init_failed":
+      case "invalid_state":
+      case "oauth_failed":
+      case "invalid_code":
+      case "account_creation_failed":
+      case "session_fetch_failed":
+      case "unexpected_error":
+      default:
+        return LOCALE.TRY_AGAIN_LATER || "Please try again later";
+    }
+  }
+
+  /**
+   * Show the provider failure on the sign-in form, then scrub the reason from
+   * the URL so a reload does not replay a message about an attempt that is over.
+   * @param {string} error
+   */
+  _renderOauthError(error) {
+    this.renderMessage(this._oauthErrorMessage(error));
+    try {
+      history.replaceState(null, "", "#/welcome/signin");
+    } catch (e) { }
+  }
+
+  /**
+   * 2FA screen for an OAuth sign-in (see skeleton/otp-oauth.js). Self-registers
+   * dtk_otp on demand, exactly as _promptOtpReconnect does — this bundle does
+   * not run the widget's loadSeeds().
+   * @param {string} email  address the code was sent to
+   */
+  async _promptOtpOauth(email) {
+    this._inOauthMfa = true;
+    if (!Kind.exists("dtk_otp")) {
+      Kind.registerAddons({ dtk_otp: import("@drumee/ui-toolkit/widgets/otp") });
+    }
+    await Kind.waitFor("dtk_otp");
+    const skel = require("./skeleton/otp-oauth")(this, email);
+    if (!this.__content) {
+      this.feed(this._skeleton(this, { content: skel }));
+    } else {
+      this.__content.feed(skel);
+    }
+    this.ensurePart("oauth-otp").then((otp) => this._armOauthOtp(otp));
+  }
+
+  /**
+   * Teach the dtk_otp instance to recognise a rejected code on this path.
+   *
+   * The widget self-POSTs and classifies the answer with its own list of failure
+   * shapes ('wrong-code', 'INVALID_CODE', …). oauth.verify_otp answers
+   * {status:'error'}, which is on none of those lists and carries no `error`
+   * key — so a mistyped code would be read as SUCCESS, fire the host service and
+   * reload the page, leaving the user back on a blank OTP screen with no idea
+   * why. Normalizing the response before the widget inspects it turns that into
+   * the inline "invalid code" it already knows how to show.
+   *
+   * Wrapping (rather than patching the widget) keeps the change scoped to this
+   * flow: dtk_otp is shared with the reconnect and password-reset screens, whose
+   * APIs answer with the shapes it already understands.
+   *
+   * @param {LetcBox} otp  the dtk_otp instance
+   */
+  _armOauthOtp(otp) {
+    if (!otp || otp._oauthWrapped || !_.isFunction(otp.postService)) {
+      return;
+    }
+    const api = otp.mget(_a.api);
+    if (!api) {
+      return;
+    }
+    otp._oauthWrapped = true;
+    const post = otp.postService.bind(otp);
+    otp.postService = function (service, ...rest) {
+      const p = post(service, ...rest);
+      // Resend goes through the host (resendService), so `api` is the only POST
+      // this instance makes — but stay narrow anyway.
+      if (service !== api) {
+        return p;
+      }
+      return Promise.resolve(p).then((data) => {
+        if (data && data.status && data.status !== "success" && data.status !== _a.ok) {
+          return { ...data, error: 1 };
+        }
+        return data;
+      });
+    };
+  }
+
+  /**
+   * Re-mint and re-email the code for the pending OAuth sign-in.
+   *
+   * Host-driven (the skeleton sets `resendService`) rather than letting dtk_otp
+   * POST for itself: the widget assigns the resend RESPONSE over its `payload`,
+   * and oauth.resend_otp answers {status:'ok'} — which would wipe the email the
+   * message line was built from. No secret has to be swapped back in either
+   * (unlike the otp-gate resend): the new code is minted against the same
+   * pending session and resolved server-side at verify time.
+   *
+   * Follows the otp-gate resend contract otherwise — [data-resending] on the
+   * widget for the spinner, displayMessage for the outcome, and the digit boxes
+   * cleared so a half-typed old code cannot be auto-submitted with a digit of
+   * the new one.
+   */
+  async _resendOauthOtp() {
+    const api = SERVICE.oauth && SERVICE.oauth.resend_otp;
+    if (!api || this._resendingOauth) {
+      return;
+    }
+    const otp = this.getPart("oauth-otp");
+    const say = (msg, isError) => {
+      if (otp && _.isFunction(otp.displayMessage)) {
+        otp.displayMessage(msg, isError);
+      }
+    };
+    this._resendingOauth = true;
+    if (otp && otp.el) {
+      otp.el.dataset.resending = "1";
+    }
+    try {
+      const data = await this.postService(api, {});
+      if (!data || data.status !== _a.ok) {
+        this.warn("oauth.resend_otp refused", data);
+        return say(LOCALE.UNKNOWN_ERROR || "Something went wrong", 1);
+      }
+      if (otp && _.isFunction(otp.ensurePart)) {
+        const p = await otp.ensurePart("digits");
+        const boxes = (p && p.children && p.children.toArray()) || [];
+        for (const c of boxes) {
+          if (_.isFunction(c.setValue)) c.setValue("");
+        }
+        if (boxes[0] && _.isFunction(boxes[0].focus)) boxes[0].focus();
+      }
+      say(LOCALE.NEW_CODE_RESENT || "We have sent a new code");
+    } catch (e) {
+      this.warn("oauth.resend_otp failed", e);
+      say(LOCALE.UNKNOWN_ERROR || "Something went wrong", 1);
+    } finally {
+      this._resendingOauth = false;
+      if (otp && otp.el) {
+        otp.el.dataset.resending = "0";
+      }
+    }
+  }
+
+  /**
+   * "Back to sign in" from the OAuth 2FA screen.
+   *
+   * The pending cookie has to be dropped SERVER-side or this screen comes
+   * straight back: session_check_cookie reports connection 'otp' while the code
+   * is live, and the hand-off params survive a reload. Logging out cannot do it
+   * either — session_logout matches the cookie by uid, which a session that was
+   * never authenticated does not have. oauth.cancel_otp deletes it by session
+   * id. Best-effort: we return to the form whether or not it succeeds.
+   */
+  _cancelOauthMfa() {
+    const done = () => {
+      this._inOauthMfa = false;
+      this._reloadClean();
+    };
+    const api = SERVICE.oauth && SERVICE.oauth.cancel_otp;
+    if (!api) {
+      return done();
+    }
+    this.postService(api, {}).then(done).catch((e) => {
+      this.warn("oauth.cancel_otp failed", e);
+      done();
+    });
+  }
+
+  /**
+   * Re-boot on a bare sign-in URL, dropping the oauth_mfa / email / oauth_error
+   * params. Reloading with them still in place would re-enter the OTP screen —
+   * on the success path against a session that has already been finalized.
+   */
+  _reloadClean() {
+    try {
+      history.replaceState(null, "", "#/welcome/signin");
+    } catch (e) {
+      location.hash = "#/welcome/signin";
+    }
+    location.reload();
   }
 
   /**

--- a/src/drumee/modules/welcome/signin/skeleton/content.js
+++ b/src/drumee/modules/welcome/signin/skeleton/content.js
@@ -99,17 +99,29 @@ function __skl_welcome_signin_content(ui) {
     kids: [emailField, passwordField, forgotRow, submit, msgBox],
   });
 
-  const divider = Skeletons.Box.X({
-    className: `${contentFig}__divider`,
-    kids: [
-      Skeletons.Box.X({ className: `${contentFig}__divider-line` }),
-      Skeletons.Note({
-        className: `${contentFig}__divider-label`,
-        content: LOCALE.OR,
-      }),
-      Skeletons.Box.X({ className: `${contentFig}__divider-line` }),
-    ],
-  });
+  // Social sign-in is served by the `loby` plugin (acl/google.json,
+  // acl/apple.json -> google.initiate / apple.initiate). Those services reach
+  // the client through Platform.get('services'), so on an install without loby
+  // they are simply absent — and a button that cannot start a flow must not be
+  // shown. Checked per provider: a deployment may register one and not the
+  // other. See ../index.js -> startOauth for the click side of this contract.
+  const hasGoogle = !!(SERVICE.google && SERVICE.google.initiate);
+  const hasApple = !!(SERVICE.apple && SERVICE.apple.initiate);
+  const hasSocial = hasGoogle || hasApple;
+
+  const divider = hasSocial
+    ? Skeletons.Box.X({
+        className: `${contentFig}__divider`,
+        kids: [
+          Skeletons.Box.X({ className: `${contentFig}__divider-line` }),
+          Skeletons.Note({
+            className: `${contentFig}__divider-label`,
+            content: LOCALE.OR,
+          }),
+          Skeletons.Box.X({ className: `${contentFig}__divider-line` }),
+        ],
+      })
+    : "";
 
   const googleButton = Skeletons.Box.X({
     className: `${contentFig}__social-button google`,
@@ -145,10 +157,12 @@ function __skl_welcome_signin_content(ui) {
     ],
   });
 
-  const socialButtons = Skeletons.Box.Y({
-    className: `${contentFig}__social-buttons`,
-    kids: [googleButton, appleButton],
-  });
+  const socialButtons = hasSocial
+    ? Skeletons.Box.Y({
+        className: `${contentFig}__social-buttons`,
+        kids: [hasGoogle ? googleButton : "", hasApple ? appleButton : ""].filter(Boolean),
+      })
+    : "";
 
   // Reconnect mode: re-auth form + social buttons, but no signup/terms footer
   // (a disconnected, already-registered user shouldn't see "Start free").

--- a/src/drumee/modules/welcome/signin/skeleton/otp-oauth.js
+++ b/src/drumee/modules/welcome/signin/skeleton/otp-oauth.js
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2024 Thidima SA. All Rights Reserved.
+ * Licensed under the GNU AFFERO GENERAL PUBLIC LICENSE, Version 3 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+/**
+ * 2FA screen for an OAuth (Google / Apple) sign-in, using the shared dtk_otp
+ * 6-box widget.
+ *
+ * Reached only via the hand-off loby's provider callback performs when the
+ * resolved account has email 2FA enabled: the session is left pending
+ * (cookie.status = 'otp_pending'), a code is emailed, and the browser is
+ * bounced to #/welcome/signin?oauth_mfa=1&email=...
+ *
+ * Unlike ./otp.js and ./otp-reconnect.js, NO secret is carried here. The OTP
+ * secret never leaves the server on this path: the widget submits only the six
+ * digits, and oauth.verify_otp resolves the secret from the pending session
+ * before promoting it via session_login_otp. Hence the empty-but-for-email
+ * payload — do not add a `secret` to it.
+ *
+ * Resend is host-driven (`resendService`) rather than the widget's own POST: the
+ * widget overwrites its `payload` with the resend response, which would drop the
+ * email the message line is built from. See ../index.js -> _resendOauthOtp.
+ *
+ * The back link sits alongside the widget rather than inside it because
+ * abandoning this screen needs server-side cleanup (oauth.cancel_otp) that
+ * dtk_otp knows nothing about. Caller must ensure `dtk_otp` is registered
+ * (Kind.waitFor).
+ *
+ * @param {LetcBox} ui  the welcome_signin instance
+ * @param {string} email  address the code was sent to (already decoded)
+ */
+function __skl_welcome_signin_otp_oauth(ui, email = "") {
+  const fig = ui.fig.family;
+  const message = email
+    ? (LOCALE.WE_HAVE_SENT_CODE || "We have sent a code to {0}").format(email)
+    : (LOCALE.ENTER_CODE || "Enter the code we sent you");
+
+  return Skeletons.Box.Y({
+    debug: __filename,
+    className: `${fig}__items otp oauth`,
+    kids: [
+      {
+        kind: "dtk_otp",
+        sys_pn: "oauth-otp",
+        api: SERVICE.oauth.verify_otp,
+        // email is display copy only — verify_otp identifies the pending
+        // sign-in from the session cookie, not from anything posted here.
+        payload: { email, method: "oauth" },
+        length: 6,
+        charset: "numeric",
+        resendService: "resend-oauth-otp",
+        title: LOCALE.MULTI_FACTOR_AUTH || "Multi factor authentication",
+        message,
+        service: "oauth-otp-verified",
+        uiHandler: [ui],
+        dataset: { fit: "parent" },
+      },
+      Skeletons.Box.X({
+        className: `${fig}__backlink-row`,
+        kids: [
+          Skeletons.Note({
+            className: `${fig}__backlink`,
+            content: LOCALE.BACK_TO_SIGN_IN || "← Back to sign in",
+            service: "back-to-signin",
+            uiHandler: [ui],
+          }),
+        ],
+      }),
+    ],
+  });
+}
+
+module.exports = __skl_welcome_signin_otp_oauth;

--- a/src/drumee/modules/welcome/signin/skin/index.scss
+++ b/src/drumee/modules/welcome/signin/skin/index.scss
@@ -42,14 +42,17 @@ $drumee-link-purple: #b1adff;
     height: 100%;
   }
 
-  // Reconnect OTP embeds the dtk_otp widget (data-fit="parent"). The widget's
-  // shared skin is the full-page layout (52×72 cells, 180px top offset); here
-  // we reshape it to the shared otp-gate modal — the "Unlock Activity Insights"
-  // Figma popup (file g5V3PjhNMf5bHlsHMvV17w, node 100:53094): a 450 white card,
-  // padding 32, gap 16, radius 12, two-layer shadow, Geist 20/14 typography,
-  // 44×44 square digit cells. Mirrors builtins/widget/otp-gate so the reconnect
-  // popup matches dtk-otp__main everywhere else it is used.
-  &__items.reconnect {
+  // Both embedded-dtk_otp screens: the reconnect popup and the OAuth 2FA
+  // hand-off (skeleton/otp-oauth.js). The widget's shared skin is the full-page
+  // layout (52×72 cells, 180px top offset), which would sit badly inside our
+  // content slot; here we reshape it to the shared otp-gate modal — the "Unlock
+  // Activity Insights" Figma popup (file g5V3PjhNMf5bHlsHMvV17w, node
+  // 100:53094): a 450 white card, padding 32, gap 16, radius 12, two-layer
+  // shadow, Geist 20/14 typography, 44×44 square digit cells. Mirrors
+  // builtins/widget/otp-gate so both match dtk-otp__main everywhere else it is
+  // used.
+  &__items.reconnect,
+  &__items.oauth {
     $otp-font: "Geist", system-ui, sans-serif;
 
     // Transparent centering wrapper — the popup container provides the
@@ -244,6 +247,47 @@ $drumee-link-purple: #b1adff;
           font-size: 18px;
         }
       }
+    }
+  }
+
+  // OAuth 2FA only: the "Back to sign in" escape hatch, which lives beside the
+  // dtk_otp widget rather than inside it (abandoning the screen needs a server
+  // round-trip the widget knows nothing about — see index.js -> _cancelOauthMfa).
+  // Stacked under the card and centered on it.
+  &__items.oauth {
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+
+  &__backlink-row {
+    flex: 0 0 auto;
+    width: 100%;
+    justify-content: center;
+    align-items: center;
+    padding-top: 8px;
+  }
+
+  &__backlink {
+    @include drumee.typo(
+      $size: 14px,
+      $line: 1.4,
+      $weight: 600,
+      $color: $drumee-grey-80
+    );
+    width: auto;
+    // typo() maps $weight to a font-family and only knows 300/400/500/700, so
+    // 600 emits nothing — same as __social-label above, the semibold face has
+    // to be named explicitly.
+    font-family: var(--font-bold);
+    text-align: center;
+    cursor: pointer;
+    padding: 8px 16px;
+    border-radius: 4px;
+    transition: color 120ms ease;
+
+    &:hover {
+      color: $drumee-primary;
     }
   }
 

--- a/tests/welcome-signin-oauth.test.js
+++ b/tests/welcome-signin-oauth.test.js
@@ -1,0 +1,570 @@
+/**
+ * welcome/signin OAuth (Google / Apple) sign-in.
+ *
+ * These tests drive the REAL module. Nothing here reimplements its logic: the
+ * bundle-only surroundings are stubbed (the LetcBox base chain, Skeletons,
+ * LOCALE, _a/_e, SERVICE, Visitor, bootstrap, and the `.scss` / skeleton-helper
+ * requires that only webpack can resolve) and then src/.../welcome/signin is
+ * required as-is.
+ *
+ * The behaviours worth locking down, and why:
+ *
+ *  - ORDERING. session_check_cookie derives `connection` from the otp TABLE, not
+ *    from cookie.status (yellow_page/procedures/session/session_check_cookie.sql).
+ *    After loby's provider callback there is a pending cookie AND a freshly
+ *    minted code, so the page loads with connection == 'otp'. If the OAuth
+ *    hand-off is not tested first, the password-2FA branch takes the return and
+ *    posts to yp.authenticate with a client-side secret this path deliberately
+ *    does not have.
+ *
+ *  - THE dtk_otp FAILURE SHAPE. oauth.verify_otp answers {status:'error'}, which
+ *    is on none of the widget's failure lists and carries no `error` key, so a
+ *    mistyped code would read as success and silently reload the screen.
+ *
+ *  - NO SECRET CLIENT-SIDE. On this path the OTP secret never leaves the server.
+ */
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const path = require("node:path");
+
+const ROOT = path.join(__dirname, "..");
+const SIGNIN = path.join(ROOT, "src/drumee/modules/welcome/signin");
+
+// ---------------------------------------------------------------------------
+// Stub base class, standing in for interact -> password-meter -> core -> LetcBox.
+// ---------------------------------------------------------------------------
+class StubBase {
+  initialize() { }
+  declareHandlers() { }
+  onUiEvent() { return "SUPER"; }
+  warn(...a) { this._warns.push(a); }
+  mget(k) { return (this._model || {})[k]; }
+  mset(o) { Object.assign(this._model, o); }
+  feed(x) { this._fed.push(x); return x; }
+  getPart(n) { return (this._parts || {})[n]; }
+  ensurePart(n) { return Promise.resolve((this._parts || {})[n]); }
+  postService(api, vars) {
+    this._posts.push({ api, vars });
+    const r = this._responses.shift();
+    return r instanceof Error ? Promise.reject(r) : Promise.resolve(r);
+  }
+  gotSignedIn() { this._signedIn = true; }
+  suppress() { }
+  onDestroy() { }
+}
+
+// Intercept the requires that only exist under webpack.
+const realLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (/\.scss$/.test(request)) return {};
+  if (/(^|\/)\.\.\/interact$/.test(request) || /\/interact$/.test(request)) return StubBase;
+  if (/skeleton\/common\/(button|message-box)$/.test(request)) {
+    return { default: (...a) => ({ stub: request, a }) };
+  }
+  return realLoad(request, parent, isMain);
+};
+
+// ---------------------------------------------------------------------------
+// Bundle globals.
+// ---------------------------------------------------------------------------
+global._ = require(path.join(ROOT, "node_modules/lodash"));
+global._a = {
+  ok: "ok", api: "api", email: "email", dataset: "dataset", sys_pn: "sys_pn",
+  password: "password", commit: "commit", error: "error", url: "url",
+  open: "open", closed: "closed", loader: "loader", mobile: "mobile",
+  socket_id: "socket_id", system: "system",
+};
+global._e = {
+  submit: "submit", commit: "commit", Enter: "Enter", show: "show",
+  part: { ready: "part.ready" },
+};
+global.LOCALE = {
+  OR: "or", EMAIL: "Email", PASSWORD: "Password",
+  MULTI_FACTOR_AUTH: "Multi factor authentication",
+  UNKNOWN_ERROR: "Unknown error", TRY_AGAIN_LATER: "Please try again later",
+  NEW_CODE_RESENT: "New code sent", CONTINUE_WITH_GOOGLE: "Continue with Google",
+  PRIVACY_POLICY: "privacy", TERM_OF_SERVICE: "terms",
+  ENTER_YOUR_EMAIL: "", ENTER_YOUR_PASSWORD: "", Q_NO_ACCOUNT: "",
+  START_FREE: "", Q_FORGOT_PASSWORD: "", LOG_IN_TO_WORKSPACE: "",
+};
+// String.prototype.format — the real one, since the OTP copy depends on it.
+require(path.join(ROOT, "node_modules/@drumee/ui-core/letc/addons/string.js"));
+
+const mkBox = (kind) => (o) => ({ _box: kind, ...o });
+global.Skeletons = {
+  Box: { X: mkBox("X"), Y: mkBox("Y") },
+  Note: (o) => ({ _note: 1, ...o }),
+  Element: (o) => ({ _el: 1, ...o }),
+  EntryBox: (o) => ({ _entry: 1, ...o }),
+  Button: { Svg: (o) => ({ _svg: 1, ...o }) },
+};
+global.Kind = { exists: () => true, waitFor: () => Promise.resolve(), registerAddons: () => { } };
+global.Organization = { name: () => "Acme", get: () => 1 };
+global.Platform = { get: (k) => (k === "arch" ? "cloud" : k === "isPublic" ? 1 : null) };
+global.Visitor = {
+  profile: () => ({}), get: () => "", timeout: (t) => t,
+  parseModuleArgs: () => global.__ARGS,
+};
+global.bootstrap = () => ({ endpoint: "/-/", connection: global.__CONNECTION });
+global.SERVICE = {};
+global.uiRouter = { ensureWebsocket: () => Promise.resolve(), changeHost: () => { global.__CHANGED_HOST = true; } };
+global.RADIO_BROADCAST = { once: () => { }, trigger: () => { } };
+global.wsRouter = { restart: () => { } };
+global.Butler = { sleep: () => { } };
+global._K = { module: { signup: "#/welcome/signup" } };
+global.history = { replaceState: () => { global.__REPLACED = true; } };
+global.location = {
+  host: "", hash: "", reload: () => { global.__RELOADED = true; },
+  set href(v) { global.__HREF = v; },
+  get href() { return global.__HREF; },
+};
+
+const Signin = require(path.join(SIGNIN, "index.js"));
+
+/** Fresh navigation/global state; called at the top of every test. */
+function reset() {
+  global.__HREF = null;
+  global.__REPLACED = false;
+  global.__RELOADED = false;
+  global.__CHANGED_HOST = false;
+  global.__ARGS = {};
+  global.__CONNECTION = "offline";
+  global.SERVICE = {};
+}
+
+function mkInstance(over = {}) {
+  const o = Object.create(Signin.prototype);
+  return Object.assign(o, {
+    _model: {}, _fed: [], _posts: [], _messages: [], _warns: [], _loading: [],
+    _responses: [], _parts: {}, fig: { family: "welcome-signin" },
+    _skeleton: (ui, opt) => ({ _page: 1, ...opt }),
+    // Own properties: the class defines its own renderMessage/setButtonLoading,
+    // which shadow the base stubs and need real DOM parts. What matters here is
+    // that the OAuth code CALLS them, so record the calls.
+    renderMessage(m) { this._messages.push(m); },
+    setButtonLoading(v) { this._loading.push(v); },
+  }, over);
+}
+
+const ev = (service) => [{ model: { get: () => null } }, { service }];
+
+// Walk every nested object/array: the page skeleton nests the screen under
+// `content`, so a kids-only walk would miss it.
+function flat(n, out = [], seen = new Set()) {
+  if (!n || typeof n !== "object" || seen.has(n)) return out;
+  seen.add(n);
+  if (Array.isArray(n)) {
+    for (const v of n) flat(v, out, seen);
+    return out;
+  }
+  out.push(n);
+  for (const v of Object.values(n)) {
+    if (v && typeof v === "object") flat(v, out, seen);
+  }
+  return out;
+}
+const hasService = (t, s) => flat(t).some((n) => n.service === s);
+const hasClass = (t, c) => flat(t).some((n) => (n.className || "").includes(c));
+
+// ===========================================================================
+// Hash-query parsing. parseModuleArgs splits on [#/&?] and does NOT decode.
+// ===========================================================================
+test("the hand-off email is percent-decoded", () => {
+  reset();
+  assert.equal(mkInstance()._decodeArg("jo%40drumee.org"), "jo@drumee.org");
+});
+
+test("a malformed escape does not throw", () => {
+  reset();
+  assert.equal(mkInstance()._decodeArg("100%"), "100%");
+});
+
+test("a missing arg reads as an empty string", () => {
+  reset();
+  const s = mkInstance();
+  assert.equal(s._decodeArg(undefined), "");
+  assert.equal(s._decodeArg(null), "");
+});
+
+test("oauth_mfa params are read only when the flag is set", () => {
+  reset();
+  global.SERVICE = { oauth: { verify_otp: "oauth.verify_otp" } };
+  assert.equal(mkInstance()._oauthMfaParams(), null);
+
+  global.__ARGS = { oauth_mfa: "0" };
+  assert.equal(mkInstance()._oauthMfaParams(), null);
+
+  global.__ARGS = { oauth_mfa: "1", email: "jo%40drumee.org" };
+  assert.deepEqual(mkInstance()._oauthMfaParams(), { email: "jo@drumee.org" });
+});
+
+test("the OTP screen is refused when oauth.verify_otp is unregistered", () => {
+  // Better the sign-in form than a screen that takes a code it cannot submit.
+  reset();
+  global.__ARGS = { oauth_mfa: "1", email: "jo%40drumee.org" };
+  const s = mkInstance();
+  assert.equal(s._oauthMfaParams(), null);
+  assert.equal(s._warns.length, 1);
+});
+
+// ===========================================================================
+// The ordering guarantee.
+// ===========================================================================
+test("an OAuth 2FA return wins over connection:'otp'", () => {
+  reset();
+  global.__ARGS = { oauth_mfa: "1", email: "jo%40drumee.org" };
+  global.SERVICE = { oauth: { verify_otp: "oauth.verify_otp" } };
+  global.__CONNECTION = "otp";
+  const s = mkInstance();
+  let prompted = null;
+  s._promptOtpOauth = (email) => { prompted = email; };
+  s.prompt_otp = () => assert.fail("password-2FA branch took the OAuth return");
+  s.onDomRefresh();
+  assert.equal(prompted, "jo@drumee.org");
+});
+
+test("a plain connection:'otp' still reaches the password-2FA branch", () => {
+  reset();
+  global.SERVICE = { oauth: { verify_otp: "x" } };
+  global.__CONNECTION = "otp";
+  // That branch only prompts once the tab is on the org's own host; otherwise it
+  // redirects there first. Satisfy the host check so we reach prompt_otp.
+  global.location.host = "acme.drumee.com";
+  const orgGet = global.Organization.get;
+  global.Organization.get = (k) => (k === "url" ? "acme.drumee.com" : 1);
+  try {
+    const s = mkInstance();
+    let prompted = false;
+    s.prompt_otp = () => { prompted = true; };
+    s._promptOtpOauth = () => assert.fail("OAuth screen hijacked the password path");
+    s.onDomRefresh();
+    assert.equal(prompted, true);
+  } finally {
+    global.Organization.get = orgGet;
+    global.location.host = "";
+  }
+});
+
+// ===========================================================================
+// Failure returns.
+// ===========================================================================
+test("oauth_error is shown on the form and scrubbed from the URL", () => {
+  reset();
+  global.__ARGS = { oauth_error: "access_denied" };
+  const s = mkInstance();
+  s.onDomRefresh();
+  assert.equal(s._fed.length, 1, "the form must still render");
+  assert.equal(s._messages[0], "Sign-in was cancelled");
+  assert.equal(global.__REPLACED, true, "a reload must not replay the message");
+});
+
+test("a normal load says nothing", () => {
+  reset();
+  const s = mkInstance();
+  s.onDomRefresh();
+  assert.equal(s._messages.length, 0);
+});
+
+test("no provider error token ever reaches the screen raw", () => {
+  reset();
+  const s = mkInstance();
+  const tokens = [
+    "access_denied", "oauth_not_linked", "credentials_missing",
+    "oauth_init_failed", "invalid_state", "oauth_failed", "invalid_code",
+    "account_creation_failed", "session_fetch_failed", "unexpected_error",
+    "a_reason_added_server_side_later", undefined,
+  ];
+  for (const t of tokens) {
+    const m = s._oauthErrorMessage(t);
+    assert.ok(m && m.length > 3, `no copy for ${t}`);
+    assert.ok(!/_/.test(m), `raw token leaked for ${t}: ${m}`);
+  }
+});
+
+// ===========================================================================
+// initiate -> provider redirect.
+// ===========================================================================
+test("initiate drives the redirect", async () => {
+  // The URL must come from initiate: it also persists the single-use state row
+  // carrying this session id, which is how the cross-site callback finds its way
+  // back to this visitor.
+  reset();
+  global.SERVICE = { google: { initiate: "google.initiate" } };
+  const s = mkInstance({ _responses: [{ status: "prompt", authUrl: "https://accounts.google.com/x" }] });
+  s.startOauth("google");
+  await new Promise((r) => setImmediate(r));
+  assert.equal(global.__HREF, "https://accounts.google.com/x");
+  assert.deepEqual(s._posts[0], { api: "google.initiate", vars: {} });
+  assert.deepEqual(s._loading, [true], "the spinner stays up while navigating away");
+});
+
+test("a refused initiate is reported and does not navigate", async () => {
+  reset();
+  global.SERVICE = { apple: { initiate: "apple.initiate" } };
+  const s = mkInstance({ _responses: [{ status: "error", error: "credentials_missing" }] });
+  s.startOauth("apple");
+  await new Promise((r) => setImmediate(r));
+  assert.equal(global.__HREF, null);
+  assert.equal(s._messages[0], "Please try again later");
+  assert.deepEqual(s._loading, [true, false]);
+});
+
+test("a failed initiate request is reported and does not navigate", async () => {
+  reset();
+  global.SERVICE = { google: { initiate: "google.initiate" } };
+  const s = mkInstance({ _responses: [new Error("network down")] });
+  s.startOauth("google");
+  await new Promise((r) => setImmediate(r));
+  assert.equal(global.__HREF, null);
+  assert.equal(s._messages[0], "Please try again later");
+  assert.deepEqual(s._loading, [true, false]);
+});
+
+test("an unregistered provider service is never posted to", () => {
+  reset();
+  const s = mkInstance();
+  s.startOauth("google");
+  assert.equal(s._posts.length, 0);
+  assert.equal(s._messages.length, 1);
+});
+
+test("the buttons route to their providers", () => {
+  reset();
+  const s = mkInstance();
+  const seen = [];
+  s.startOauth = (p) => seen.push(p);
+  s.onUiEvent(...ev("use-google"));
+  s.onUiEvent(...ev("use-apple"));
+  assert.deepEqual(seen, ["google", "apple"]);
+});
+
+// ===========================================================================
+// The 2FA screen.
+// ===========================================================================
+test("the 2FA screen is wired to oauth.verify_otp and carries no secret", async () => {
+  reset();
+  global.SERVICE = { oauth: { verify_otp: "oauth.verify_otp", resend_otp: "oauth.resend_otp" } };
+  const s = mkInstance({ _parts: { "oauth-otp": { marker: 1 } } });
+  let armed = null;
+  s._armOauthOtp = (o) => { armed = o; };
+  await s._promptOtpOauth("jo@drumee.org");
+
+  assert.equal(s._inOauthMfa, true, "back-to-signin keys off this flag");
+  assert.equal(s._fed.length, 1);
+  const otp = flat(s._fed[0]).find((n) => n.kind === "dtk_otp");
+  assert.ok(otp, "no dtk_otp in the screen");
+  assert.equal(otp.api, "oauth.verify_otp");
+  assert.equal(otp.sys_pn, "oauth-otp");
+  assert.equal(otp.resendService, "resend-oauth-otp");
+  assert.equal(otp.service, "oauth-otp-verified");
+  assert.equal(otp.length, 6);
+  assert.ok(!("secret" in otp.payload), "the OTP secret must stay server-side");
+  assert.equal(otp.payload.email, "jo@drumee.org");
+  assert.match(otp.message, /jo@drumee\.org/);
+  assert.ok(hasService(s._fed[0], "back-to-signin"), "no escape hatch");
+  assert.ok(hasClass(s._fed[0], "oauth"), "the skin targets .oauth");
+
+  await new Promise((r) => setImmediate(r));
+  assert.ok(armed, "the widget must be armed for the failure-shape fix");
+});
+
+test("the 2FA screen renders into the existing content slot", async () => {
+  reset();
+  global.SERVICE = { oauth: { verify_otp: "oauth.verify_otp" } };
+  const inner = [];
+  const s = mkInstance({ __content: { feed: (x) => inner.push(x) } });
+  s._armOauthOtp = () => { };
+  await s._promptOtpOauth("a@b.com");
+  assert.equal(inner.length, 1);
+  assert.equal(s._fed.length, 0, "the whole page must not be re-rendered");
+});
+
+test("the 2FA copy holds up with no email in the hand-off", async () => {
+  reset();
+  global.SERVICE = { oauth: { verify_otp: "oauth.verify_otp" } };
+  const s = mkInstance();
+  s._armOauthOtp = () => { };
+  await s._promptOtpOauth("");
+  const otp = flat(s._fed[0]).find((n) => n.kind === "dtk_otp");
+  assert.ok(otp.message);
+  assert.doesNotMatch(otp.message, /\{0\}/, "unsubstituted placeholder");
+});
+
+// ===========================================================================
+// The dtk_otp failure-shape fix.
+// ===========================================================================
+function mkOtpStub(response) {
+  return {
+    _model: { api: "oauth.verify_otp" },
+    mget(k) { return this._model[k]; },
+    postService(service, vars) { this._lastVars = vars; return Promise.resolve(response); },
+  };
+}
+
+test("a rejected code is turned into an error the widget recognises", async () => {
+  reset();
+  const otp = mkOtpStub({ status: "error" });
+  mkInstance()._armOauthOtp(otp);
+  const out = await otp.postService("oauth.verify_otp", { code: "000000" });
+  assert.equal(out.error, 1, "the widget would otherwise read this as success");
+});
+
+test("a good code is left alone", async () => {
+  reset();
+  const otp = mkOtpStub({ status: "success" });
+  mkInstance()._armOauthOtp(otp);
+  const out = await otp.postService("oauth.verify_otp", { code: "123456" });
+  assert.ok(!out.error);
+});
+
+test("only the verify POST is normalized", async () => {
+  reset();
+  const otp = mkOtpStub({ status: "error" });
+  mkInstance()._armOauthOtp(otp);
+  const out = await otp.postService("some.other.service", {});
+  assert.ok(!out.error);
+});
+
+test("arming twice does not double-wrap", () => {
+  reset();
+  const s = mkInstance();
+  const otp = mkOtpStub({ status: "error" });
+  s._armOauthOtp(otp);
+  const first = otp.postService;
+  s._armOauthOtp(otp);
+  assert.equal(otp.postService, first);
+});
+
+// ===========================================================================
+// Resend.
+// ===========================================================================
+test("a resend clears the stale digits and confirms", async () => {
+  reset();
+  global.SERVICE = { oauth: { resend_otp: "oauth.resend_otp" } };
+  const cleared = [];
+  const boxes = [
+    { setValue: (v) => cleared.push(v), focus: () => { } },
+    { setValue: (v) => cleared.push(v) },
+  ];
+  const said = [];
+  const otp = {
+    el: { dataset: {} },
+    displayMessage: (m, e) => said.push([m, e]),
+    ensurePart: () => Promise.resolve({ children: { toArray: () => boxes } }),
+  };
+  const s = mkInstance({ _parts: { "oauth-otp": otp }, _responses: [{ status: "ok" }] });
+  await s._resendOauthOtp();
+  assert.deepEqual(cleared, ["", ""], "a half-typed old code must not survive");
+  assert.equal(said[0][0], "New code sent");
+  assert.equal(otp.el.dataset.resending, "0", "the spinner must be released");
+});
+
+test("a refused resend is surfaced as an error", async () => {
+  reset();
+  global.SERVICE = { oauth: { resend_otp: "oauth.resend_otp" } };
+  const said = [];
+  const otp = {
+    el: { dataset: {} },
+    displayMessage: (m, e) => said.push([m, e]),
+    ensurePart: () => Promise.resolve(null),
+  };
+  const s = mkInstance({ _parts: { "oauth-otp": otp }, _responses: [{ status: "error" }] });
+  await s._resendOauthOtp();
+  assert.equal(said[0][0], "Unknown error");
+  assert.equal(said[0][1], 1);
+});
+
+test("a second resend click while one is in flight is ignored", async () => {
+  reset();
+  global.SERVICE = { oauth: { resend_otp: "oauth.resend_otp" } };
+  const s = mkInstance({ _responses: [{ status: "ok" }], _resendingOauth: true });
+  await s._resendOauthOtp();
+  assert.equal(s._posts.length, 0);
+});
+
+// ===========================================================================
+// Leaving and finishing.
+// ===========================================================================
+test("leaving the 2FA screen cancels the pending session first", async () => {
+  // Without cancel_otp the otp_pending cookie survives and the page lands right
+  // back on this screen; session_logout cannot clear it (it matches by uid).
+  reset();
+  global.SERVICE = { oauth: { cancel_otp: "oauth.cancel_otp" } };
+  const s = mkInstance({ _inOauthMfa: true, _responses: [{ status: "ok" }] });
+  s.onUiEvent(...ev("back-to-signin"));
+  await new Promise((r) => setImmediate(r));
+  assert.equal(s._posts[0].api, "oauth.cancel_otp");
+  assert.equal(global.__RELOADED, true);
+  assert.equal(s._inOauthMfa, false);
+});
+
+test("a failed cancel does not trap the user on the 2FA screen", async () => {
+  reset();
+  global.SERVICE = { oauth: { cancel_otp: "oauth.cancel_otp" } };
+  const s = mkInstance({ _inOauthMfa: true, _responses: [new Error("boom")] });
+  s._cancelOauthMfa();
+  await new Promise((r) => setImmediate(r));
+  assert.equal(global.__RELOADED, true);
+});
+
+test("back-to-signin elsewhere does not call cancel_otp", () => {
+  reset();
+  global.SERVICE = { oauth: { cancel_otp: "oauth.cancel_otp" } };
+  const s = mkInstance({ _model: { reconnect: 0 } });
+  s.showSignin = () => { s._showed = true; };
+  s.onUiEvent(...ev("back-to-signin"));
+  assert.equal(s._posts.length, 0);
+  assert.equal(s._showed, true);
+});
+
+test("a verified code scrubs the hand-off params before reloading", () => {
+  // Reloading with oauth_mfa=1 still set would re-enter the OTP screen against a
+  // session that has already been finalized.
+  reset();
+  const s = mkInstance();
+  s.onUiEvent(...ev("oauth-otp-verified"));
+  assert.equal(global.__REPLACED, true);
+  assert.equal(global.__RELOADED, true);
+});
+
+test("unrelated services still fall through to the base handler", () => {
+  reset();
+  assert.equal(mkInstance().onUiEvent(...ev("something-else")), "SUPER");
+});
+
+// ===========================================================================
+// Button gating: the services come from the loby plugin and may be absent.
+// ===========================================================================
+function renderContent() {
+  delete require.cache[path.join(SIGNIN, "skeleton/content.js")];
+  return require(path.join(SIGNIN, "skeleton/content.js"))(mkInstance());
+}
+
+test("both buttons render when both services exist", () => {
+  reset();
+  global.SERVICE = { google: { initiate: "g" }, apple: { initiate: "a" } };
+  const t = renderContent();
+  assert.ok(hasService(t, "use-google"));
+  assert.ok(hasService(t, "use-apple"));
+  assert.ok(hasClass(t, "__divider"));
+});
+
+test("with no provider services the divider goes too", () => {
+  reset();
+  const t = renderContent();
+  assert.ok(!hasService(t, "use-google"), "a dead Google button must not render");
+  assert.ok(!hasService(t, "use-apple"), "a dead Apple button must not render");
+  assert.ok(!hasClass(t, "__divider"), "an 'or' above nothing");
+  assert.ok(hasClass(t, "__form-section"), "the password form must survive");
+});
+
+test("gating is per provider", () => {
+  reset();
+  global.SERVICE = { google: { initiate: "g" } };
+  const t = renderContent();
+  assert.ok(hasService(t, "use-google"));
+  assert.ok(!hasService(t, "use-apple"));
+  assert.ok(hasClass(t, "__divider"), "the divider stays for the one provider");
+});


### PR DESCRIPTION
The built-in welcome/signin module already drew both provider buttons; the handler was a stub returning "Coming soon". The loby plugin has served the backend for a while (google.initiate / google.callback, apple.*, oauth.verify_otp / resend_otp / cancel_otp) and the standalone signin plugin drives it — but welcome/signin, which loadSignin() falls back to whenever Platform plugins.signin is absent, never learned how.

The non-2FA return leg needs no client code: google.callback finishes by serving account-created.html, which redirects to the desk (or shows the welcome card whose CTA continues there), with the session cookie already set by sendHtml. So this covers the three things the client does own: starting the flow, the 2FA return, and the failure return.

Two things made it more than plumbing:

ORDERING. session_check_cookie derives `connection` from the otp TABLE, not from cookie.status. After the provider callback hits the 2FA gate both of that query's conditions hold — session_login_with_oauth set cookie.uid and left status='otp_pending', and _send2faOtp minted an otp row — so the page loads reporting connection:'otp', the same value a password+2FA sign-in produces. onDomRefresh switches on exactly that, and its 'otp' branch posts to yp.authenticate with Visitor.get('otp_key'). On this path there IS no client-side secret, by design. So the oauth_mfa hand-off is now tested BEFORE the switch. Both directions are covered by tests, because nothing in the code makes the collision visible.

THE dtk_otp FAILURE SHAPE. oauth.verify_otp answers {status:'error'}, which is on none of the widget's failure lists and carries no `error` key, so a mistyped code read as SUCCESS: the host service fired and the page reloaded, dropping the user on a blank OTP screen with no reason given. _armOauthOtp wraps the instance's postService and normalizes the response before the widget classifies it, so the inline "invalid code" it already knows how to render is what shows. Wrapping rather than patching dtk_otp keeps this off the reconnect and password-reset screens, whose APIs answer in shapes it understands; builtins/widget/otp-gate wraps the same method for its own spinner, so the idiom is established.

Also:

  - The buttons now render only when their initiate service exists, per provider. These arrive via Platform.get('services'), so an install without loby has none, and a button that cannot start a flow should not be drawn. The "or" divider goes with them.
  - Leaving the OTP screen POSTs oauth.cancel_otp first. Nothing else can clear that cookie — session_logout matches by uid, which a never-authenticated session lacks — so a plain reload would land straight back on the OTP screen.
  - A verified code scrubs oauth_mfa from the URL before reloading; left in place it re-enters the OTP screen against a finalized session.
  - ?oauth_error= is now read and shown. loby's sendOauthError has always passed a reason and no client read it; the user just landed back on the form in silence. Unknown reasons collapse to generic copy so no internal token reaches the screen.
  - New copy uses the LOCALE.X || "fallback" idiom already used here, so the screens read correctly before BACK_TO_SIGN_IN / SIGNIN_CANCELLED / OAUTH_NOT_LINKED are added to the lexicon.
  - The OAuth screen joins the existing __items.reconnect skin block, which already reshapes dtk_otp out of its full-page default into the otp-gate card; it occupies the same content slot.

Verified: 33 node:test cases in tests/welcome-signin-oauth.test.js drive the real module with only the bundle surroundings stubbed (40 pass across tests/), plus a sass compile of the skin against the webpack load paths. Not verified end to end, and the spec says so: yp on this box has no oauth_accounts / oauth_state tables, so initiate cannot even redirect — no live provider round-trip was performed.