### PR TITLE
fix(contextmenu): keep the browser's own menu on text inputs

### DIFF
--- a/patches/@drumee+ui-core+1.1.50.patch
+++ b/patches/@drumee+ui-core+1.1.50.patch
@@ -1,8 +1,18 @@
 diff --git a/node_modules/@drumee/ui-core/letc/addons/letc.js b/node_modules/@drumee/ui-core/letc/addons/letc.js
-index be31634..74857a8 100644
+index be31634..450aeb0 100644
 --- a/node_modules/@drumee/ui-core/letc/addons/letc.js
 +++ b/node_modules/@drumee/ui-core/letc/addons/letc.js
-@@ -91,7 +91,7 @@ function deviceChanged() {
+@@ -12,6 +12,9 @@ const { View } = Backbone;
+ // ========================
+ 
+ const { isNumeric, timestamp, log } = require("@drumee/ui-essentials");
++// Resolved through the app's global `libs` webpack alias (webpack/resolve.js),
++// which applies to requires from node_modules too. See __handleContextmenu.
++const { isTextEntry } = require("libs/is-text-entry");
+ const ORIENTATION = {
+   'landscape-primary': 'x',
+   'landscape': 'x',
+@@ -91,7 +94,7 @@ function deviceChanged() {
  
  const Timer = new Map();
  
@@ -11,7 +21,7 @@ index be31634..74857a8 100644
  
  
  /** Common addons */
-@@ -317,10 +317,19 @@ View.prototype.__handleClick = function (e) {
+@@ -317,10 +320,19 @@ View.prototype.__handleClick = function (e) {
      }
    }
  
@@ -33,6 +43,30 @@ index be31634..74857a8 100644
    e.stopPropagation();
    this.triggerHandlers(e);
    e.stopImmediatePropagation();
+@@ -371,6 +383,23 @@ View.prototype.__handleContextmenu = function (e) {
+     }
+   }
+ 
++  // Text entry keeps the browser's own cut/copy/paste/spellcheck menu. The
++  // event is answered here rather than by the input, which owns no view: the
++  // Entry widget injects a raw <input> as innerHTML, so the contextmenu bubbles
++  // one level to the Entry root. Without this the walk below reaches the owning
++  // window and preventDefault()s the native menu — the reason a Drive link
++  // could not be pasted (migrate-gdrive-popup) among others.
++  //
++  // A view that wants its app menu on an input anyway sets forceContextmenu,
++  // read exactly like escapeContextmenu below.
++  //
++  // The bare `return` matters: this is a property-style `oncontextmenu`
++  // handler, so returning `false` cancels the default — which is precisely the
++  // suppression being removed. Returning undefined lets the browser proceed.
++  if (!(this.forceContextmenu || this.mget('forceContextmenu')) && isTextEntry(e.target)) {
++    return
++  }
++
+   if (this.escapeContextmenu || this.mget('escapeContextmenu')) {
+     return
+   }
 diff --git a/node_modules/@drumee/ui-core/letc/user.js b/node_modules/@drumee/ui-core/letc/user.js
 index a288e64..4b85937 100644
 --- a/node_modules/@drumee/ui-core/letc/user.js

--- a/src/drumee/libs/is-text-entry.js
+++ b/src/drumee/libs/is-text-entry.js
@@ -1,0 +1,74 @@
+/**
+ * Is this DOM node a text-entry element?
+ *
+ * Right-clicking anywhere in the app used to open the owning window's menu,
+ * because `View.prototype.__handleContextmenu` (ui-core, patched) walks the
+ * VIEW-parent chain to the first ancestor offering a `contextmenuSkeleton` and
+ * calls `preventDefault()` there. A raw `<input>` is injected as innerHTML by
+ * the Entry widget and owns no view, so its right-click was answered by the
+ * folder window — costing the user cut/copy/paste on every field in the app.
+ *
+ * The handler consults this predicate on `e.target` and bails out before
+ * `preventDefault()` when it answers true.
+ *
+ * Deliberately DOM-free: it reads `tagName`, `getAttribute` and
+ * `isContentEditable` only, so it is exhaustively unit-testable and safe
+ * against the synthetic `{pageX, pageY, target, ...}` object the media-grid
+ * kebab passes straight into `el.oncontextmenu` — an object whose `target` may
+ * be any element, or absent entirely.
+ *
+ * A view that genuinely wants its app menu on an input reclaims it with
+ * `forceContextmenu` (own property or model attribute), read the same way
+ * `escapeContextmenu` is.
+ */
+
+// Input types that carry no editable text. Everything else — including a
+// missing, empty or unrecognised type, which HTML resolves to "text" — is
+// treated as text entry, so a browser gaining a new text-ish type needs no
+// change here.
+const NON_TEXT_INPUT_TYPES = new Set([
+  "button",
+  "checkbox",
+  "color",
+  "file",
+  "image",
+  "radio",
+  "range",
+  "reset",
+  "submit",
+]);
+
+/**
+ * @param {Element|null|undefined} el  usually `event.target`
+ * @returns {boolean} true when the browser's own menu must be left alone
+ */
+function isTextEntry(el) {
+  if (!el || typeof el !== "object") {
+    return false;
+  }
+
+  // Covers a contenteditable host AND everything nested inside one: the DOM
+  // reports isContentEditable true on descendants, so no parent walk is needed.
+  if (el.isContentEditable === true) {
+    return true;
+  }
+
+  const tag = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
+
+  if (tag === "TEXTAREA") {
+    return true;
+  }
+
+  if (tag === "INPUT") {
+    // `readonly` still counts — copy and select-all remain useful. `disabled`
+    // fires no contextmenu event at all, so it never reaches this predicate.
+    const raw =
+      typeof el.getAttribute === "function" ? el.getAttribute("type") : null;
+    const type = (raw == null ? "" : String(raw)).trim().toLowerCase();
+    return !NON_TEXT_INPUT_TYPES.has(type);
+  }
+
+  return false;
+}
+
+module.exports = { isTextEntry, NON_TEXT_INPUT_TYPES };

--- a/tests/contextmenu-text-entry.test.js
+++ b/tests/contextmenu-text-entry.test.js
@@ -1,0 +1,273 @@
+// `__handleContextmenu` decides, for every right-click in the app, whether the
+// browser keeps its own menu or the owning window opens the app menu over it.
+//
+// The handler lives in the vendored SDK (`@drumee/ui-core`), patched in place by
+// patch-package. It cannot be `require`d here: it is an addon module that
+// mutates a Backbone prototype and reaches for app-level globals (`_`, `_a`,
+// `Skeletons`, `drumeeDialog`) plus a webpack alias (`libs/is-text-entry`) that
+// only exists inside the bundle. So it is read as source and instantiated with
+// its free variables injected — the same extraction the folder/task tests use,
+// pointed at node_modules instead of src.
+//
+// A side effect worth having: this file only passes when the patch is actually
+// applied to the installed copy, which is the thing that ships.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { readFileSync, existsSync } = require("node:fs");
+const { join } = require("node:path");
+const { isTextEntry } = require("../src/drumee/libs/is-text-entry");
+
+const LETC = join(
+  __dirname,
+  "..",
+  "node_modules/@drumee/ui-core/letc/addons/letc.js",
+);
+
+function handlerSource() {
+  assert.ok(
+    existsSync(LETC),
+    "@drumee/ui-core is not installed — run `npm ci` so postinstall applies patches/",
+  );
+  const src = readFileSync(LETC, "utf8");
+  const start = src.indexOf("View.prototype.__handleContextmenu = function (e) {");
+  assert.notEqual(start, -1, "__handleContextmenu not found in the installed SDK");
+  const end = src.indexOf("\n}\n", start);
+  assert.notEqual(end, -1, "__handleContextmenu has no closing brace");
+  return src.slice(start + "View.prototype.__handleContextmenu = ".length, end + 2);
+}
+
+// Every free name the handler closes over inside letc.js, injected rather than
+// stubbed on `global` (see harness-hygiene.test.js).
+function buildHandler(fed) {
+  const menuFor = (p) => ({ menuFor: p.name });
+  return new Function(
+    "isTextEntry",
+    "localStorage",
+    "_a",
+    "_",
+    "drumeeDialog",
+    "buildContextmenu",
+    "window",
+    `return (${handlerSource()});`,
+  )(
+    isTextEntry,
+    { logLevel: 0 },
+    { debug: "debug", ui: "ui", toggle: "toggle" },
+    { isFunction: (f) => typeof f === "function" },
+    {
+      isDestroyed: () => false,
+      feed: (kids) => fed.push(kids),
+      children: {
+        last: () => ({
+          $el: { height: () => 10, width: () => 10 },
+          el: { style: {} },
+        }),
+      },
+    },
+    menuFor,
+    { innerHeight: 800, innerWidth: 1200 },
+  );
+}
+
+// A view stand-in. `owner` is the ancestor carrying contextmenuSkeleton — the
+// folder window, in the real tree.
+function view(opt = {}) {
+  const owner = opt.orphan
+    ? null
+    : { name: "window-folder", contextmenuSkeleton: () => [], mget: () => null };
+  return {
+    escapeContextmenu: opt.escapeContextmenu,
+    forceContextmenu: opt.forceContextmenu,
+    parent: owner,
+    mget: (k) => (k === "escapeContextmenu" || k === "forceContextmenu" ? undefined : null),
+    triggerMethod: () => {},
+    getHandlers: () => [],
+    debug: () => {},
+  };
+}
+
+const el = (tagName, attrs = {}) => ({
+  tagName,
+  isContentEditable: attrs.isContentEditable || false,
+  getAttribute: (k) => (attrs[k] == null ? null : attrs[k]),
+});
+
+function rightClick(target) {
+  const calls = { preventDefault: 0, stopPropagation: 0, stopImmediatePropagation: 0 };
+  return {
+    calls,
+    event: {
+      target,
+      pageX: 40,
+      pageY: 60,
+      shiftKey: false,
+      ctrlKey: false,
+      preventDefault: () => calls.preventDefault++,
+      stopPropagation: () => calls.stopPropagation++,
+      stopImmediatePropagation: () => calls.stopImmediatePropagation++,
+    },
+  };
+}
+
+test("a right-click on a text input never reaches preventDefault", () => {
+  const fed = [];
+  const handler = buildHandler(fed);
+  const { calls, event } = rightClick(el("INPUT", { type: "text" }));
+
+  const result = handler.call(view(), event);
+
+  assert.equal(calls.preventDefault, 0, "the native menu must not be cancelled");
+  assert.deepEqual(fed, [], "no app menu is built over an input");
+  // The killer detail: `oncontextmenu` is a property-style handler, so a
+  // returned `false` cancels the default just as preventDefault() would. The
+  // early return must yield undefined.
+  assert.notEqual(result, false, "returning false would cancel the native menu");
+});
+
+test("a text input still gets the propagation stops, like escapeContextmenu", () => {
+  const fed = [];
+  const { calls, event } = rightClick(el("TEXTAREA"));
+
+  buildHandler(fed).call(view(), event);
+
+  assert.equal(calls.stopPropagation, 1);
+  assert.equal(calls.stopImmediatePropagation, 1);
+});
+
+test("contenteditable is treated as a text input", () => {
+  const fed = [];
+  const { calls, event } = rightClick(el("DIV", { isContentEditable: true }));
+
+  buildHandler(fed).call(view(), event);
+
+  assert.equal(calls.preventDefault, 0);
+  assert.deepEqual(fed, []);
+});
+
+test("a plain element inside a window with contextmenuSkeleton still gets the app menu", () => {
+  const fed = [];
+  const { calls, event } = rightClick(el("DIV"));
+
+  buildHandler(fed).call(view(), event);
+
+  assert.equal(calls.preventDefault, 1, "the app menu suppresses the native one");
+  assert.deepEqual(fed, [{ menuFor: "window-folder" }]);
+});
+
+test("a checkbox keeps the app menu", () => {
+  const fed = [];
+  const { calls, event } = rightClick(el("INPUT", { type: "checkbox" }));
+
+  buildHandler(fed).call(view(), event);
+
+  assert.equal(calls.preventDefault, 1);
+  assert.deepEqual(fed, [{ menuFor: "window-folder" }]);
+});
+
+test("the kebab's synthetic event still builds its menu", () => {
+  // Exactly what media/grid/index.js hands to el.oncontextmenu: a plain object
+  // with the tile root as target and no-op event methods.
+  const fed = [];
+  const tile = el("DIV");
+  const synthetic = {
+    pageX: 120,
+    pageY: 240,
+    clientX: 120,
+    clientY: 240,
+    target: tile,
+    shiftKey: false,
+    ctrlKey: false,
+    preventDefault() {},
+    stopPropagation() {},
+    stopImmediatePropagation() {},
+  };
+
+  buildHandler(fed).call(view(), synthetic);
+
+  assert.deepEqual(fed, [{ menuFor: "window-folder" }], "kebab menu still opens");
+});
+
+test("a synthetic event with no target falls through to existing behaviour", () => {
+  const fed = [];
+  const synthetic = {
+    pageX: 1,
+    pageY: 2,
+    preventDefault() {},
+    stopPropagation() {},
+    stopImmediatePropagation() {},
+  };
+
+  buildHandler(fed).call(view(), synthetic);
+
+  assert.deepEqual(fed, [{ menuFor: "window-folder" }]);
+});
+
+test("escapeContextmenu on a Note behaves exactly as before", () => {
+  const fed = [];
+  const { calls, event } = rightClick(el("SECTION"));
+
+  const result = buildHandler(fed).call(view({ escapeContextmenu: true }), event);
+
+  assert.equal(calls.preventDefault, 0);
+  assert.deepEqual(fed, []);
+  assert.notEqual(result, false);
+});
+
+test("forceContextmenu reclaims the app menu on a text input", () => {
+  const fed = [];
+  const { calls, event } = rightClick(el("INPUT", { type: "text" }));
+
+  buildHandler(fed).call(view({ forceContextmenu: true }), event);
+
+  assert.equal(calls.preventDefault, 1);
+  assert.deepEqual(fed, [{ menuFor: "window-folder" }]);
+});
+
+test("forceContextmenu is also read off the model, like escapeContextmenu", () => {
+  const fed = [];
+  const { calls, event } = rightClick(el("INPUT", { type: "text" }));
+  const v = view();
+  v.mget = (k) => (k === "forceContextmenu" ? true : null);
+
+  buildHandler(fed).call(v, event);
+
+  assert.equal(calls.preventDefault, 1);
+  assert.deepEqual(fed, [{ menuFor: "window-folder" }]);
+});
+
+test("the Shift/Ctrl debug hatch still wins over the text-entry check", () => {
+  // Ordering guard: the escape hatch is documented as the first thing that
+  // runs, so a shift-right-click on an input must still dump to the console
+  // rather than fall out through the new early return.
+  const fed = [];
+  const debugged = [];
+  const handler = new Function(
+    "isTextEntry",
+    "localStorage",
+    "_a",
+    "_",
+    "drumeeDialog",
+    "buildContextmenu",
+    "window",
+    `return (${handlerSource()});`,
+  )(
+    isTextEntry,
+    { logLevel: 3 },
+    { debug: "debug", ui: "ui", toggle: "toggle" },
+    { isFunction: (f) => typeof f === "function" },
+    { isDestroyed: () => false, feed: (k) => fed.push(k), children: { last: () => ({ $el: { height: () => 1, width: () => 1 }, el: { style: {} } }) } },
+    (p) => ({ menuFor: p.name }),
+    { innerHeight: 800, innerWidth: 1200 },
+  );
+
+  const { event } = rightClick(el("INPUT", { type: "text" }));
+  event.shiftKey = true;
+  const v = view();
+  v.debug = (...args) => debugged.push(args);
+  v.mget = () => "skeleton.js";
+
+  handler.call(v, event);
+
+  assert.ok(debugged.length > 0, "the debug dump still runs");
+  assert.deepEqual(fed, []);
+});

--- a/tests/is-text-entry.test.js
+++ b/tests/is-text-entry.test.js
@@ -1,0 +1,102 @@
+// The predicate that decides whether a right-click keeps the browser's own
+// cut/copy/paste menu. It runs against a raw DOM node handed over by the
+// `contextmenu` event, so it must survive anything that is not an element —
+// notably the synthetic `{pageX, pageY, target, ...}` object the media-grid
+// kebab passes straight into `el.oncontextmenu`.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { isTextEntry } = require("../src/drumee/libs/is-text-entry");
+
+// Minimal element stand-in. `isContentEditable` is a real DOM property that is
+// true on every descendant of a contenteditable host, which is why the
+// predicate never has to walk a parent chain.
+const el = (tagName, attrs = {}) => ({
+  tagName,
+  isContentEditable: attrs.isContentEditable || false,
+  getAttribute: (k) => (attrs[k] == null ? null : attrs[k]),
+});
+
+const input = (type) =>
+  type === undefined ? el("INPUT") : el("INPUT", { type });
+
+test("text-like input types keep the native menu", () => {
+  for (const type of [
+    "text",
+    "search",
+    "url",
+    "tel",
+    "email",
+    "password",
+    "number",
+  ]) {
+    assert.equal(isTextEntry(input(type)), true, `type="${type}"`);
+  }
+});
+
+test("a missing type is text — HTML's own default", () => {
+  assert.equal(isTextEntry(input(undefined)), true);
+  assert.equal(isTextEntry(input("")), true);
+});
+
+test("an unknown type is treated as text, matching the browser", () => {
+  // date/time inputs land here too; they carry a native menu of their own and
+  // nothing in the app claims them.
+  assert.equal(isTextEntry(input("date")), true);
+  assert.equal(isTextEntry(input("wat")), true);
+});
+
+test("non-text input types keep the app menu", () => {
+  for (const type of [
+    "checkbox",
+    "radio",
+    "button",
+    "submit",
+    "reset",
+    "file",
+    "range",
+    "color",
+    "image",
+  ]) {
+    assert.equal(isTextEntry(input(type)), false, `type="${type}"`);
+  }
+});
+
+test("input type matching ignores case and padding", () => {
+  // Attribute values are author-controlled; the DOM normalises `type` but a
+  // stand-in (or a hand-built synthetic) may not.
+  assert.equal(isTextEntry(el("INPUT", { type: "CHECKBOX" })), false);
+  assert.equal(isTextEntry(el("INPUT", { type: " checkbox " })), false);
+  assert.equal(isTextEntry(el("input", { type: "text" })), true);
+});
+
+test("textarea is text entry", () => {
+  assert.equal(isTextEntry(el("TEXTAREA")), true);
+});
+
+test("readonly still counts — copy and select-all stay useful", () => {
+  assert.equal(isTextEntry(el("INPUT", { type: "text", readonly: "" })), true);
+  assert.equal(isTextEntry(el("TEXTAREA", { readonly: "" })), true);
+});
+
+test("contenteditable is text entry whatever the tag", () => {
+  assert.equal(isTextEntry(el("DIV", { isContentEditable: true })), true);
+  assert.equal(isTextEntry(el("SPAN", { isContentEditable: true })), true);
+});
+
+test("a plain element is not text entry", () => {
+  assert.equal(isTextEntry(el("DIV")), false);
+  assert.equal(isTextEntry(el("SECTION")), false);
+  assert.equal(isTextEntry(el("BUTTON")), false);
+});
+
+test("a missing target is not text entry — existing behaviour wins", () => {
+  assert.equal(isTextEntry(null), false);
+  assert.equal(isTextEntry(undefined), false);
+});
+
+test("a synthetic event object with no target is not text entry", () => {
+  // What the kebab passes when it cannot find a trigger element.
+  assert.equal(isTextEntry({ pageX: 10, pageY: 20 }), false);
+  assert.equal(isTextEntry({}), false);
+  assert.equal(isTextEntry("input"), false);
+});


### PR DESCRIPTION
Right-clicking any field in the app opened the owning window's menu instead of cut/copy/paste. The Entry widget injects its <input> as innerHTML, so the input owns no view; the contextmenu bubbles one level to the Entry root, where ui-core's __handleContextmenu walks the VIEW-parent chain to the first ancestor with a contextmenuSkeleton — the folder window — and calls preventDefault(). That preventDefault is the only thing suppressing the native menu.

__handleContextmenu now returns before that point when e.target is a text
entry, tested by the new libs/is-text-entry predicate: textarea, an <input>
whose type is text-like (including missing/unknown, which HTML resolves to text), and anything with isContentEditable — which covers the task comment composer and every descendant of a contenteditable host. checkbox, radio, button, submit, reset, file, range, color and image keep the app menu, as does a null or non-element target, so the media-grid kebab's synthetic event is untouched. readonly still counts as text entry: copy and select-all stay useful.

The early return is a bare `return`, not `return false`. This is a property-style oncontextmenu handler, so returning false cancels the default — it would reinstate the very suppression being removed.

An escape hatch exists in the opposite direction: a view that wants its app menu on an input sets `forceContextmenu` (own property or model attribute, read exactly like escapeContextmenu). Nothing sets it today; it is available for the case where flipping the default turns out wrong for some widget.

Two existing per-skeleton opt-outs are now redundant — the markdown editor (editor/markdow/skeleton/content.js) and the Drive-link field (widget/migrate-gdrive-popup/skeleton/index.js, whose comment describes this exact bug). Both are left in place: removing them widens the diff for no behaviour change. The other 23 escapeContextmenu sites are on Note/Element widgets — chat bubbles, addressbook rows, the task comment body — which are not text entry and still need their opt-out.

The handler lives in the vendored SDK, so the change ships as a regenerated patches/@drumee+ui-core+1.1.50.patch. The predicate lives in app source and is reached through the global `libs` webpack alias, which resolves from node_modules too, verified with a real webpack compile of the patched file. Verified end to end by wiping node_modules and reinstalling: patch applies clean and the guard is present in the fresh copy.