### PR TITLE
feat(butler): optional close X on a notice, and a one-shot close call…

### DIFF
--- a/src/drumee/router/butler/index.js
+++ b/src/drumee/router/butler/index.js
@@ -250,8 +250,14 @@ class __router_butler extends LetcBox {
       case _e.close:
         this.trigger("close-content");
         this.sleep();
+        // One-shot. _onClose was set and never cleared, so a callback handed to
+        // say()/alert()/message() stayed armed and fired again on the close of
+        // every LATER, unrelated dialog — a navigating callback would then take
+        // the user somewhere the second dialog said nothing about.
         if (_.isFunction(this._onClose)) {
-          return this._onClose();
+          const done = this._onClose;
+          this._onClose = null;
+          return done();
         }
         break;
 
@@ -282,8 +288,8 @@ class __router_butler extends LetcBox {
    * @param {*} cb
    * @returns
    */
-  say(message, cb) {
-    this.feed(require("./skeleton/message")(this, message, "info"));
+  say(message, cb, opt = {}) {
+    this.feed(require("./skeleton/message")(this, message, "info", opt));
     this.el.dataset.state = _a.open;
     if (_.isFunction(cb)) {
       return (this._onClose = cb);

--- a/src/drumee/router/butler/skeleton/header.js
+++ b/src/drumee/router/butler/skeleton/header.js
@@ -4,26 +4,32 @@
  * dialogs so they match the window/confirm look.
  * @param {Object} ui
  * @param {String} [closeSignal]  signal fired by the X (defaults to _e.close)
+ * @param {Object} [opt]
+ * @param {Boolean} [opt.closable=true]  false drops the X, for a dialog whose
+ *        button is meant to be the only way out — an X that merely repeats the
+ *        button reads as "dismiss without doing the thing", which is wrong when
+ *        closing IS the action.
  */
-module.exports = function (ui, closeSignal) {
+module.exports = function (ui, closeSignal, opt = {}) {
   const fig = ui.fig.family;
-  return Skeletons.Box.X({
-    className: `${fig}__topbar`,
-    debug: __filename,
-    kids: [
-      Skeletons.Box.X({
-        className: `${fig}__logo`,
-        kids: [
-          Skeletons.Button.Svg({
-            ico: "logo-upload",
-            className: `${fig}__logo-ico`,
-          }),
-          Skeletons.Note({
-            content: "drumee",
-            className: `${fig}__logo-text`,
-          }),
-        ],
-      }),
+  const kids = [
+    Skeletons.Box.X({
+      className: `${fig}__logo`,
+      kids: [
+        Skeletons.Button.Svg({
+          ico: "logo-upload",
+          className: `${fig}__logo-ico`,
+        }),
+        Skeletons.Note({
+          content: "drumee",
+          className: `${fig}__logo-text`,
+        }),
+      ],
+    }),
+  ];
+
+  if (opt.closable !== false) {
+    kids.push(
       Skeletons.Box.X({
         className: `${fig}__close`,
         signal: closeSignal || _e.close,
@@ -36,7 +42,13 @@ module.exports = function (ui, closeSignal) {
             className: `${fig}__close-ico`,
           }),
         ],
-      }),
-    ],
+      })
+    );
+  }
+
+  return Skeletons.Box.X({
+    className: `${fig}__topbar`,
+    debug: __filename,
+    kids,
   });
 };

--- a/src/drumee/router/butler/skeleton/message.js
+++ b/src/drumee/router/butler/skeleton/message.js
@@ -14,7 +14,14 @@
  * limitations under the License.
  * =============================================================================
  */
-const message = function(_ui_, content, type) {
+/**
+ * @param {Object} [opt]
+ * @param {Boolean} [opt.closable=true]  false drops the header X, leaving the
+ *        primary button as the single way out. Both fire _e.close, so they
+ *        already did the same thing; a caller that gives closing a MEANING
+ *        (Butler.say's callback) wants one control, not two.
+ */
+const message = function(_ui_, content, type, opt = {}) {
   const fig = _ui_.fig.family;
   let body;
   if (_.isString(content)) {
@@ -32,7 +39,7 @@ const message = function(_ui_, content, type) {
     debug     : __filename,
     sys_pn    : "container",
     kids: [
-      require('./header')(_ui_, _e.close),
+      require('./header')(_ui_, _e.close, opt),
       type ? Skeletons.Note({
         className : `${fig}__title`,
         content   : type


### PR DESCRIPTION
…back

Butler.say() has always accepted a callback fired when its dialog closes, so a caller can give closing a MEANING — the onboarding wizard uses it to carry the user from "N invite(s) sent" to the workspace. The dialog then offers two controls that both fire _e.close: the primary button and the header X. When closing merely dismisses, that duplication is harmless; when closing performs an action, an X reads as "dismiss without doing the thing" while in fact doing it.

say(message, cb, opt) now forwards `opt` to the message skeleton, which forwards it to the shared header, where `closable: false` omits the X. Opt-in throughout: every existing say/wip/confirm/quota caller passes nothing and keeps the X exactly as before.

Also fixes a leak in the same handler: _onClose was assigned and never cleared, so a callback given to say()/alert()/message() stayed armed and ran again on the close of every LATER, unrelated dialog. A dismissal of some passing error toast would then trigger whatever the earlier caller had asked for — with a navigating callback, quietly moving the user somewhere the second dialog said nothing about. It is now taken and nulled before it runs.