### PR TITLE
fix(locale): add the missing ALREADY_IN_LIST string

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -405,6 +405,7 @@
   "MESSAGE_ACTIVATION": "If you don't receive it, check your Spam and address above.",
   "CHECK_YOUR_MAIL": "Oops ... Wrong credentials",
   "ALREADY_EXISTS": "Oooops, {0} already exists ...",
+  "ALREADY_IN_LIST": "That email is already in the list",
   "PERMISSION_READ": "View",
   "PERMISSION_UPLOAD_DOWNLOAD": "Upload/Download",
   "PERMISSION_DELETE_ORGANIZE": "Delete/Organize",

--- a/locale/es.json
+++ b/locale/es.json
@@ -180,6 +180,7 @@
   "OOPS_EMAIL_NOT_FOUND": "¡Ups! No encontramos este correo. Por favor, revise.",
   "EMAIL_REQUIRED": "Email is required",
   "INVALID_EMAIL_FORMAT": "Invalid email format",
+  "ALREADY_IN_LIST": "Ese correo ya está en la lista",
   "CANNOT_ADD_SELF_AS_CONTACT": "You cannot add yourself as a contact",
   "FIRST_NAME_REQUIRED": "First name is required",
   "LASTNAME_REQUIRED": "Last name is required",

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -420,6 +420,7 @@
   "MESSAGE_ACTIVATION": "Si vous ne le recevez pas, vérifiez vos Spams et votre adresse ci-dessus.",
   "CHECK_YOUR_MAIL": "Oups... Vérifiez votre mail et votre mot de passe",
   "ALREADY_EXISTS": "Oups, {0} existe déjà...",
+  "ALREADY_IN_LIST": "Cet e-mail est déjà dans la liste",
   "PERMISSION_READ": "Voir",
   "PERMISSION_UPLOAD_DOWNLOAD": "Importer/Télécharger",
   "PERMISSION_DELETE_ORGANIZE": "Supprimer / Organiser",

--- a/locale/km.json
+++ b/locale/km.json
@@ -418,6 +418,7 @@
   "MESSAGE_ACTIVATION": "ប្រសិនបើអ្នកមិនទទួលបានទេ សូមពិនិត្យមើល Spam និងអាសយដ្ឋានខាងលើ។",
   "CHECK_YOUR_MAIL": "អូ៎... លិខិតសម្គាល់ខុស",
   "ALREADY_EXISTS": "អូ! {0} មានរួចហើយ...",
+  "ALREADY_IN_LIST": "អ៊ីមែលនេះមានក្នុងបញ្ជីរួចហើយ",
   "PERMISSION_READ": "មើល",
   "PERMISSION_UPLOAD_DOWNLOAD": "បង្ហោះ/ទាញយក",
   "PERMISSION_DELETE_ORGANIZE": "លុប/រៀបចំ",

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -420,6 +420,7 @@
   "MESSAGE_ACTIVATION": "Если вы не получили его, проверьте ваш Спам и адрес выше.",
   "CHECK_YOUR_MAIL": "Упс ... Проверьте свою электронную почту и пароль",
   "ALREADY_EXISTS": "Ой, {0} уже существует ...",
+  "ALREADY_IN_LIST": "Этот адрес уже в списке",
   "PERMISSION_READ": "См",
   "PERMISSION_UPLOAD_DOWNLOAD": "Загрузить/Скачать",
   "PERMISSION_DELETE_ORGANIZE": "Удалить / Oрганизовать",

--- a/locale/zh.json
+++ b/locale/zh.json
@@ -420,6 +420,7 @@
   "MESSAGE_ACTIVATION": "如果您没有收到，请检查上面的垃圾邮件和地址。",
   "CHECK_YOUR_MAIL": "糟糕...请检查您的电子邮件和密码",
   "ALREADY_EXISTS": "糟糕，{0}已经存在...",
+  "ALREADY_IN_LIST": "该邮箱已在列表中",
   "PERMISSION_READ": "查看",
   "PERMISSION_UPLOAD_DOWNLOAD": "上传/下载",
   "PERMISSION_DELETE_ORGANIZE": "删除/整理",


### PR DESCRIPTION
The onboarding invite step rejects a duplicate address with ALREADY_IN_LIST, which has never existed in any of these files. LOCALE echoes an unset key back, and that echo is truthy, so the caller's `|| 'That email is already in the list'` fallback never fired: the step printed the literal key, in red, where a sentence belonged.

Six languages, beside ALREADY_EXISTS. Its three sibling validations — EMAIL_REQUIRED, INVALID_EMAIL_FORMAT, CANNOT_ADD_SELF_AS_CONTACT — were already here; only this one was missed.