### PR TITLE
feat(desk): mobile search card driven by the sidebar "Search" row

### DIFF
--- a/src/drumee/modules/desk/index.js
+++ b/src/drumee/modules/desk/index.js
@@ -1651,6 +1651,13 @@ class desk_module extends LetcBox {
         this._searchSuggestions = child;
         return;
 
+      // Mobile only — the card that hosts search-box / search-suggestions when
+      // the desktop topbar is display:none. Its absence is how
+      // _closeMobileSearch knows there is no card to close.
+      case "mobile-search-card":
+        this._mobileSearchCard = child;
+        return;
+
       case "suggestions-list":
         // Topbar search must not surface the user's hidden personal hub
         // (area='personal') or the auto-created wicket/dmz. Filter hub
@@ -2780,13 +2787,71 @@ class desk_module extends LetcBox {
     });
   }
 
-  _closeMobileDrawer() {
+  /**
+   * `keepBackdrop` is for the drawer → search-card handoff. _setMobileBackdrop
+   * writes inside ensurePart().then(), so two callers racing false-then-true
+   * would be ordered only by promise resolution, not by program order — correct
+   * today merely because "overlay" is already mounted and resolves eagerly, and
+   * silently wrong the day ensurePart goes cold. The handoff therefore suppresses
+   * this closer's write entirely and lets _openMobileSearch issue the single
+   * one, so the backdrop's final state does not depend on ordering at all.
+   */
+  _closeMobileDrawer(keepBackdrop) {
     this.ensurePart("sidebar-main").then((p) => {
       if (!p || !p.el) return;
       p.el.dataset.state = "closed";
     });
-    this._setMobileBackdrop(false);
+    if (!keepBackdrop) this._setMobileBackdrop(false);
     this._setMobileTopbarActive(null);
+  }
+
+  /**
+   * Open the mobile search card (skeleton/index.js). The caller closes the
+   * drawer first; the card then re-lights the SAME backdrop, so the two never
+   * show together and one tap outside dismisses whichever is up.
+   *
+   * The card reuses the topbar's part names, so `_searchBoxInner` and
+   * `_searchSuggestions` already point at its input and list by the time this
+   * runs — nothing here is mobile-specific beyond the card's own visibility.
+   *
+   * Focus stays inside the click's microtask (no rAF / setTimeout) so the tap's
+   * user activation still counts and the soft keyboard opens. focus() fires
+   * focusin, whose handler (onPartReady, "search-box") already fetches — the
+   * explicit fetch below is the fallback for when it didn't, so the card is
+   * never left blank. An empty query is not a no-op: desk.search short-circuits
+   * it to mfs_show_node_by, i.e. the user's workspaces.
+   */
+  _openMobileSearch() {
+    return this.ensurePart("mobile-search-card").then((p) => {
+      if (!p || !p.el) return;
+      p.setState(1);
+      this._setMobileBackdrop(true);
+      if (this._searchBoxInner && _.isFunction(this._searchBoxInner.focus)) {
+        this._searchBoxInner.focus();
+      }
+      const shown =
+        this._searchSuggestions &&
+        this._searchSuggestions.el.dataset.state === "1";
+      if (shown) return;
+      return this._updateSearchSuggestions();
+    });
+  }
+
+  /**
+   * Close the mobile search card and drop its query. A no-op wherever the card
+   * was never built (desktop / tablet), which is what lets the shared backdrop,
+   * Escape and open-search-hit all call it unconditionally.
+   */
+  _closeMobileSearch() {
+    if (!this._mobileSearchCard) return false;
+    if (this._mobileSearchCard.el.dataset.state !== "1") return false;
+    this._mobileSearchCard.setState(0);
+    this._hideSearchSuggestions();
+    if (this._searchBoxInner && _.isFunction(this._searchBoxInner.setValue)) {
+      this._searchBoxInner.setValue("");
+    }
+    this._setMobileBackdrop(false);
+    return true;
   }
 
   /**
@@ -3265,8 +3330,21 @@ class desk_module extends LetcBox {
       case "mobile-show-menu":
         return this.openMobileDrawer("nav");
 
+      // The backdrop is shared between the drawer and the search card, so one
+      // tap has to dismiss whichever layer is actually up. Both closers are
+      // no-ops when their layer is already closed.
       case "mobile-close-drawer":
+        this._closeMobileSearch();
         return this._closeMobileDrawer();
+
+      // Hand off to the card without touching the backdrop — it stays lit
+      // across the swap, and _openMobileSearch performs the only write.
+      case "open-mobile-search":
+        this._closeMobileDrawer(1);
+        return this._openMobileSearch();
+
+      case "close-mobile-search":
+        return this._closeMobileSearch();
 
       case "toggle-sidebar-pin":
         return this._toggleSidebarPin();
@@ -3418,6 +3496,7 @@ class desk_module extends LetcBox {
         //   message      → open the hosting chat scope (see _openMessageHit)
         // Files/folders reuse the notification-reveal path (openFileLocation).
         this._hideSearchSuggestions();
+        this._closeMobileSearch();
         const hit = cmd && cmd.model ? cmd.model.toJSON() : {};
         if (hit.result_type === "message") {
           return this._openMessageHit(hit);
@@ -3717,6 +3796,10 @@ class desk_module extends LetcBox {
       this._dismissTransientUi();
       return false;
     }
+    // Ahead of _closeEscapeModal: the search card is the topmost layer on
+    // mobile, so it must consume the press before anything under it. Returns
+    // false (no card / already closed) everywhere else, so desktop is unchanged.
+    if (this._closeMobileSearch()) return false;
     if (this._closeEscapeModal()) return false;
     this._closeEscapeWindow();
     return false;
@@ -3928,6 +4011,12 @@ class desk_module extends LetcBox {
     if (this._searchSuggestions.el.dataset.state !== "1") {
       this._searchSuggestions.setState(1);
     }
+    // Mobile: no outside-click dismisser. The list is the body of the search
+    // card, not a dropdown hanging off a topbar — `_searchContainer` is the
+    // topbar cluster, which does not exist on mobile, so the check below would
+    // read every tap as "outside" and collapse the card's own results on first
+    // touch. Dismissal there is the backdrop, the ✕ and Escape.
+    if (this._mobileSearchCard) return;
     if (this._suggestionsDismiss) return;
     this._suggestionsDismiss = (e) => {
       const inside =

--- a/src/drumee/modules/desk/skeleton/index.js
+++ b/src/drumee/modules/desk/skeleton/index.js
@@ -37,6 +37,82 @@ const _build_mobile_topbar = (ui) => {
   });
 };
 
+// Mobile search card. The desktop topbar — and with it the search cluster —
+// is display:none at mobile widths, so search gets its own centered card here.
+//
+// It deliberately reuses the topbar's part names ("search-box",
+// "search-suggestions", "suggestions-list") rather than declaring its own:
+// every handler in desk/index.js (the 300ms debounce, _updateSearchSuggestions,
+// the personal-hub filter on the list, open-search-hit) then drives this card
+// with no branching. skeleton/topbar.js drops its own cluster on mobile so
+// only one node ever claims each name.
+//
+// Mounted at state 0 on every mobile desk rather than lazily, so ensurePart()
+// resolves immediately on the first tap instead of racing a mount.
+const _build_mobile_search_card = (ui) => {
+  const fig = ui.fig.family;
+
+  return Skeletons.Box.Y({
+    className: `${fig}__mobile-search`,
+    sys_pn: "mobile-search-card",
+    partHandler: ui,
+    state: 0,
+    kids: [
+      Skeletons.Box.X({
+        className: `${fig}__mobile-search-bar`,
+        kids: [
+          Skeletons.Image.Svg({
+            ico: "magnifying-glass",
+            className: `${fig}__mobile-search-icon`,
+          }),
+          Skeletons.Entry({
+            className: `${fig}__mobile-search-input`,
+            sys_pn: "search-box",
+            uiHandler: [ui],
+            partHandler: ui,
+            placeholder: LOCALE.SEARCH || "Search...",
+            service: "search-files",
+            type: _a.text,
+            autocomplete: _a.off,
+            interactive: 1,
+          }),
+          Skeletons.Button.Svg({
+            ico: "cross",
+            className: `${fig}__mobile-search-close`,
+            service: "close-mobile-search",
+            uiHandler: [ui],
+          }),
+        ],
+      }),
+
+      Skeletons.Box.Y({
+        className: `${fig}__mobile-search-suggestions`,
+        sys_pn: "search-suggestions",
+        partHandler: ui,
+        state: 0,
+        kids: [
+          Skeletons.List.Smart({
+            className: `${fig}__mobile-search-list`,
+            sys_pn: "suggestions-list",
+            partHandler: ui,
+            flow: _a.none,
+            spinner: true,
+            spinnerWait: 300,
+            vendorOpt: Preset.List.Orange_e,
+            itemsOpt: {
+              kind: "workspace_item",
+              uiHandler: [ui],
+              // Same reveal-in-context path as the desktop suggestions —
+              // desk/index.js onUiEvent → "open-search-hit".
+              service: "open-search-hit",
+            },
+          }),
+        ],
+      }),
+    ],
+  });
+};
+
 const _desk_main = function (ui) {
   const isMobile = Visitor.isMobile();
 
@@ -105,6 +181,12 @@ const _desk_main = function (ui) {
       ...(isMobile ? { uiHandler: [ui], service: "mobile-close-drawer" } : {}),
     }),
   ];
+
+  // After the overlay, so the card sits later in DOM order as well as above it
+  // by z-index (skin/mobile-search.scss).
+  if (isMobile) {
+    bodyKids.push(_build_mobile_search_card(ui));
+  }
 
   const mainKids = [
     Skeletons.Box.X({

--- a/src/drumee/modules/desk/skeleton/sidebar.js
+++ b/src/drumee/modules/desk/skeleton/sidebar.js
@@ -361,11 +361,15 @@ const createActionsNav = (ui) => {
             "mobile-upload",
           ),
         ]),
+    // "open-mobile-search", not "search-files": the latter is the search
+    // INPUT's per-keystroke service, so a row sharing it landed in the
+    // debounce branch and did nothing. This row opens the card; the input
+    // inside the card keeps "search-files".
     createNavItem(
       ui,
       "app-search",
       LOCALE.SEARCH || "Search",
-      "search-files",
+      "open-mobile-search",
       "",
       null,
       "mobile-search",

--- a/src/drumee/modules/desk/skeleton/topbar.js
+++ b/src/drumee/modules/desk/skeleton/topbar.js
@@ -218,8 +218,17 @@ module.exports = function (ui) {
           // the moment the org is within limits again.
           ...(require("libs/over-limit").isLocked() ? [] : [deskNewMenu(pfx, ui, mayWrite)]),
 
-          // Search bar + suggestions
-          Skeletons.Box.Y({
+          // Search bar + suggestions.
+          //
+          // Mobile drops the whole cluster: this topbar is display:none at
+          // mobile widths (skin/index.scss, __topbar[data-device="mobile"]),
+          // and search there lives in the centered card built by
+          // skeleton/index.js. That card reuses these EXACT sys_pn names
+          // ("search-box", "search-suggestions", "suggestions-list") so the
+          // desk's existing wiring drives it unchanged — which only works if
+          // exactly one of the two is ever mounted. "" is dropped by ui-core's
+          // validChild, the same idiom the New menu rows use above.
+          Visitor.isMobile() ? "" : Skeletons.Box.Y({
             className: `${pfx}__search-container`,
             sys_pn: "search-container",
             partHandler: ui,

--- a/src/drumee/modules/desk/skin/index.scss
+++ b/src/drumee/modules/desk/skin/index.scss
@@ -9,6 +9,7 @@ html {
 @include meta.load-css("buttons.scss");
 @include meta.load-css("topbar");
 @include meta.load-css("mobile-topbar");
+@include meta.load-css("mobile-search");
 @include meta.load-css("body");
 @include meta.load-css("desk/dmz-copy-media");
 @include meta.load-css("desk/intro-popup");

--- a/src/drumee/modules/desk/skin/mobile-search.scss
+++ b/src/drumee/modules/desk/skin/mobile-search.scss
@@ -1,0 +1,241 @@
+@use "mixins/drumee";
+
+// Centered search card, mobile only. The desktop topbar — and with it the
+// search cluster — is display:none at mobile widths (index.scss,
+// __topbar[data-device="mobile"]), so skeleton/index.js builds this card
+// instead and skeleton/topbar.js drops its own. Every rule below assumes
+// mobile; the element is not rendered anywhere else.
+//
+// Hidden state is visibility/opacity rather than display:none on purpose:
+// _openMobileSearch focuses the input in the same task as the tap that opened
+// the card (so the soft keyboard counts it as user-initiated), and focus() on
+// a display:none subtree is refused.
+.desk-module {
+  &__mobile-search {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(90vw, 420px);
+    max-height: 70vh;
+    box-sizing: border-box;
+    padding: 12px;
+    gap: 10px;
+    border-radius: 12px;
+    background-color: var(--normal-bg);
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.22);
+    // Above the 10010 backdrop and in the drawer's layer, so the mobile
+    // topbar (99999) cannot sit over the card.
+    z-index: 100000;
+    // Hidden is the DEFAULT, revealed only by data-state="1" — the same
+    // polarity as the topbar's __search-suggestions. Do not invert this to
+    // `[data-state="0"] { hidden }`: the skeleton's `state: 0` is not
+    // guaranteed to have written the attribute by first paint, and an
+    // absent attribute would then render the card open over a fresh desk.
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.2s ease, visibility 0.2s;
+
+    &[data-state="1"] {
+      opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
+    }
+  }
+
+  &__mobile-search-bar {
+    position: relative;
+    align-items: center;
+    width: 100%;
+    height: 40px;
+    box-sizing: border-box;
+    padding: 0 8px 0 38px;
+    border-radius: 8px;
+    background-color: var(--normal-bg-90);
+    flex-shrink: 0;
+  }
+
+  &__mobile-search-icon {
+    position: absolute;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    padding: 0;
+    pointer-events: none;
+    color: var(--primary-50);
+
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  &__mobile-search-input {
+    flex: 1;
+    min-width: 0;
+
+    input {
+      background-color: transparent;
+      // 16px keeps iOS Safari from zooming the viewport on focus.
+      font-size: 16px;
+      color: var(--normal-fg-10);
+      width: 100%;
+
+      &::placeholder {
+        color: #c7c7cc;
+      }
+    }
+  }
+
+  &__mobile-search-close {
+    width: 28px;
+    height: 28px;
+    padding: 6px;
+    border-radius: 4px;
+    flex-shrink: 0;
+    cursor: pointer;
+    color: var(--normal-fg-20);
+
+    svg {
+      width: 100%;
+      height: 100%;
+      fill: currentColor;
+    }
+  }
+
+  // The results body. Unlike the desktop dropdown this is in flow inside the
+  // card, so the card's max-height is what bounds it and the scroll happens
+  // here.
+  &__mobile-search-suggestions {
+    visibility: hidden;
+    pointer-events: none;
+    width: 100%;
+    min-height: 0;
+    flex: 1;
+    overflow-y: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    &[data-state="1"] {
+      visibility: visible;
+      pointer-events: auto;
+    }
+  }
+
+  &__mobile-search-list {
+    width: 100%;
+    gap: 4px;
+
+    .workspace-item {
+      padding: 8px 6px;
+      cursor: pointer;
+      border-radius: 6px;
+
+      &__row {
+        min-height: auto;
+        padding: 0;
+        gap: 8px;
+        font-size: 14px;
+        line-height: 1.4;
+        color: #65656c;
+
+        &[data-level="0"],
+        &[data-radio="on"][data-level="0"] {
+          padding-left: 0;
+        }
+      }
+
+      &__icon {
+        width: 20px;
+        height: 20px;
+        padding: 0;
+        flex-shrink: 0;
+
+        svg {
+          width: 22px;
+          height: 22px;
+        }
+
+        &.file {
+          color: #65656c;
+        }
+      }
+
+      &__name {
+        font-size: 14px;
+        color: #65656c;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      &:hover,
+      &[data-state="1"],
+      &[data-radio="on"] {
+        background-color: rgba(89, 80, 255, 0.1);
+        border-left: none;
+
+        .workspace-item__row {
+          padding-left: 0;
+        }
+      }
+    }
+  }
+}
+
+// ── Dark mode overrides ─────────────────────────────────────────
+// Mirrors the topbar search block in topbar.scss: elevated surfaces in place
+// of stark whites, softened foregrounds.
+html[data-theme="dark"] {
+  .desk-module {
+    &__mobile-search {
+      background-color: var(--normal-bg-elevated);
+      box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+    }
+
+    &__mobile-search-bar {
+      background-color: var(--normal-bg-80);
+    }
+
+    &__mobile-search-icon {
+      color: var(--normal-fg-20);
+    }
+
+    &__mobile-search-input input {
+      color: var(--normal-fg);
+
+      &::placeholder {
+        color: var(--placeholder-fg);
+      }
+    }
+
+    &__mobile-search-close {
+      color: var(--normal-fg-20);
+    }
+
+    &__mobile-search-list {
+      .workspace-item {
+        &__name {
+          color: var(--normal-fg);
+        }
+
+        &__row {
+          color: var(--normal-fg);
+        }
+
+        &:hover,
+        &[data-state="1"],
+        &[data-radio="on"] {
+          background-color: var(--hover-bg-40);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
On mobile the drawer's "Search" row did nothing. The topbar's search cluster is display:none at mobile widths, and the row shared the service name "search-files" with the search INPUT — so the row's tap landed in the per-keystroke debounce branch and fell through.

Split the two services and give mobile its own centered card. The card reuses the topbar's part names ("search-box", "search-suggestions", "suggestions-list"), so every existing handler drives it unchanged: the 300ms debounce, _updateSearchSuggestions, the personal-hub filter on the list, and open-search-hit. topbar.js drops its own cluster on mobile so exactly one node ever claims each name. No API, server or SQL change.

Tapping Search closes the drawer, keeps the shared backdrop lit and opens the card populated — an empty query is not a no-op, desk.search short-circuits it to mfs_show_node_by, i.e. the user's workspaces. Dismissal is the backdrop, the close button or Escape.

Two details worth keeping:

- The card is hidden by DEFAULT and revealed by [data-state="1"], the same polarity as the topbar's __search-suggestions. The inverse form would render the card open over a fresh desk if the skeleton's `state: 0` has not written the attribute by first paint.
- _closeMobileDrawer takes `keepBackdrop` for the drawer -> card handoff. _setMobileBackdrop writes inside ensurePart().then(), so two callers racing false-then-true would be ordered only by promise resolution. The handoff suppresses the closer's write and lets _openMobileSearch issue the single one, so the result does not depend on ordering.

Verified by compiling the desk skin and measuring the card in headless chromium at a 390x844 viewport: centered (351px = min(90vw,420px), no horizontal overflow), capped at exactly 70vh with the list scrolling inside it, and hidden when data-state is absent. Both themes rendered. The live mobile drawer was NOT click-tested — this box serves only local.drumee. The dispatch path is a static trace, not an observation.